### PR TITLE
FromNetmapDevice: get interface name from element config

### DIFF
--- a/elements/userlevel/fromnetmapdevice.cc
+++ b/elements/userlevel/fromnetmapdevice.cc
@@ -111,7 +111,7 @@ FromNetmapDevice::initialize(ErrorHandler *errh)
 
 	//IRQ
 	char netinfo[100];
-	sprintf(netinfo, "/sys/class/net/%s/device/msi_irqs", _device->parent_nmd->nifp->ni_name);
+	sprintf(netinfo, "/sys/class/net/%s/device/msi_irqs", _device->ifname.c_str() + 7);
 	DIR *dir;
 	struct dirent *ent;
 


### PR DESCRIPTION
From @vlolteanu : 
If udev decides to rename an interface, 
_device->parent_nmd->nifp->ni_name will still contain the device's old 
name. This causes issues when FromNetmapDevice::initialize tries to look 
at /sys/class/net/$DEVICE/device/msi_irqs.