### PR TITLE
Prevent potential access to unallocated memory in queue dev

### DIFF
--- a/elements/analysis/timestampdiff.cc
+++ b/elements/analysis/timestampdiff.cc
@@ -55,15 +55,20 @@ int TimestampDiff::configure(Vector<String> &conf, ErrorHandler *errh)
             .complete() < 0)
         return -1;
 
-    if (get_passing_threads().weight() > 1 && !_limit) {
-        return errh->error("TimestampDiff is only thread safe if N is set");
-    }
-
     if ((_rt = static_cast<RecordTimestamp*>(e->cast("RecordTimestamp"))) == 0)
         return errh->error("RECORDER must be a valid RecordTimestamp element");
 
     if (_limit) {
         _delays.resize(_limit, 0);
+    }
+
+    return 0;
+}
+
+int TimestampDiff::initialize(ErrorHandler *errh)
+{
+    if (get_passing_threads().weight() > 1 && !_limit) {
+        return errh->error("TimestampDiff is only thread safe if N is set");
     }
 
     return 0;

--- a/elements/analysis/timestampdiff.hh
+++ b/elements/analysis/timestampdiff.hh
@@ -54,6 +54,7 @@ public:
     const char *flow_code() const { return "x/x"; }
 
     int configure(Vector<String> &, ErrorHandler *) CLICK_COLD;
+    int initialize(ErrorHandler *) CLICK_COLD;
     void add_handlers() CLICK_COLD;
     static String read_handler(Element *, void *) CLICK_COLD;
 

--- a/elements/userlevel/queuedevice.hh
+++ b/elements/userlevel/queuedevice.hh
@@ -160,12 +160,13 @@ protected:
     bool get_spawning_threads(Bitvector& bmk, bool)
     {
     	if (noutputs()) { //RX
-		for (int i = 0; i < n_queues; i++) {
-    			for (int j = 0; j < queue_share; j++) {
-    				bmk[thread_for_queue(i) - j] = 1;
-    			}
-    		}
-    		return true;
+            assert(thread_for_queue_available());
+            for (int i = 0; i < n_queues; i++) {
+                for (int j = 0; j < queue_share; j++) {
+                    bmk[thread_for_queue(i) - j] = 1;
+                }
+            }
+            return true;
     	} else { //TX
     		if (input_is_pull(0)) {
     			bmk[router()->home_thread_id(this)] = 1;
@@ -228,8 +229,11 @@ protected:
         return _tasks[id_for_thread(tid)];
     }
 
+    inline bool thread_for_queue_available() {
+        return !_queue_to_thread.empty();
+    }
+
     inline int thread_for_queue(int queue) {
-        assert(!_queue_to_thread.empty());
         return _queue_to_thread[queue];
     }
 

--- a/elements/userlevel/queuedevice.hh
+++ b/elements/userlevel/queuedevice.hh
@@ -229,9 +229,7 @@ protected:
     }
 
     inline int thread_for_queue(int queue) {
-        if (_queue_to_thread.empty()) {
-            return 0;
-        }
+        assert(!_queue_to_thread.empty());
         return _queue_to_thread[queue];
     }
 

--- a/elements/userlevel/queuedevice.hh
+++ b/elements/userlevel/queuedevice.hh
@@ -229,6 +229,9 @@ protected:
     }
 
     inline int thread_for_queue(int queue) {
+        if (_queue_to_thread.empty()) {
+            return 0;
+        }
         return _queue_to_thread[queue];
     }
 


### PR DESCRIPTION
This might occur when another element has been configured prior
to a queue device and attempts to call the thread_for_queue
function

Signed-off-by: Georgios Katsikas <katsikas.gp@gmail.com>