### PR TITLE
RecordTimestamp takes numbered packets from input element

### DIFF
--- a/elements/analysis/recordtimestamp.cc
+++ b/elements/analysis/recordtimestamp.cc
@@ -33,9 +33,9 @@ RecordTimestamp::~RecordTimestamp() {
 
 int RecordTimestamp::configure(Vector<String> &conf, ErrorHandler *errh) {
     uint32_t n = 0;
-    Element *e;
+    Element *e = NULL;
     if (Args(conf, this, errh)
-            .read_mp("COUNTER", e)
+            .read("COUNTER", e)
             .read("N", n)
             .read("OFFSET", _offset)
             .read("DYNAMIC", _dynamic)
@@ -46,7 +46,7 @@ int RecordTimestamp::configure(Vector<String> &conf, ErrorHandler *errh) {
         n = 65536;
     _timestamps.reserve(n);
 
-    if ((_np = static_cast<NumberPacket *>(e->cast("NumberPacket"))) == 0)
+    if (e && (_np = static_cast<NumberPacket *>(e->cast("NumberPacket"))) == 0)
         return errh->error("COUNTER must be a valid NumberPacket element");
 
     return 0;
@@ -56,7 +56,7 @@ inline void
 RecordTimestamp::smaction(Packet *p) {
     uint64_t i;
     if (_offset >= 0) {
-        i = _np->read_number_of_packet(p, _offset);
+        i = _np ? _np->read_number_of_packet(p, _offset) : NumberPacket::read_number_of_packet(p, _offset);
         assert(i < INT_MAX);
         while (i >= _timestamps.size()) {
             if (!_dynamic && i >= _timestamps.capacity()) {

--- a/elements/analysis/recordtimestamp.cc
+++ b/elements/analysis/recordtimestamp.cc
@@ -25,7 +25,7 @@
 
 CLICK_DECLS
 
-RecordTimestamp::RecordTimestamp() : _offset(-1), _timestamps(), _dynamic(false) {
+RecordTimestamp::RecordTimestamp() : _offset(-1), _timestamps(), _dynamic(false), _np(0) {
 }
 
 RecordTimestamp::~RecordTimestamp() {
@@ -33,7 +33,9 @@ RecordTimestamp::~RecordTimestamp() {
 
 int RecordTimestamp::configure(Vector<String> &conf, ErrorHandler *errh) {
     uint32_t n = 0;
+    Element *e;
     if (Args(conf, this, errh)
+            .read_mp("COUNTER", e)
             .read("N", n)
             .read("OFFSET", _offset)
             .read("DYNAMIC", _dynamic)
@@ -44,6 +46,9 @@ int RecordTimestamp::configure(Vector<String> &conf, ErrorHandler *errh) {
         n = 65536;
     _timestamps.reserve(n);
 
+    if ((_np = static_cast<NumberPacket *>(e->cast("NumberPacket"))) == 0)
+        return errh->error("COUNTER must be a valid NumberPacket element");
+
     return 0;
 }
 
@@ -51,7 +56,7 @@ inline void
 RecordTimestamp::smaction(Packet *p) {
     uint64_t i;
     if (_offset >= 0) {
-        i = NumberPacket::read_number_of_packet(p, _offset);
+        i = _np->read_number_of_packet(p, _offset);
         assert(i < INT_MAX);
         while (i >= _timestamps.size()) {
             if (!_dynamic && i >= _timestamps.capacity()) {

--- a/elements/analysis/recordtimestamp.hh
+++ b/elements/analysis/recordtimestamp.hh
@@ -7,6 +7,8 @@
 
 CLICK_DECLS
 
+class NumberPacket;
+
 /*
 =c
 
@@ -60,6 +62,7 @@ private:
     int _offset;
     bool _dynamic;
     Vector<Timestamp> _timestamps;
+    NumberPacket *_np;
 };
 
 inline Timestamp RecordTimestamp::get(uint64_t i) {


### PR DESCRIPTION
This allows to use the desired element if more than one
are present in a Click configuration

Signed-off-by: Georgios Katsikas <katsikas.gp@gmail.com>