### PR TITLE
Extensions in counting and timestamping elements

### DIFF
--- a/elements/analysis/checknumberpacket.hh
+++ b/elements/analysis/checknumberpacket.hh
@@ -2,6 +2,7 @@
 #define CLICK_CHECKNUMBERPACKET_HH
 
 #include <click/batchelement.hh>
+#include "numberpacket.hh"
 
 CLICK_DECLS
 
@@ -17,6 +18,11 @@ Check there is an increasing number inside the payload of each packets
 =item OFFSET
 
 Set an offset to write the data. Default to 40.
+
+=item NET_ORDER
+
+Writes the number in network order format and returns this number
+acounting for this format. Defaults to false.
 
 =a
 
@@ -39,14 +45,15 @@ public:
     void push_batch(int,PacketBatch *) override;
 #endif
 
-    static inline uint64_t read_number_of_packet(const Packet *p, int offset) {
-        return *(reinterpret_cast<const uint64_t *>(p->data() + offset));
+    static inline uint64_t read_number_of_packet(
+            const Packet *p, int offset, bool net_order = false) {
+        return NumberPacket::read_number_of_packet(p, offset, net_order);
     }
-
 
     void add_handlers();
 private:
     int _offset;
+    bool _net_order;
     uint64_t _count;
     Vector<int> _numbers;
 

--- a/elements/analysis/numberpacket.cc
+++ b/elements/analysis/numberpacket.cc
@@ -1,8 +1,10 @@
 /*
  * numberpacket.{cc,hh} -- Store a packet count inside packet payload
  * Cyril Soldani, Tom Barbette
+ * Support for network order numbering by Georgios Katsikas
  *
  * Copyright (c) 2015-2016 University of Liège
+ * Copyright (c) 2018 RISE SICS
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -17,14 +19,14 @@
 
 #include <click/config.h>
 
-#include "numberpacket.hh"
-
 #include <click/args.hh>
 #include <click/error.hh>
 
+#include "numberpacket.hh"
+
 CLICK_DECLS
 
-NumberPacket::NumberPacket() : _offset(40) {
+NumberPacket::NumberPacket() : _offset(40), _net_order(false) {
     _count = 0;
 }
 
@@ -34,6 +36,7 @@ NumberPacket::~NumberPacket() {
 int NumberPacket::configure(Vector<String> &conf, ErrorHandler *errh) {
     if (Args(conf, this, errh)
         .read_p("OFFSET", _offset)
+        .read("NET_ORDER", _net_order)
         .complete() < 0)
         return -1;
     if (_offset < 0)
@@ -51,8 +54,16 @@ inline Packet* NumberPacket::smaction(Packet *p) {
         assert(wp);
         wp->ip_header()->ip_len = htons(_offset + _size_of_number);
     }
+
+    uint64_t number = _count;
+    _count++;
+
+    if (_net_order) {
+        number = htonll(number);
+    }
+
     // Skip header
-    *reinterpret_cast<uint64_t *>(wp->data() + _offset) = _count.fetch_and_add(1);
+    *reinterpret_cast<uint64_t *>(wp->data() + _offset) = number;
 
     return wp;
 }

--- a/elements/analysis/numberpacket.cc
+++ b/elements/analysis/numberpacket.cc
@@ -55,15 +55,14 @@ inline Packet* NumberPacket::smaction(Packet *p) {
         wp->ip_header()->ip_len = htons(_offset + _size_of_number);
     }
 
-    // Skip header
-    if (_net_order) {
-        *reinterpret_cast<uint64_t *>(wp->data() + _offset) = htonll(_count);
-    } else {
-        *reinterpret_cast<uint64_t *>(wp->data() + _offset) = _count;
-    }
+    uint64_t number = _count.fetch_and_add(1);
 
-    // Atomically increment
-    _count++;
+    // Skip header    
+    if (_net_order) {
+        *reinterpret_cast<uint64_t *>(wp->data() + _offset) = htonll(number);
+    } else {
+        *reinterpret_cast<uint64_t *>(wp->data() + _offset) = number;
+    }
 
     return wp;
 }

--- a/elements/analysis/numberpacket.cc
+++ b/elements/analysis/numberpacket.cc
@@ -55,15 +55,15 @@ inline Packet* NumberPacket::smaction(Packet *p) {
         wp->ip_header()->ip_len = htons(_offset + _size_of_number);
     }
 
-    uint64_t number = _count;
-    _count++;
-
+    // Skip header
     if (_net_order) {
-        number = htonll(number);
+        *reinterpret_cast<uint64_t *>(wp->data() + _offset) = htonll(_count);
+    } else {
+        *reinterpret_cast<uint64_t *>(wp->data() + _offset) = _count;
     }
 
-    // Skip header
-    *reinterpret_cast<uint64_t *>(wp->data() + _offset) = number;
+    // Atomically increment
+    _count++;
 
     return wp;
 }

--- a/elements/analysis/numberpacket.hh
+++ b/elements/analysis/numberpacket.hh
@@ -3,6 +3,10 @@
 
 #include <click/batchelement.hh>
 
+#define TYPE_INIT 0
+#define TYPE_LITEND 1
+#define TYPE_BIGEND 2
+
 CLICK_DECLS
 
 /*
@@ -17,6 +21,11 @@ Set an increasing number inside the payload of each packets
 =item OFFSET
 
 Set an offset to write the data. Default to 40.
+
+=item NET_ORDER
+
+Writes the number in network order format and returns this number
+acounting for this format. Defaults to false.
 
 =a
 
@@ -34,22 +43,56 @@ public:
 
     int configure(Vector<String> &, ErrorHandler *) CLICK_COLD;
 
-    Packet * simple_action(Packet *) override;
+    Packet *simple_action(Packet *) override;
 #if HAVE_BATCH
-    PacketBatch * simple_action_batch(PacketBatch *) override;
+    PacketBatch *simple_action_batch(PacketBatch *) override;
 #endif
 
-    static inline uint64_t read_number_of_packet(const Packet *p,int offset) {
+    static unsigned long long htonll(unsigned long long src) {
+        static int typ = TYPE_INIT;
+        unsigned char c;
+        union {
+            unsigned long long ull;
+            unsigned char c[8];
+        } x;
+
+        if (typ == TYPE_INIT) {
+            x.ull = 0x01;
+            typ = (x.c[7] == 0x01ULL) ? TYPE_BIGEND : TYPE_LITEND;
+        }
+
+        if (typ == TYPE_BIGEND)
+            return src;
+
+        x.ull = src;
+        c = x.c[0]; x.c[0] = x.c[7]; x.c[7] = c;
+        c = x.c[1]; x.c[1] = x.c[6]; x.c[6] = c;
+        c = x.c[2]; x.c[2] = x.c[5]; x.c[5] = c;
+        c = x.c[3]; x.c[3] = x.c[4]; x.c[4] = c;
+
+        return x.ull;
+    }
+
+    static inline uint64_t read_number_of_packet(
+            const Packet *p, int offset, bool net_order = false) {
+        if (net_order) {
+            return htonll(*(reinterpret_cast<const uint64_t *>(p->data() + offset)));
+        }
         return *(reinterpret_cast<const uint64_t *>(p->data() + offset));
+    }
+
+    inline bool has_net_order() {
+        return _net_order;
     }
 
     void add_handlers();
 private:
-    atomic_uint32_t _count;
+    atomic_uint64_t _count;
     int _offset;
+    bool _net_order;
     const int _size_of_number = sizeof(uint64_t);
 
-    inline Packet* smaction(Packet* p) CLICK_WARN_UNUSED_RESULT;
+    inline Packet *smaction(Packet *p) CLICK_WARN_UNUSED_RESULT;
 
     enum{ H_COUNT};
     static String read_handler(Element *e, void *thunk);

--- a/elements/analysis/numberpacket.hh
+++ b/elements/analysis/numberpacket.hh
@@ -1,11 +1,8 @@
 #ifndef CLICK_NUMBERPACKET_HH
 #define CLICK_NUMBERPACKET_HH
 
+#include <click/glue.hh>
 #include <click/batchelement.hh>
-
-#define TYPE_INIT 0
-#define TYPE_LITEND 1
-#define TYPE_BIGEND 2
 
 CLICK_DECLS
 
@@ -47,31 +44,6 @@ public:
 #if HAVE_BATCH
     PacketBatch *simple_action_batch(PacketBatch *) override;
 #endif
-
-    static unsigned long long htonll(unsigned long long src) {
-        static int typ = TYPE_INIT;
-        unsigned char c;
-        union {
-            unsigned long long ull;
-            unsigned char c[8];
-        } x;
-
-        if (typ == TYPE_INIT) {
-            x.ull = 0x01;
-            typ = (x.c[7] == 0x01ULL) ? TYPE_BIGEND : TYPE_LITEND;
-        }
-
-        if (typ == TYPE_BIGEND)
-            return src;
-
-        x.ull = src;
-        c = x.c[0]; x.c[0] = x.c[7]; x.c[7] = c;
-        c = x.c[1]; x.c[1] = x.c[6]; x.c[6] = c;
-        c = x.c[2]; x.c[2] = x.c[5]; x.c[5] = c;
-        c = x.c[3]; x.c[3] = x.c[4]; x.c[4] = c;
-
-        return x.ull;
-    }
 
     static inline uint64_t read_number_of_packet(
             const Packet *p, int offset, bool net_order = false) {

--- a/elements/analysis/recordtimestamp.hh
+++ b/elements/analysis/recordtimestamp.hh
@@ -19,6 +19,11 @@ RecordTimestamp([I<keywords> N])
 record current timestamp in a vector each time a packet is pushed through this
 element.
 
+=item COUNTER
+
+Relies on a specific NumberPacket element to fetch the packet counter.
+Defaults to no COUNTER element.
+
 =item N
 
 Size of the vector, defaults to 65536.
@@ -33,6 +38,13 @@ If not set or < 0, the vector will be filled in order.
 
 If true, allows to grow the vector on runtime. This is disabled by default because it is not multi thread safe a,d creates a spike in latency that is due to the long time taken to resize. If
 the number of packets reaches a non dynamic TimestampDiff, it will crash.
+
+=item NET_ORDER
+
+Writes the number in network order format and returns this number
+acounting for this format.
+If COUNTER is set, it adheres to the settings of that element.
+Otherwise, user can set it. Defaults to false.
 
 =a
 
@@ -58,9 +70,14 @@ public:
 
     inline Timestamp get(uint64_t i);
 
+    inline bool has_net_order() {
+        return _net_order;
+    }
+
 private:
     int _offset;
     bool _dynamic;
+    bool _net_order;
     Vector<Timestamp> _timestamps;
     NumberPacket *_np;
 };

--- a/elements/analysis/timestampdiff.cc
+++ b/elements/analysis/timestampdiff.cc
@@ -36,7 +36,8 @@
 
 CLICK_DECLS
 
-TimestampDiff::TimestampDiff() : _delays(), _offset(40), _limit(0), _max_delay_ms(1000)
+TimestampDiff::TimestampDiff() :
+    _delays(), _offset(40), _limit(0), _net_order(false), _max_delay_ms(1000)
 {
     _nd = 0;
 }
@@ -61,6 +62,8 @@ int TimestampDiff::configure(Vector<String> &conf, ErrorHandler *errh)
 
     if ((_rt = static_cast<RecordTimestamp*>(e->cast("RecordTimestamp"))) == 0)
         return errh->error("RECORDER must be a valid RecordTimestamp element");
+
+    _net_order = _rt->has_net_order();
 
     if (_limit) {
         _delays.resize(_limit, 0);
@@ -168,7 +171,7 @@ void TimestampDiff::add_handlers()
 inline int TimestampDiff::smaction(Packet *p)
 {
     Timestamp now = Timestamp::now_steady();
-    uint64_t i = NumberPacket::read_number_of_packet(p, _offset);
+    uint64_t i = NumberPacket::read_number_of_packet(p, _offset, _net_order);
     Timestamp old = get_recordtimestamp_instance()->get(i);
     if (old == Timestamp::uninitialized_t()) {
         return 1;

--- a/elements/analysis/timestampdiff.hh
+++ b/elements/analysis/timestampdiff.hh
@@ -66,6 +66,7 @@ private:
     Vector<unsigned> _delays;
     int _offset;
     uint32_t _limit;
+    bool _net_order;
     int _max_delay_ms;
     RecordTimestamp *_rt;
     atomic_uint32_t _nd;

--- a/elements/userlevel/monitoringreportsocket.cc
+++ b/elements/userlevel/monitoringreportsocket.cc
@@ -40,7 +40,6 @@
 #include <netinet/tcp.h>
 #include <netinet/in.h>
 
-#include "../analysis/numberpacket.hh"
 #include "monitoringreportsocket.hh"
 
 CLICK_DECLS
@@ -371,7 +370,7 @@ MonitoringReportSocket::run_timer(Timer *t)
         // Create a fixed-size buffer and, at first, store a timestamp
         char buffer[_tot_msg_length];
         bzero(buffer, _tot_msg_length);
-        int64_to_char(buffer, NumberPacket::htonll(ts));
+        int64_to_char(buffer, htonll(ts));
 
         for (String handler_name : _elementHandlers[e]) {
             // Ask for a handler instance with this name
@@ -388,7 +387,7 @@ MonitoringReportSocket::run_timer(Timer *t)
              * If handler's name is longer than HANDLER_LEN,
              * we send only the first HANDLER_LEN characters.
              */
-            int64_to_char(&buffer[sizeof(ts)], NumberPacket::htonll(value));
+            int64_to_char(&buffer[sizeof(ts)], htonll(value));
             snprintf(&buffer[sizeof(ts) + sizeof(value)], HANDLER_LEN, "%s", handler_name.c_str());
             buffer[sizeof(ts) + sizeof(value) + handler_name.length() + 1] = '\0';
 
@@ -484,7 +483,7 @@ MonitoringReportSocket::print_data(char *buffer, const int buffer_len)
 
     click_chatter(
         "[Monitoring element %s] [Thread %d] Timestamp: %" PRId64 " - Value: %" PRId64 " - Name: %s",
-        this->name().c_str(), click_current_cpu_id(), NumberPacket::htonll(ts), NumberPacket::htonll(value), handler_name
+        this->name().c_str(), click_current_cpu_id(), htonll(ts), htonll(value), handler_name
     );
 }
 

--- a/include/click/atomic.hh
+++ b/include/click/atomic.hh
@@ -978,7 +978,7 @@ atomic_uint64_t::fetch_and_add(uint64_t delta)
           : "cc");
     return delta;
 #elif CLICK_LINUXMODULE && HAVE_LINUX_ATOMIC_ADD_RETURN
-    return atomic_add_return(&_val, delta) - delta;
+    return atomic64_add_return(&_val, delta) - delta;
 #elif CLICK_LINUXMODULE
 # warning "using nonatomic approximation for atomic_uint64_t::fetch_and_add"
     unsigned long flags;

--- a/include/click/glue.hh
+++ b/include/click/glue.hh
@@ -725,6 +725,36 @@ inline click_cycles_t cycles_hz() {
 }
 #endif
 
+// Host to network order
+
+#define TYPE_INIT 0
+#define TYPE_LITEND 1
+#define TYPE_BIGEND 2
+
+inline unsigned long long htonll(unsigned long long src) {
+    static int typ = TYPE_INIT;
+    unsigned char c;
+    union {
+        unsigned long long ull;
+        unsigned char c[8];
+    } x;
+
+    if (typ == TYPE_INIT) {
+        x.ull = 0x01;
+        typ = (x.c[7] == 0x01ULL) ? TYPE_BIGEND : TYPE_LITEND;
+    }
+
+    if (typ == TYPE_BIGEND)
+        return src;
+
+    x.ull = src;
+    c = x.c[0]; x.c[0] = x.c[7]; x.c[7] = c;
+    c = x.c[1]; x.c[1] = x.c[6]; x.c[6] = c;
+    c = x.c[2]; x.c[2] = x.c[5]; x.c[5] = c;
+    c = x.c[3]; x.c[3] = x.c[4]; x.c[4] = c;
+
+    return x.ull;
+}
 
 CLICK_ENDDECLS
 


### PR DESCRIPTION
This patch extends the NumberPacket element to support network order
packet numbering and modifies this counter to a uint64_t integer to
support more scalable counting. The network order is configurable
by the user.

Since the NumberPacket element is used by other elements to perform
latency measurements, updates are performed to those elements as well.
Specifically:
 * CheckNumberPacket has also support for network order
 * RecordTimestamp can either be configured with network order or inherit
   the settings of its own NumberPacket element
 * TimestampDiff inherits the settings of its reference RecordTimestamp element

MonitoringReportSocket re-uses some static methods of the NumberPacket element
to perform host to network order conversions, instead of re-implementing the
same methods.

The patch takes care of compatibility issues by setting the network order to
false by default.

Signed-off-by: Georgios Katsikas <katsikas.gp@gmail.com>