### PR TITLE
Add FORCE_SHRINK parameter to the EnsureHeadroom element

### DIFF
--- a/elements/standard/ensureheadroom.cc
+++ b/elements/standard/ensureheadroom.cc
@@ -22,7 +22,7 @@
 CLICK_DECLS
 
 EnsureHeadroom::EnsureHeadroom()
-    :  _headroom(Packet::default_headroom)
+    :  _headroom(Packet::default_headroom), _force(false)
 {
 
 }
@@ -32,6 +32,7 @@ EnsureHeadroom::configure(Vector<String> &conf, ErrorHandler *errh)
 {
     if (Args(conf, this, errh)
 	.read_p("HEADROOM", _headroom)
+	.read_p("FORCE_SHRINK", _force)
 	.complete() < 0)
 	return -1;
     return 0;
@@ -40,7 +41,7 @@ EnsureHeadroom::configure(Vector<String> &conf, ErrorHandler *errh)
 inline Packet* EnsureHeadroom::smaction(Packet* p) {
 	int length = p->length();
 	Packet* q;
-	if (p->headroom() < _headroom) {
+	if (p->headroom() < _headroom || _force) {
 		q = p->shift_data(_headroom - p->headroom());
 	}	else
 		q = p;

--- a/elements/standard/ensureheadroom.hh
+++ b/elements/standard/ensureheadroom.hh
@@ -25,6 +25,7 @@ class EnsureHeadroom : public BatchElement { public:
 	Packet* smaction(Packet*);
 	private:
    unsigned _headroom;
+   bool _force;
 };
 
 CLICK_ENDDECLS


### PR DESCRIPTION
`EnsureHeadroom(FORCE_SHRINK 1)` can be put after each element generating packets on slow path (`ICMPError`, ARP speakers) in order to explicitly remove headroom from a packet. That way, warnings about data move can be avoided in `ToNetmapDevice` for these packets. So, when such a warning occurs, it will be certain that it comes from some fast path packet.