### PR TITLE
Allow FromDump to set a fixed frame size

### DIFF
--- a/elements/userlevel/fromdump.hh
+++ b/elements/userlevel/fromdump.hh
@@ -234,6 +234,7 @@ class FromDump : public Element { public:
     int _minor_version;
     int _linktype;
     long _preload;
+    int _force_len;
 
     Timestamp _first_time;
     Timestamp _last_time;


### PR DESCRIPTION
This patch allows FromDump elements to generate packets from
pcap traces while being able to enforce a fixed frame size.
This configuration could be handy when you want to use the very
same Click code to generate either arbitrary frame sizes from a trace
or fixed frame sizes from the same trace.
Default behaviour is unchanged.

Signed-off-by: Georgios Katsikas <katsikas.gp@gmail.com>