### PR TITLE
TimestampDiff

### DIFF
--- a/elements/analysis/timestampdiff.cc
+++ b/elements/analysis/timestampdiff.cc
@@ -167,6 +167,8 @@ int TimestampDiff::handler(int operation, String &data, Element *e,
 void TimestampDiff::add_handlers()
 {
     set_handler("average", Handler::f_read | Handler::f_read_param, handler, TSD_AVG_HANDLER, 0);
+    set_handler("avg", Handler::f_read | Handler::f_read_param, handler, TSD_AVG_HANDLER, 0);
+
     set_handler("min", Handler::f_read | Handler::f_read_param, handler, TSD_MIN_HANDLER, 0);
     set_handler("max", Handler::f_read | Handler::f_read_param, handler, TSD_MAX_HANDLER, 0);
     set_handler("stddev", Handler::f_read | Handler::f_read_param, handler, TSD_STD_HANDLER, 0);

--- a/elements/analysis/timestampdiff.hh
+++ b/elements/analysis/timestampdiff.hh
@@ -60,7 +60,8 @@ public:
     int configure(Vector<String> &, ErrorHandler *) CLICK_COLD;
     int initialize(ErrorHandler *) CLICK_COLD;
     void add_handlers() CLICK_COLD;
-    static String read_handler(Element *, void *) CLICK_COLD;
+    static int handler(int operation, String &data, Element *element,
+            const Handler *handler, ErrorHandler *errh) CLICK_COLD;
 
     void push(int, Packet *);
 #if HAVE_BATCH
@@ -74,6 +75,7 @@ private:
     bool _net_order;
     int _max_delay_ms;
     RecordTimestamp *_rt;
+    //Current index in the delays
     atomic_uint32_t _nd;
     bool _verbose;
 
@@ -84,10 +86,11 @@ private:
     void min_mean_max(
         unsigned &min,
         double   &mean,
-        unsigned &max
+        unsigned &max,
+        uint32_t begin = 0
     );
-    double standard_deviation(const double mean);
-    double percentile(const double percent);
+    double standard_deviation(const double mean, uint32_t begin = 0);
+    double percentile(const double percent, uint32_t begin = 0);
     unsigned last_value_seen();
 };
 

--- a/elements/standard/delayunqueue.cc
+++ b/elements/standard/delayunqueue.cc
@@ -32,7 +32,9 @@ DelayUnqueue::DelayUnqueue()
 int
 DelayUnqueue::configure(Vector<String> &conf, ErrorHandler *errh)
 {
-    return Args(conf, this, errh).read_mp("DELAY", _delay).complete();
+    return Args(conf, this, errh)
+            .read_mp("DELAY", _delay)
+            .complete();
 }
 
 int

--- a/test/analysis/latency-begin.testie
+++ b/test/analysis/latency-begin.testie
@@ -1,0 +1,48 @@
+%info
+RecordTimestamp ecosystem
+
+Test the RecordTimestamp ecosystem (TimestampDiff, NumberPacket, ...)
+
+%script
+click -j 1 CONFIG
+
+%file IN1
+!data ts_sec len payload
+1 60 A
+2 60 B
+3 60 C
+4 60 D
+5 60 E
+10 60 F
+15 60 1
+20 60 2
+25 60 3
+30 60 4
+
+%file CONFIG
+FromIPSummaryDump(IN1, STOP false)
+-> SetTimestamp
+-> MarkMACHeader
+-> NumberPacket
+-> record:: RecordTimestamp()
+-> Queue
+-> DelayUnqueue(1)
+-> counter :: AverageCounter()
+-> CheckNumberPacket(OFFSET 40, COUNT 10)
+-> diff :: TimestampDiff(RECORDER record)
+-> Counter(COUNT_CALL 5 double.run)
+-> Counter(COUNT_CALL 10 finished.run)
+-> Discard;
+
+double :: Script(TYPE PASSIVE, write du.delay 5)
+finished :: Script(TYPE PASSIVE, read diff.average, read diff.average 0, read diff.average 5, read counter.count, stop)
+
+%expect stderr
+diff.average:
+{{[0-9]{1,2}[.][0-9]+}}
+diff.average:
+{{[0-9]{1,2}[.][0-9]+}}
+diff.average:
+{{[0-9]{1,2}[.][0-9]+}}
+counter.count:
+10


### PR DESCRIPTION
Allows to give an index from which the average/mean/max/... should be computed. This index is a packet number, maybe read using "index". By default, index is 0, the old behaviour.

This ultimately allows to display the change of latency over time.