### PR TITLE
click: Add --simtick options

### DIFF
--- a/include/click/timestamp.hh
+++ b/include/click/timestamp.hh
@@ -678,6 +678,11 @@ class Timestamp { public:
      * @sa assign_now_steady(), now_steady_unwarped() */
     inline void assign_now_steady_unwarped();
     //@}
+
+
+    /** @brief set amounts of ticks to warp
+     */
+    static void set_warp_tick(unsigned long tick);
 #endif
 
 #if HAVE_USER_TIMING

--- a/lib/timestamp.cc
+++ b/lib/timestamp.cc
@@ -61,6 +61,7 @@ Timestamp::warp_class_type TimestampWarp::kind = Timestamp::warp_none;
 double TimestampWarp::speed = 1.0;
 Timestamp TimestampWarp::flat_offset[2];
 double TimestampWarp::offset[2] = { 0.0, 0.0 };
+unsigned long warp_tick = 1;
 
 void
 Timestamp::warp(bool steady, bool from_now)
@@ -70,9 +71,9 @@ Timestamp::warp(bool steady, bool from_now)
         if (from_now)
             for (int i = 0; i < 2; ++i) {
 # if TIMESTAMP_REP_FLAT64 || TIMESTAMP_MATH_FLAT64
-                ++TimestampWarp::flat_offset[i]._t.x;
+                TimestampWarp::flat_offset[i]._t.x += warp_tick;
 # else
-                ++TimestampWarp::flat_offset[i]._t.subsec;
+                TimestampWarp::flat_offset[i]._t.subsec += warp_tick;
 # endif
                 TimestampWarp::flat_offset[i].add_fix();
             }
@@ -143,6 +144,15 @@ Timestamp::warp_jump_steady(const Timestamp &expiry)
             warp_adjust(true, now_steady_raw, expiry);
         }
     }
+}
+
+void
+Timestamp::set_warp_tick(unsigned long tick)
+{
+#if !TIMESTAMP_NANOSEC
+    tick /= 1000;
+#endif
+    warp_tick = tick;
 }
 #endif
 

--- a/test/analysis/latency-begin.testie
+++ b/test/analysis/latency-begin.testie
@@ -2,9 +2,10 @@
 RecordTimestamp ecosystem
 
 Test the RecordTimestamp ecosystem (TimestampDiff, NumberPacket, ...)
+For some reason with clang the simtime is different.
 
 %script
-click -j 1 CONFIG
+click -j 1 CONFIG --simtime --simtick 1000
 
 %file IN1
 !data ts_sec len payload
@@ -35,14 +36,14 @@ FromIPSummaryDump(IN1, STOP false)
 -> Discard;
 
 double :: Script(TYPE PASSIVE, write du.delay 5)
-finished :: Script(TYPE PASSIVE, read diff.average, read diff.average 0, read diff.average 5, read counter.count, stop)
+finished :: Script(TYPE PASSIVE, wait 100ms, read diff.average, read diff.average 0, read diff.average 5, read counter.count, stop)
 
 %expect stderr
 diff.average:
-{{[0-9]{1,3}[.][0-9]+}}
+{{22.8|20.8}}
 diff.average:
-{{[0-9]{1,3}[.][0-9]+}}
+{{22.8|20.8}}
 diff.average:
-{{[0-9]{1,3}[.][0-9]+}}
+{{35|33}}
 counter.count:
 10

--- a/userlevel/click.cc
+++ b/userlevel/click.cc
@@ -82,6 +82,7 @@ CLICK_USING_DECLS
 #define SOCKET_OPT              318
 #define THREADS_AFF_OPT         319
 #define DPDK_OPT                320
+#define SIMTICK_OPT             321
 
 static const Clp_Option options[] = {
     { "allow-reconfigure", 'R', ALLOW_RECONFIG_OPT, 0, Clp_Negate },
@@ -97,6 +98,7 @@ static const Clp_Option options[] = {
     { "quit", 'q', QUIT_OPT, 0, 0 },
     { "simtime", 0, SIMTIME_OPT, Clp_ValDouble, Clp_Optional },
     { "simulation-time", 0, SIMTIME_OPT, Clp_ValDouble, Clp_Optional },
+    { "simtick", 0, SIMTICK_OPT, Clp_ValUnsignedLong, Clp_Mandatory },
     { "threads", 'j', THREADS_OPT, Clp_ValInt, 0 },
     { "cpu", 0, THREADS_AFF_OPT, Clp_ValInt, Clp_Optional | Clp_Negate },
     { "affinity", 'a', THREADS_AFF_OPT, Clp_ValInt, Clp_Optional | Clp_Negate },
@@ -153,6 +155,7 @@ Options:\n\
   -t, --time                    Print information on how long driver took.\n\
   -w, --no-warnings             Do not print warnings.\n\
       --simtime                 Run in simulation time.\n\
+      --simtick                 Amount of subseconds to add in warp time.\n\
   -C, --clickpath PATH          Use PATH for CLICKPATH.\n\
       --help                    Print this message and exit.\n\
   -v, --version                 Print version number and exit.\n\
@@ -667,7 +670,10 @@ main(int argc, char **argv)
         Timestamp::warp_set_now(simbegin, simbegin);
         break;
     }
-
+    case SIMTICK_OPT: {
+        Timestamp::set_warp_tick(clp->val.ul);
+        break;
+    }
      case CLICKPATH_OPT:
       set_clickpath(clp->vstr);
       break;


### PR DESCRIPTION
Allows to change the amount of tick to warp in simtime mode

This allows to force us scale to enable some testing