### PR TITLE
Timewarp test: relax constraint and more robust

### DIFF
--- a/test/userlevel/timewarp-01.testie
+++ b/test/userlevel/timewarp-01.testie
@@ -8,10 +8,15 @@ now () {
     click -e 'Script(print $(now), stop)'
 }
 
-a=`now`; click X; b=`now`; perl -e "print $b - $a, \"\\n\""
-a=`now`; click Y; b=`now`; perl -e "print $b - $a, \"\\n\""
-a=`now`; click Z; b=`now`; perl -e "print $b - $a, \"\\n\""
-a=`now`; click --simtime X; b=`now`; perl -e "print $b - $a, \"\\n\""
+a=`now`; click EMPTY ; b=`now`; diff=$(perl -e "print $b - $a")
+a=`now`; click X; b=`now`; perl -e "($b - $a - $diff) > 0.45 ? print \"true\n\":print \"false : \", ($b - $a -$diff), \"\n\""
+a=`now`; click Y; b=`now`; perl -e "($b - $a - $diff) > 0.20 && ($b - $a - $diff) < 0.40 ? print \"true\n\":print \"false : \", ($b - $a -$diff), \"\n\""
+a=`now`; click Z; b=`now`; perl -e "($b - $a - $diff) < 0.40 ? print \"true\n\":print \"false : \", ($b - $a -$diff), \"\n\""
+a=`now`; click --simtime X; b=`now`; perl -e "($b - $a - $diff) < 0.1 ? print \"true\n\":print \"false : \", ($b - $a -$diff), \"\n\""
+
+%file EMPTY
+
+Script(stop)
 
 %file X
 
@@ -27,10 +32,10 @@ Script(write timewarp 2, set a $(now), wait 0.25s, write timewarp 1, wait 0.25s,
 
 %expect stdout
 0.5{{|[01].*}}
-0.{{(48|49|50|51|52|53).*}}
+true
 0.5{{|[01].*}}
-0.{{(23|24|25|26|27|28|29|30).*}}
+true
 0.5{{|[01].*}}
-0.{{(35|36|37|38|39|40|41|42).*}}
+true
 0.5{{|[01].*}}
-0.{{(00|01|02|03).*}}
+true


### PR DESCRIPTION
The timewrap test fails from time to time on travis, which is very slow.
The time to launch the process makes the delay longer than expected, so
let's relax the constraints.

In addition, substract from the real time the time it takes to launch an
empty click. This allows to be less error-proned regarding the time
a process takes to execute, eg on travis.