### PR TITLE
If using DPDK, allocate memory from DPDK mem

### DIFF
--- a/include/click/packet.hh
+++ b/include/click/packet.hh
@@ -51,6 +51,8 @@ class Packet { public:
 	default_headroom = 48,		///< Increase headroom for improved performance.
 #elif CLICK_PACKET_USE_DPDK || HAVE_DPDK_PACKET_POOL
 	default_headroom = RTE_PKTMBUF_HEADROOM,
+#elif HAVE_CLICK_PACKET_POOL
+	default_headroom = 64,
 #else
 	default_headroom = 28,		///< Default packet headroom() for
 					///  Packet::make().  4-byte aligned.


### PR DESCRIPTION
A little memory improvement. Ensure head of packet is on a boundary, and if using DPDK use the dpdk system for packet allocation.

Allows to simply use huge pages and cache alignment (mem is allocated on
boundary, and headroom is changed to be a multiple of cacheline size)