### PR TITLE
FromDump reworked

### DIFF
--- a/elements/userlevel/fromdump.cc
+++ b/elements/userlevel/fromdump.cc
@@ -479,7 +479,8 @@ FromDump::read_packet(ErrorHandler *errh)
         WritablePacket *q = 0;
         int desired_len = -1;
 
-        // User asked for the real length of the packet
+        // User asked for the real length of the packet.
+        // In the case of raw IP packets we reduce the length as they lack an Ethernet header
         if (_force_len == REAL_LEN) {
             desired_len = (_linktype == FAKE_DLT_RAW) ? (len - 14) : len;
         // .. or a given legnth

--- a/elements/userlevel/fromdump.cc
+++ b/elements/userlevel/fromdump.cc
@@ -481,21 +481,17 @@ FromDump::read_packet(ErrorHandler *errh)
 
         // User asked for the real length of the packet
         if (_force_len == REAL_LEN) {
-            // desired_len = len;
             desired_len = (_linktype == FAKE_DLT_RAW) ? (len - 14) : len;
         // .. or a given legnth
         } else {
-            // Raw IP packets lack an Ethernet header
             desired_len = (_linktype == FAKE_DLT_RAW) ? (_force_len - 14) : _force_len;
         }
 
         // Need to enlarge the packet
         if (desired_len > caplen) {
-            // click_chatter(" Put: %d bytes", (desired_len - caplen));
             q = p->put((desired_len - caplen));
         // Need to chop the packet
-        } else if (desired_len <= caplen) {
-            // click_chatter("Take: %d bytes", (caplen - desired_len));
+        } else {
             q = p->uniqueify();
             q->take(caplen - desired_len);
         }
@@ -519,6 +515,7 @@ FromDump::read_packet(ErrorHandler *errh)
             _packet = 0;
             return false;
         }
+
         // Keep the old length for incremental IP checksum calculation
         uint16_t len_old = ip->ip_len;
 

--- a/elements/userlevel/fromdump.cc
+++ b/elements/userlevel/fromdump.cc
@@ -51,7 +51,7 @@ CLICK_DECLS
 #define MAX_MTU 9000
 
 FromDump::FromDump()
-    : _packet(0), _end_h(0), _count(0), _timer(this), _task(this), _preload_head(0), _force_len(-1)
+    : _packet(0), _end_h(0), _count(0), _timer(this), _task(this), _preload_head(0), _force_len(DISABLED)
 {
 }
 
@@ -82,7 +82,7 @@ FromDump::declaration() const
 int
 FromDump::configure(Vector<String> &conf, ErrorHandler *errh)
 {
-    int force_len = -1;
+    int force_len = DISABLED;
     bool timing = false, stop = false, active = true, force_ip = false;
     Timestamp first_time, first_time_off, last_time, last_time_off, interval;
     HandlerCall end_h;
@@ -96,25 +96,25 @@ FromDump::configure(Vector<String> &conf, ErrorHandler *errh)
     if (_ff.configure_keywords(conf, this, errh) < 0)
 	return -1;
     if (Args(conf, this, errh)
-	.read_mp("FILENAME", FilenameArg(), _ff.filename())
-	.read_p("TIMING", timing)
-	.read("STOP", stop)
-	.read("ACTIVE", active)
-	.read("SAMPLE", FixedPointArg(SAMPLING_SHIFT), _sampling_prob)
-	.read("FORCE_IP", force_ip)
-	.read("FORCE_LEN", force_len)
-	.read("START", first_time)
-	.read("START_AFTER", first_time_off)
-	.read("END", last_time)
-	.read("END_AFTER", last_time_off)
-	.read("INTERVAL", interval)
-	.read("END_CALL", HandlerCallArg(HandlerCall::writable), end_h)
+    .read_mp("FILENAME", FilenameArg(), _ff.filename())
+    .read_p("TIMING", timing)
+    .read("STOP", stop)
+    .read("ACTIVE", active)
+    .read("SAMPLE", FixedPointArg(SAMPLING_SHIFT), _sampling_prob)
+    .read("FORCE_IP", force_ip)
+    .read("FORCE_LEN", force_len)
+    .read("START", first_time)
+    .read("START_AFTER", first_time_off)
+    .read("END", last_time)
+    .read("END_AFTER", last_time_off)
+    .read("INTERVAL", interval)
+    .read("END_CALL", HandlerCallArg(HandlerCall::writable), end_h)
 #if CLICK_NS
-	.read("PER_NODE", per_node)
+    .read("PER_NODE", per_node)
 #endif
-	.read("FILEPOS", _packet_filepos)
-	.read("PRELOAD", _preload)
-	.complete() < 0)
+    .read("FILEPOS", _packet_filepos)
+    .read("PRELOAD", _preload)
+    .complete() < 0)
 	return -1;
 
     // check sampling rate
@@ -163,9 +163,28 @@ FromDump::configure(Vector<String> &conf, ErrorHandler *errh)
     _force_ip = force_ip;
     _force_len = force_len;
 
-    if ((_force_len != -1) && ((_force_len < MIN_MTU) || (_force_len > MAX_MTU))) {
-        errh->error("FORCE_LEN requires a valid frame size");
-        return -1;
+    if ((_force_len != DISABLED) && (_force_len != REAL_LEN) &&
+       ((_force_len < MIN_MTU) || (_force_len > MAX_MTU))) {
+        return errh->error("FORCE_LEN requires a valid frame size");
+    }
+
+    // User feedback regarding a potential frame length manipulation
+    if (_force_len == DISABLED) {
+        errh->warning(
+            "Frames will be loaded with their capture lengths; "
+            "this might cause issues when the length of the capture is different from the actual frame length. \n"
+            "Use Pad() to avoid frame drops, e.g., caused by a subsequent CheckIPHeader element."
+        );
+    } else if (_force_len == REAL_LEN) {
+        errh->warning(
+            "Frames will be loaded with their actual lengths; "
+            "this will likely slow down the injection rate due to frame padding/chopping operations."
+        );
+    } else {
+        errh->warning(
+            "Frames will be loaded with a fixed length of %d bytes; "
+            "this will likely slow down the injection rate due to frame padding/chopping operations.", _force_len
+        );
     }
 
 #if CLICK_NS
@@ -264,11 +283,12 @@ FromDump::initialize(ErrorHandler *errh)
 
     // if forcing IP packets, check datalink type to ensure we understand it
     if (_force_ip) {
-	if (!fake_pcap_dlt_force_ipable(_linktype))
-	    return _ff.error(errh, "unknown linktype %d; can't force IP packets", _linktype);
-    } else if (_linktype == FAKE_DLT_RAW)
-	// force FORCE_IP.
-	_force_ip = true;
+	   if (!fake_pcap_dlt_force_ipable(_linktype))
+	       return _ff.error(errh, "unknown linktype %d; can't force IP packets", _linktype);
+    } else if (_linktype == FAKE_DLT_RAW) {
+        // force FORCE_IP.
+        _force_ip = true;
+    }
 
     // maybe skip ahead in the file
     int result;
@@ -454,41 +474,77 @@ FromDump::read_packet(ErrorHandler *errh)
     if (!p)
 	return false;
 
-    // Adjust the packet length if requested by the user
-    if (_force_len != -1) {
-        // User likes larger packets
-        if (_force_len > caplen) {
-            p = p->nonunique_put(_force_len - caplen);
-            if (!p) {
-                _packet = 0;
-                return false;
-            }
-        // User likes smaller packets
-        } else if (_force_len < caplen) {
-            WritablePacket *q = p->uniqueify();
-            click_ip *ip = reinterpret_cast<click_ip *>(q->data() + sizeof(click_ether));
-            if (!ip) {
-                _packet = 0;
-                return false;
-            }
-            // Keep the old length for incremental IP checksum calculation
-            uint16_t len_old = ip->ip_len;
+    // Adjust the packet length as requested by the user
+    if (_force_len != DISABLED) {
+        WritablePacket *q = 0;
+        int desired_len = -1;
 
-            // Reduce the packet's length
-            q->take(caplen - _force_len);
-            // Update the IP header
-            ip->ip_len = htons(q->length() - 14);
-            // and don't forget the checksum
-            click_update_in_cksum(&ip->ip_sum, len_old, ip->ip_len);
-
-            p = q;
+        // User asked for the real length of the packet
+        if (_force_len == REAL_LEN) {
+            // desired_len = len;
+            desired_len = (_linktype == FAKE_DLT_RAW) ? (len - 14) : len;
+        // .. or a given legnth
+        } else {
+            // Raw IP packets lack an Ethernet header
+            desired_len = (_linktype == FAKE_DLT_RAW) ? (_force_len - 14) : _force_len;
         }
+
+        // Need to enlarge the packet
+        if (desired_len > caplen) {
+            // click_chatter(" Put: %d bytes", (desired_len - caplen));
+            q = p->put((desired_len - caplen));
+        // Need to chop the packet
+        } else if (desired_len <= caplen) {
+            // click_chatter("Take: %d bytes", (caplen - desired_len));
+            q = p->uniqueify();
+            q->take(caplen - desired_len);
+        }
+
+        if (!q) {
+            _packet = 0;
+            return false;
+        }
+
+        // Recompute the IP checksum
+        click_ip *ip = 0;
+        int offset = 0;
+        if (_linktype == FAKE_DLT_RAW) {
+            ip = reinterpret_cast<click_ip *>(q->data());
+        } else {
+            ip = reinterpret_cast<click_ip *>(q->data() + sizeof(click_ether));
+            offset = 14;
+        }
+
+        if (!ip) {
+            _packet = 0;
+            return false;
+        }
+        // Keep the old length for incremental IP checksum calculation
+        uint16_t len_old = ip->ip_len;
+
+        // Update the IP header
+        ip->ip_len = htons(q->length() - offset);
+        // and don't forget the checksum
+        if (len_old != ip->ip_len) {
+            click_update_in_cksum(&ip->ip_sum, len_old, ip->ip_len);
+        }
+
+        p = q;
+
+        SET_EXTRA_LENGTH_ANNO(p, len - desired_len);
+    } else {
+        SET_EXTRA_LENGTH_ANNO(p, len - caplen);
     }
 
-    SET_EXTRA_LENGTH_ANNO(p, len - caplen);
     _ff.shift_pos(skiplen);
 
-    p->set_mac_header(p->data());
+    // Raw IP case; Leave the link layer information out
+    if (_linktype == FAKE_DLT_RAW) {
+        p->set_network_header(p->data());
+    // Regular case; frames contain link layer info
+    } else {
+        p->set_mac_header(p->data());
+    }
     _packet = p;
 
     return true;

--- a/elements/userlevel/fromdump.cc
+++ b/elements/userlevel/fromdump.cc
@@ -497,7 +497,13 @@ FromDump::read_packet(ErrorHandler *errh)
             q->take(caplen - desired_len);
         }
 
-        if (!q) {
+        if (!q || (q->length() > Packet::max_buffer_length())) {
+            if (q) {
+                click_chatter(
+                    "Frame length (%" PRIu32 " bytes) exceeds the available buffer length (%" PRIu32 " bytes)",
+                    q->length(), Packet::max_buffer_length()
+                );
+            }
             _packet = 0;
             return false;
         }

--- a/elements/userlevel/fromdump.cc
+++ b/elements/userlevel/fromdump.cc
@@ -488,14 +488,6 @@ FromDump::read_packet(ErrorHandler *errh)
             desired_len = (_linktype == FAKE_DLT_RAW) ? (_force_len - 14) : _force_len;
         }
 
-        // TODO: Fix this issue
-        if (desired_len > 2048) {
-            click_chatter("Drop frame with length %d bytes as it exceeds the available buffer length", desired_len);
-            p->kill();
-            _packet = 0;
-            return false;
-        }
-
         // Need to enlarge the packet
         if (desired_len > caplen) {
             q = p->put(desired_len - caplen);
@@ -506,6 +498,7 @@ FromDump::read_packet(ErrorHandler *errh)
         }
 
         if (!q) {
+            p->kill();
             _packet = 0;
             return false;
         }
@@ -521,6 +514,7 @@ FromDump::read_packet(ErrorHandler *errh)
         }
 
         if (!ip) {
+            q->kill();
             _packet = 0;
             return false;
         }

--- a/elements/userlevel/fromdump.hh
+++ b/elements/userlevel/fromdump.hh
@@ -56,6 +56,15 @@ Boolean. If true, then FromDump will emit only IP packets with their IP header
 annotations correctly set. (If FromDump has two outputs, non-IP packets are
 pushed out on output 1; otherwise, they are dropped.) Default is false.
 
+=item FORCE_LEN
+
+Integer. This parameter allows to force a desired frame length for all the frames
+of a trace, given that this length is in [MIN_MTU, MAX_MTU] range.
+To replay a trace with the real frame sizes (not the captured ones), set value to
+0. Otherwise, set value to -1 to disable this feature (default case).
+When FORCE_LEN is 0 or in [MIN_MTU, MAX_MTU], expensive packet operations might be
+applied, therefore it is likely to experience lower traffic injection throughput.
+
 =item START
 
 Absolute time in seconds since the epoch. FromDump will output packets with
@@ -213,6 +222,8 @@ class FromDump : public Element { public:
   private:
 
     enum { BUFFER_SIZE = 32768, SAMPLING_SHIFT = 28 };
+
+    enum { DISABLED = -1, REAL_LEN = 0};
 
     FromFile _ff;
 

--- a/include/click/packet.hh
+++ b/include/click/packet.hh
@@ -325,6 +325,7 @@ class Packet { public:
     inline void change_buffer_length(uint32_t length);
 #endif
     bool copy(Packet* p, int headroom=0);
+    static uint32_t max_buffer_length();
     //@}
 
     /** @name Header Pointers */

--- a/include/click/packet.hh
+++ b/include/click/packet.hh
@@ -325,7 +325,6 @@ class Packet { public:
     inline void change_buffer_length(uint32_t length);
 #endif
     bool copy(Packet* p, int headroom=0);
-    static uint32_t max_buffer_length();
     //@}
 
     /** @name Header Pointers */

--- a/lib/packet.cc
+++ b/lib/packet.cc
@@ -518,12 +518,6 @@ inline bool WritablePacket::is_from_data_pool(WritablePacket *p) {
 
 }
 
-uint32_t
-Packet::max_buffer_length()
-{
-    return CLICK_PACKET_POOL_BUFSIZ;
-}
-
 /**
  * @Precond _use_count == 1
  */
@@ -981,7 +975,7 @@ Packet::expensive_uniqueify(int32_t extra_headroom, int32_t extra_tailroom,
 
     npkt->shift_header_annotations(buffer(), extra_headroom);
 
-    click_chatter("HEadroom %d %d",headroom(),npkt->headroom());
+    click_chatter("Headroom %d %d",headroom(),npkt->headroom());
     click_chatter("Tailroom %d %d",tailroom(),npkt->tailroom());
     click_chatter("Length %d %d",length(),npkt->length());
     click_chatter("Shared %d %d",shared(),npkt->shared());

--- a/lib/packet.cc
+++ b/lib/packet.cc
@@ -518,6 +518,12 @@ inline bool WritablePacket::is_from_data_pool(WritablePacket *p) {
 
 }
 
+uint32_t
+Packet::max_buffer_length()
+{
+    return CLICK_PACKET_POOL_BUFSIZ;
+}
+
 /**
  * @Precond _use_count == 1
  */


### PR DESCRIPTION
This enhances the way parameter FORCE_LEN works.
When FORCE_LEN==-1, FromDump works as before.
When FORCE_LEN=x, where x in [MIN_MTU, MAX_MTU], each
frame is crafted with a fixed length x bytes.
When FORCE_LEN=0, each frame takes its original (actual)
length.
IP checksums are properly computed when needed.

Signed-off-by: Georgios Katsikas <katsikas.gp@gmail.com>