### PR TITLE
Prevent accessing non-existing MAC header

### DIFF
--- a/include/click/packet.hh
+++ b/include/click/packet.hh
@@ -2115,6 +2115,7 @@ Packet::set_dst_ip_anno(IPAddress a)
 inline void
 Packet::set_mac_header(const unsigned char *p)
 {
+    if (!p) return;
     assert(p >= buffer() && p <= end_buffer());
 #if CLICK_LINUXMODULE	/* Linux kernel module */
 # if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 24)


### PR DESCRIPTION
This patch fixes an issue when attempting to set MAC
header on e.g., raw IP packets.

Signed-off-by: Georgios Katsikas <katsikas.gp@gmail.com>