### PR TITLE
lexer: fix Compound::expand_into sanity check

### DIFF
--- a/lib/lexer.cc
+++ b/lib/lexer.cc
@@ -416,7 +416,7 @@ Lexer::Compound::expand_into(Lexer *lexer, int which, VariableEnvironment &ve)
 
     // now copy hookups
     for (const Connection *cp = _conn.begin(); cp != _conn.end(); ++cp)
-        if (eidx_map[(*cp)[0].idx] >= 0 && eidx_map[(*cp)[0].idx] >= 0)
+        if (eidx_map[(*cp)[0].idx] >= 0 && eidx_map[(*cp)[1].idx] >= 0)
             lexer->_c->connect(eidx_map[(*cp)[1].idx], (*cp)[1].port,
                                eidx_map[(*cp)[0].idx], (*cp)[0].port);
 


### PR DESCRIPTION
The check here appears to be intended to make sure that we only connect if
both indexes are valid; specifically, idx can be -1.  Unfortunately, it
checks (*cp)[0] twice.  Instead, check (*cp)[1] too.

Thanks, American Fuzzy Lop

Change-Id: I5cdeb45ac0cef5bbb0a18c6f19b4540df8007bfe