### PR TITLE
ip6address: fix parser array bounds issue/crash

### DIFF
--- a/lib/ip6address.cc
+++ b/lib/ip6address.cc
@@ -332,7 +332,7 @@ IP6AddressArg::basic_parse(const String &str, IP6Address &result, const ArgConte
     int d = 0, p = 0, coloncolon = -1;
 
     const char *begin = str.begin(), *end = str.end(), *s;
-    for (s = begin; s != end; ++s) {
+    for (s = begin; s != end && d < 8; ++s) {
 	int digit;
 	if (*s >= '0' && *s <= '9')
 	    digit = *s - '0';


### PR DESCRIPTION
A malformed IP6Address, i.e. with more than 8 components, will cause the
memmove/memset at the end of parsing to fail.  This code is supposed to move
the post-:: bytes to the end of the address and zero out the bytes in the
center.  Instead, it moves some of the bytes the wrong way, potentially
writing prior to parts[] and then zeroing with a negative size.

Instead, make the parser stop when it hits 8 components and let parse figure
out that we did not consume the entire String.

Thanks: American Fuzzy Lop

Change-Id: I2966cb22fb5b44eb9e92dfc6a94e891cf5d02fa7