### PR TITLE
Proper checksum calculation in FromDump with FORCE_LEN

### DIFF
--- a/elements/userlevel/fromdump.cc
+++ b/elements/userlevel/fromdump.cc
@@ -519,15 +519,11 @@ FromDump::read_packet(ErrorHandler *errh)
             return false;
         }
 
-        // Keep the old length for incremental IP checksum calculation
-        uint16_t len_old = ip->ip_len;
-
-        // Update the IP header
+        // Update the IP header's length
         ip->ip_len = htons(q->length() - offset);
-        // and don't forget the checksum
-        if (len_old != ip->ip_len) {
-            click_update_in_cksum(&ip->ip_sum, len_old, ip->ip_len);
-        }
+
+        // Checksum must be recomputed as a whole, as anonymized traces might have issues with partial checksum updates
+        ip->ip_sum = click_in_cksum((unsigned char *) ip, sizeof(click_ip));
 
         p = q;
 


### PR DESCRIPTION
This patch deals with FromDump when FORCE_LEN configuration
is active. In this case the checksum of each packet is entirely
recomputed to cover cases, such as anonymized traces.
The issue manifested itself when attempted to replay the new
anomymized KTH traces.

Signed-off-by: Georgios Katsikas <katsikas.gp@gmail.com>