### PR TITLE
Fix FromNetmapDevice timestamps and ToNetmapDevice arguments parsing

### DIFF
--- a/elements/userlevel/fromnetmapdevice.cc
+++ b/elements/userlevel/fromnetmapdevice.cc
@@ -33,19 +33,19 @@ CLICK_DECLS
 FromNetmapDevice::FromNetmapDevice() : _device(NULL),_keephand(false)
 {
 #if HAVE_BATCH
-	in_batch_mode = BATCH_MODE_YES;
+    in_batch_mode = BATCH_MODE_YES;
 #endif
 #if HAVE_ZEROCOPY
-	NetmapDevice::global_alloc += 2048;
+    NetmapDevice::global_alloc += 2048;
 #endif
-	_burst = 32;
+    _burst = 32;
 }
 
 void *
 FromNetmapDevice::cast(const char *n)
 {
     if (strcmp(n, "FromNetmapDevice") == 0)
-	return (Element *)this;
+        return (Element *)this;
     return NULL;
 }
 
@@ -53,26 +53,26 @@ int
 FromNetmapDevice::configure(Vector<String> &conf, ErrorHandler *errh)
 {
 
-	String flow,ifname;
+    String flow,ifname;
 
-	int thisnode = 0;
+    int thisnode = 0;
 
-	if (Args(this, errh).bind(conf)
+    if (Args(this, errh).bind(conf)
             .read_mp("DEVNAME", ifname)
             .consume() < 0)
         return -1;
-	int err = parse(conf, errh);
-	if (err != 0)
-		return err;
+    int err = parse(conf, errh);
+    if (err != 0)
+        return err;
 
     if (Args(conf, this, errh)
-		.read("KEEPHAND",_keephand)
-		.complete() < 0)
-    	return -1;
+            .read("KEEPHAND",_keephand)
+            .complete() < 0)
+        return -1;
 #if HAVE_NUMA
     if (_use_numa) {
-    const char* device = ifname.c_str();
-    thisnode = Numa::get_device_node(&device[7]);
+        const char* device = ifname.c_str();
+        thisnode = Numa::get_device_node(&device[7]);
     } else
         thisnode = 0;
 #endif
@@ -118,196 +118,196 @@ FromNetmapDevice::initialize(ErrorHandler *errh)
     ret = initialize_tasks(false,errh);
     if (ret != 0) return ret;
 
-	if (_verbose > 0 && thread_per_queues() > 2) {
-	errh->warning("Using 3 or more threads per NIC's hardware queue is "
-				"discouraged : use more hardware-queue or less threads, or they "
-				"will spin to lock the same hardware queue and do nothing usefull.");
-	}
+    if (_verbose > 0 && thread_per_queues() > 2) {
+        errh->warning("Using 3 or more threads per NIC's hardware queue is "
+                      "discouraged : use more hardware-queue or less threads, or they "
+                      "will spin to lock the same hardware queue and do nothing usefull.");
+    }
 
-	if (_verbose > 0 && queue_per_threads > 3) {
-		errh->warning(((usable_threads.weight()==1?String("The thread handling"):
-				String("Each thread of")) + String(
-						" %s will loop through %d hardware queues. Having "
-						"more than 3 queues per thread is useless. Consider limiting the "
-						"number of hardware queue of %s (via ethtool -L %s combined X "
-						"on Linux), or use N_QUEUES N argument to only use the first N queues and "
-						"prevent traffic from going to the last queues by limiting RSS "
-						"on %s (via ethtool -X %s equal N).")).c_str(),name().c_str(), queue_per_threads,_device->nmds[0]->nifp->ni_name,_device->nmds[0]->nifp->ni_name,_device->nmds[0]->nifp->ni_name,_device->nmds[0]->nifp->ni_name);
-	}
+    if (_verbose > 0 && queue_per_threads > 3) {
+        errh->warning(((usable_threads.weight()==1?String("The thread handling"):
+                String("Each thread of")) + String(
+                       " %s will loop through %d hardware queues. Having "
+                       "more than 3 queues per thread is useless. Consider limiting the "
+                       "number of hardware queue of %s (via ethtool -L %s combined X "
+                       "on Linux), or use N_QUEUES N argument to only use the first N queues and "
+                       "prevent traffic from going to the last queues by limiting RSS "
+                       "on %s (via ethtool -X %s equal N).")).c_str(),name().c_str(), queue_per_threads,_device->nmds[0]->nifp->ni_name,_device->nmds[0]->nifp->ni_name,_device->nmds[0]->nifp->ni_name,_device->nmds[0]->nifp->ni_name);
+    }
 
-	//IRQ
-	char netinfo[100];
-	sprintf(netinfo, "/sys/class/net/%s/device/msi_irqs", _device->ifname.c_str() + 7);
-	DIR *dir;
-	struct dirent *ent;
+    //IRQ
+    char netinfo[100];
+    sprintf(netinfo, "/sys/class/net/%s/device/msi_irqs", _device->ifname.c_str() + 7);
+    DIR *dir;
+    struct dirent *ent;
 
-	int i = 0;
-	if ((dir = opendir (netinfo)) != NULL) {
-	  while ((ent = readdir (dir)) != NULL && i < firstqueue + n_queues) {
-		int n = atoi(ent->d_name);
-		if (n == 0) continue;
-		if (i < firstqueue) {i++; continue;}
+    int i = 0;
+    if ((dir = opendir (netinfo)) != NULL) {
+        while ((ent = readdir (dir)) != NULL && i < firstqueue + n_queues) {
+            int n = atoi(ent->d_name);
+            if (n == 0) continue;
+            if (i < firstqueue) {i++; continue;}
 
-		char irqpath[100];
-		int irq_n = n;
+            char irqpath[100];
+            int irq_n = n;
 
-		sprintf(irqpath, "/proc/irq/%d/smp_affinity_list", irq_n);
-		int fd = open(irqpath, O_WRONLY);
-		if (fd <= 0)
-			continue;
-		sprintf(irqpath,"%d",thread_for_queue(i));
-		if (_verbose > 1)
-			click_chatter("Pinning IRQ %d (queue %d) to thread %d",irq_n,i,thread_for_queue(i));
-		write(fd, irqpath, (size_t)strlen(irqpath));
-		close(fd);
-		i++;
-	  }
-	  closedir (dir);
-	}
+            sprintf(irqpath, "/proc/irq/%d/smp_affinity_list", irq_n);
+            int fd = open(irqpath, O_WRONLY);
+            if (fd <= 0)
+                continue;
+            sprintf(irqpath,"%d",thread_for_queue(i));
+            if (_verbose > 1)
+                click_chatter("Pinning IRQ %d (queue %d) to thread %d",irq_n,i,thread_for_queue(i));
+            write(fd, irqpath, (size_t)strlen(irqpath));
+            close(fd);
+            i++;
+        }
+        closedir (dir);
+    }
 
-	//Map fd to queues to allow select handler to quickly check the right ring
-	_queue_for_fd.resize(_device->_maxfd + 1);
-	for (int i = firstqueue; i < n_queues + firstqueue; i++) {
-	    int fd = _device->nmds[i]->fd;
-	    _queue_for_fd[fd] = i;
-	}
+    //Map fd to queues to allow select handler to quickly check the right ring
+    _queue_for_fd.resize(_device->_maxfd + 1);
+    for (int i = firstqueue; i < n_queues + firstqueue; i++) {
+        int fd = _device->nmds[i]->fd;
+        _queue_for_fd[fd] = i;
+    }
 
-	//Register selects for threads
-	for (int i = 0; i < usable_threads.size();i++) {
-		if (!usable_threads[i])
-			continue;
-		for (int j = queue_for_thread_begin(i); j <= queue_for_thread_end(i); j++)
-			master()->thread(i)->select_set().add_select(_device->nmds[j]->fd,this,SELECT_READ);
-	}
+    // Register selects for threads
+    for (int i = 0; i < usable_threads.size();i++) {
+        if (!usable_threads[i])
+            continue;
+        for (int j = queue_for_thread_begin(i); j <= queue_for_thread_end(i); j++)
+            master()->thread(i)->select_set().add_select(_device->nmds[j]->fd,this,SELECT_READ);
+    }
 
-	return 0;
+    return 0;
 }
 
 inline bool
 FromNetmapDevice::receive_packets(Task* task, int begin, int end, bool fromtask) {
-		unsigned nr_pending = 0;
+    unsigned nr_pending = 0;
 
-		int sent = 0;
+    int sent = 0;
 
-		for (int i = begin; i <= end; i++) {
-			lock();
+    for (int i = begin; i <= end; i++) {
+        lock();
 
-			struct nm_desc* nmd = _device->nmds[i];
+        struct nm_desc* nmd = _device->nmds[i];
 
-			struct netmap_ring *rxring = NETMAP_RXRING(nmd->nifp, i);
+        struct netmap_ring *rxring = NETMAP_RXRING(nmd->nifp, i);
 
-			u_int cur, n;
+        u_int cur, n;
 
-			cur = rxring->cur;
+        cur = rxring->cur;
 
-			n = nm_ring_space(rxring);
-			if (_burst > 0 && n > (int)_burst) {
-			    nr_pending += n - (int)_burst;
-				n = _burst;
-			}
+        n = nm_ring_space(rxring);
+        if (_burst > 0 && n > (int)_burst) {
+            nr_pending += n - (int)_burst;
+            n = _burst;
+        }
 
-			if (n == 0) {
-			    unlock();
-				continue;
-			}
+        if (n == 0) {
+            unlock();
+            continue;
+        }
 
-			Timestamp ts = Timestamp::make_usec(nmd->hdr.ts.tv_sec, nmd->hdr.ts.tv_usec);
+        Timestamp ts = Timestamp::make_usec(nmd->hdr.ts.tv_sec, nmd->hdr.ts.tv_usec);
 
-			sent+=n;
+        sent+=n;
 
 #if HAVE_NETMAP_PACKET_POOL && HAVE_BATCH
-			PacketBatch *batch_head = NetmapDevice::make_netmap_batch(n,rxring,cur);
-			if (!batch_head) goto error;
+        PacketBatch *batch_head = NetmapDevice::make_netmap_batch(n, rxring, cur);
+        if (!batch_head) goto error;
 #else
 
-	#if HAVE_BATCH
-			PacketBatch *batch_head = NULL;
-			Packet* last = NULL;
-			unsigned int count = n;
-	#endif
-				while (n > 0) {
-
-					struct netmap_slot* slot = &rxring->slot[cur];
-
-					unsigned char* data = (unsigned char*)NETMAP_BUF(rxring, slot->buf_idx);
-					WritablePacket *p;
-			#if HAVE_NETMAP_PACKET_POOL
-					if (slot->flags & NS_MOREFRAG) {
-						click_chatter("Packets bigger than Netmap buffer size are not supported while compiled with Netmap Packet Pool. Please disable this feature.");
-						assert(false);
-					}
-					__builtin_prefetch(data);
-					p = WritablePacket::make_netmap(data, rxring, slot);
-					if (unlikely(p == NULL)) goto error;
-			#else
-                #if HAVE_ZEROCOPY
-					uint32_t new_buf = 0;
-                    if (slot->len > 64 && !(slot->flags & NS_MOREFRAG) && (new_buf = NetmapBufQ::local_pool()->extract())) {
-                        __builtin_prefetch(data);
-                        p = Packet::make( data, slot->len, NetmapBufQ::buffer_destructor,0);
-                        if (!p) goto error;
-                        slot->buf_idx = new_buf;
-                        slot->flags = NS_BUF_CHANGED;
-                    } else
-                #endif
-                    {
-                            if (slot->flags & NS_MOREFRAG) {
-                                click_chatter("Packets bigger than Netmap buffer size are not supported for now. Please set MTU lower and disable features like LRO and GRO.");
-                                assert(false);
-                            }
-                        p = Packet::make(data, slot->len);
-                        if (!p) goto error;
-                    }
-            #endif
-				p->set_packet_type_anno(Packet::HOST);
-				p->set_mac_header(p->data());
-
-	#if HAVE_BATCH
-					if (batch_head == NULL) {
-						batch_head = PacketBatch::start_head(p);
-					} else {
-						last->set_next(p);
-					}
-					last = p;
-	#else
-					p->set_timestamp_anno(ts);
-					output(0).push(p);
+    #if HAVE_BATCH
+        PacketBatch *batch_head = NULL;
+        Packet* last = NULL;
+        unsigned int count = n;
     #endif
-					cur = nm_ring_next(rxring, cur);
-					n--;
-				}
+        while (n > 0) {
+
+            struct netmap_slot* slot = &rxring->slot[cur];
+
+            unsigned char* data = (unsigned char*) NETMAP_BUF(rxring, slot->buf_idx);
+            WritablePacket *p;
+    #if HAVE_NETMAP_PACKET_POOL
+            if (slot->flags & NS_MOREFRAG) {
+                click_chatter("Packets bigger than Netmap buffer size are not supported while compiled with Netmap Packet Pool. Please disable this feature.");
+                assert(false);
+            }
+            __builtin_prefetch(data);
+            p = WritablePacket::make_netmap(data, rxring, slot);
+            if (unlikely(p == NULL)) goto error;
+    #else
+        #if HAVE_ZEROCOPY
+            uint32_t new_buf = 0;
+            if (slot->len > 64 && !(slot->flags & NS_MOREFRAG) && (new_buf = NetmapBufQ::local_pool()->extract())) {
+                __builtin_prefetch(data);
+                p = Packet::make(data, slot->len, NetmapBufQ::buffer_destructor, 0);
+                if (!p) goto error;
+                slot->buf_idx = new_buf;
+                slot->flags = NS_BUF_CHANGED;
+            } else
+        #endif
+            {
+                if (slot->flags & NS_MOREFRAG) {
+                    click_chatter("Packets bigger than Netmap buffer size are not supported for now. Please set MTU lower and disable features like LRO and GRO.");
+                    assert(false);
+                }
+                p = Packet::make(data, slot->len);
+                if (!p) goto error;
+            }
+    #endif
+            p->set_packet_type_anno(Packet::HOST);
+            p->set_mac_header(p->data());
+
+    #if HAVE_BATCH
+            if (batch_head == NULL) {
+                batch_head = PacketBatch::start_head(p);
+            } else {
+                last->set_next(p);
+            }
+            last = p;
+    #else
+            p->set_timestamp_anno(ts);
+            output(0).push(p);
+    #endif
+            cur = nm_ring_next(rxring, cur);
+            n--;
+        }
+    #if HAVE_BATCH
+        if (batch_head) {
+            batch_head->make_tail(last, count);
+        }
+    #endif
+
+#endif
+        rxring->head = rxring->cur = cur;
+        unlock();
 #if HAVE_BATCH
-				if (batch_head) {
-					batch_head->make_tail(last,count);
-				}
+        batch_head->set_timestamp_anno(ts);
+        output_push_batch(0,batch_head);
 #endif
 
-#endif
-			rxring->head = rxring->cur = cur;
-			unlock();
-#if HAVE_BATCH
-			batch_head->set_timestamp_anno(ts);
-			output_push_batch(0,batch_head);
-#endif
+    }
 
-		}
+    if ((int) nr_pending > _burst) { //TODO size/4 or something
+        if (fromtask) {
+            task->fast_reschedule();
+        } else {
 
-	if ((int)nr_pending > _burst) { //TODO size/4 or something
-	    if (fromtask) {
-	            task->fast_reschedule();
-	    } else {
+            task->reschedule();
+        }
+    }
 
-	        task->reschedule();
-	    }
-	}
+    add_count(sent);
+    return sent;
+error: //No more buffer
 
-	add_count(sent);
-  return sent;
-  error: //No more buffer
-
-  click_chatter("No more buffers !");
-  router()->master()->kill_router(router());
-  return 0;
+    click_chatter("No more buffers !");
+    router()->master()->kill_router(router());
+    return 0;
 
 
 }
@@ -315,7 +315,7 @@ FromNetmapDevice::receive_packets(Task* task, int begin, int end, bool fromtask)
 void
 FromNetmapDevice::selected(int fd, int)
 {
-	receive_packets(task_for_thread(),queue_for_fd(fd),queue_for_fd(fd),false);
+    receive_packets(task_for_thread(), queue_for_fd(fd), queue_for_fd(fd), false);
 }
 
 void
@@ -328,7 +328,7 @@ FromNetmapDevice::cleanup(CleanupStage)
 bool
 FromNetmapDevice::run_task(Task* t)
 {
-    return receive_packets(t,queue_for_thisthread_begin(),queue_for_thisthread_end(),true);
+    return receive_packets(t, queue_for_thisthread_begin(), queue_for_thisthread_end(), true);
 
 }
 

--- a/elements/userlevel/fromnetmapdevice.hh
+++ b/elements/userlevel/fromnetmapdevice.hh
@@ -88,8 +88,6 @@ public:
 
     int configure_phase() const			{ return CONFIGURE_PHASE_PRIVILEGED - 5; }
     void* cast(const char*);
-
-
     int configure(Vector<String>&, ErrorHandler*) CLICK_COLD;
     int initialize(ErrorHandler*) CLICK_COLD;
     void cleanup(CleanupStage) CLICK_COLD;

--- a/elements/userlevel/fromnetmapdevice.hh
+++ b/elements/userlevel/fromnetmapdevice.hh
@@ -72,8 +72,6 @@ CLICK_DECLS
  *
  */
 
-
-
 class FromNetmapDevice: public RXQueueDevice {
 
 public:

--- a/elements/userlevel/tonetmapdevice.cc
+++ b/elements/userlevel/tonetmapdevice.cc
@@ -46,8 +46,11 @@ ToNetmapDevice::configure(Vector<String> &conf, ErrorHandler *errh)
 
     if (Args(this, errh).bind(conf)
             .read_mp("DEVNAME", ifname)
-            .complete() < 0)
+            .consume() < 0)
     	return -1;
+
+    if (parse(conf, errh) != 0)
+        return -1;
 
     if (_internal_tx_queue_size < _burst * 2) {
         return errh->error("IQUEUE (%d) must be at least twice the size of BURST (%d)!",_internal_tx_queue_size, _burst);

--- a/include/click/netmapdevice.hh
+++ b/include/click/netmapdevice.hh
@@ -167,7 +167,7 @@ class NetmapDevice {
 #if HAVE_NETMAP_PACKET_POOL
     static WritablePacket* make_netmap(unsigned char* data, struct netmap_ring* rxring, struct netmap_slot* slot);
 # if HAVE_BATCH
-    static PacketBatch* make_netmap_batch(unsigned int n, struct netmap_ring* rxring,unsigned int &cur);
+    static PacketBatch* make_netmap_batch(unsigned int n, struct netmap_ring* rxring, unsigned int &cur);
 # endif
 #endif
 	static NetmapDevice* open(String ifname);

--- a/lib/netmapdevice.cc
+++ b/lib/netmapdevice.cc
@@ -211,10 +211,12 @@ WritablePacket* NetmapDevice::make_netmap(unsigned char* data, struct netmap_rin
 /**
  * Creates a batch of packet directly from a netmap ring.
  */
-PacketBatch* NetmapDevice::make_netmap_batch(unsigned int n, struct netmap_ring* rxring,unsigned int &cur) {
+PacketBatch* NetmapDevice::make_netmap_batch(unsigned int n, struct netmap_ring* rxring, unsigned int &cur) {
     if (n <= 0) return NULL;
     struct netmap_slot* slot;
     WritablePacket* last = 0;
+
+    Timestamp ts = Timestamp::make_usec(rxring->ts.tv_sec, rxring->ts.tv_usec);
 
     PacketPool& packet_pool = *WritablePacket::make_local_packet_pool();
 
@@ -262,6 +264,9 @@ PacketBatch* NetmapDevice::make_netmap_batch(unsigned int n, struct netmap_ring*
         }
         last->set_next(next);
 
+        last->set_packet_type_anno(Packet::HOST);
+        last->set_mac_header(last->data());
+        last->set_timestamp_anno(ts);
     }
 
     _head = static_cast<WritablePacket*>(next);


### PR DESCRIPTION
Also change indentation in FromNetmapDevice to 4 spaces. The file contained mixed portions of tabs, spaces and tabs-with-spaces indentation. I find such an indentation mess very problematic, especially in files with convoluted logic like this. Maybe its high time to introduce consistent space-only indentation across the whole FastClick codebase?