### PR TITLE
The new CounterFile element, based on CounterAtomic

### DIFF
--- a/elements/userlevel/counterfile.cc
+++ b/elements/userlevel/counterfile.cc
@@ -1,0 +1,170 @@
+/*
+ * counterfile.{cc,hh} -- element counts packets
+ * Eddie Kohler, Tom Barbette, Piotr Jurkiewicz
+ *
+ * Copyright (c) 1999-2000 Massachusetts Institute of Technology
+ * Copyright (c) 2008 Regents of the University of California
+ * Copyright (c) 2016 University of Liege
+ * Copyright (c) 2018 AGH University of Science and Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
+#include <click/config.h>
+#include "counterfile.hh"
+#include <click/error.hh>
+#include <click/args.hh>
+#include <fcntl.h>
+#include <sys/mman.h>
+CLICK_DECLS
+
+CounterFile::CounterFile()
+: _batch_precise(false), _filename(), _mmapped_stats((stats_atomic *) MAP_FAILED)
+{
+}
+
+CounterFile::~CounterFile()
+{
+}
+
+int
+CounterFile::configure(Vector<String> &conf, ErrorHandler *errh)
+{
+    if (Args(conf, this, errh)
+            .read_mp("FILENAME", FilenameArg(), _filename)
+            .read("BATCH_PRECISE", _batch_precise)
+            .complete() < 0)
+        return -1;
+
+    return 0;
+}
+
+int
+CounterFile::initialize(ErrorHandler *errh)
+{
+    int fd = open(_filename.c_str(), O_RDWR | O_CREAT, 0644);
+
+    if (fd < 0) {
+        int e = -errno;
+        errh->error("%s: %s", _filename.c_str(), strerror(-e));
+        return e;
+    }
+
+    ftruncate(fd, sizeof(stats_atomic));
+
+    void *mmap_data = mmap(0, sizeof(stats_atomic), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_POPULATE, fd, 0);
+
+    if (mmap_data == MAP_FAILED) {
+        int e = -errno;
+        errh->error("%s mmap: %s", _filename.c_str(), strerror(-e));
+        close(fd);
+        return e;
+    }
+
+    close(fd);
+
+    _mmapped_stats = static_cast<stats_atomic *>(mmap_data);
+
+    return 0;
+}
+
+void
+CounterFile::cleanup()
+{
+    void *mmap_data = static_cast<void *>(_mmapped_stats);
+
+    if (mmap_data != MAP_FAILED)
+        munmap(mmap_data, sizeof(stats_atomic));
+}
+
+bool CounterFile::do_mt_safe_check(ErrorHandler*) {
+    return true;
+}
+
+enum { H_COUNT, H_BYTE_COUNT, H_RESET };
+
+String
+CounterFile::read_handler(Element *e, void *thunk)
+{
+    CounterFile *c = (CounterFile *)e;
+
+    switch ((intptr_t)thunk) {
+    case H_COUNT:
+        return String(c->count());
+    case H_BYTE_COUNT:
+        return String(c->byte_count());
+    default:
+        return "<error>";
+    }
+}
+
+int
+CounterFile::write_handler(const String &, Element *e, void *thunk, ErrorHandler *errh)
+{
+    CounterFile *c = (CounterFile *)e;
+    switch ((intptr_t)thunk) {
+    case H_RESET:
+        c->reset();
+        return 0;
+    default:
+        return errh->error("<internal>");
+    }
+}
+
+void
+CounterFile::add_handlers()
+{
+    add_read_handler("count", CounterFile::read_handler, H_COUNT);
+    add_read_handler("byte_count", CounterFile::read_handler, H_BYTE_COUNT);
+    add_write_handler("reset", CounterFile::write_handler, H_RESET, Handler::f_button);
+    add_write_handler("reset_counts", CounterFile::write_handler, H_RESET, Handler::f_button | Handler::f_uncommon);
+}
+
+Packet*
+CounterFile::simple_action(Packet *p)
+{
+    _mmapped_stats->_count++;
+    _mmapped_stats->_byte_count += p->length();
+    return p;
+}
+
+#if HAVE_BATCH
+PacketBatch*
+CounterFile::simple_action_batch(PacketBatch *batch)
+{
+    if (unlikely(_batch_precise)) {
+        FOR_EACH_PACKET(batch, p)
+                        CounterFile::simple_action(p);
+        return batch;
+    }
+
+    counter_int_type bc = 0;
+    FOR_EACH_PACKET(batch, p) {
+        bc += p->length();
+    }
+    _mmapped_stats->_count += batch->count();
+    _mmapped_stats->_byte_count += bc;
+    return batch;
+}
+#endif
+
+void
+CounterFile::reset()
+{
+    _mmapped_stats->_count = 0;
+    _mmapped_stats->_byte_count = 0;
+}
+
+CLICK_ENDDECLS
+
+ELEMENT_REQUIRES(userlevel)
+EXPORT_ELEMENT(CounterFile)
+ELEMENT_MT_SAFE(CounterFile)

--- a/elements/userlevel/counterfile.hh
+++ b/elements/userlevel/counterfile.hh
@@ -1,0 +1,162 @@
+// -*- mode: c++; c-basic-offset: 4 -*-
+#ifndef CLICK_COUNTERFILE_HH
+#define CLICK_COUNTERFILE_HH
+#include <click/batchelement.hh>
+CLICK_DECLS
+
+#define counter_int_type uint64_t
+#define counter_atomic_int_type atomic_uint64_t
+
+/*
+=c
+
+CounterFile(FILENAME, [I<keywords BATCH_PRECISE>])
+
+=s counters
+
+measures packet count and writes it to file
+
+=d
+
+Passes packets unchanged from its input to its output, maintaining statistics
+information about packet count.
+
+Keyword arguments are:
+
+=over 8
+
+=item FILENAME
+
+Path to the file which stats will be written into. If the file does not exist,
+it will be created. Parent directory of the file must exist. File format is:
+
+    struct stats {
+        uint64_t _count;
+        uint64_t _byte_count;
+    };
+
+If click is compiled with HAVE_MULTITHREAD, fields are 16-byte aligned.
+
+=item BATCH_PRECISE
+
+If true, will count packets one by one and hence call the handlers when the
+count is exactly the limit. The default is to count the whole batch at once
+and call the handlers if the limit has been reached.
+
+=back
+
+=h count read-only
+
+Returns the number of packets that have passed through since the last reset.
+
+=h byte_count read-only
+
+Returns the number of bytes that have passed through since the last reset.
+
+=h reset_counts write-only
+
+Resets the counts and rates to zero.
+
+=h reset write-only
+
+Same as 'reset_counts'.
+
+*/
+
+/**
+ * Ancestor of all types of counter so external elements can access count and byte_count
+ * independently of the storage type
+ */
+
+class CounterFile : public BatchElement { public:
+
+    CounterFile() CLICK_COLD;
+    ~CounterFile() CLICK_COLD;
+
+    const char *class_name() const      { return "CounterFile"; }
+    const char *processing() const      { return AGNOSTIC; }
+    const char *port_count() const      { return PORTS_1_1; }
+
+    counter_int_type count() {
+        return _mmapped_stats->_count;
+    }
+
+    counter_int_type byte_count() {
+        return _mmapped_stats->_byte_count;
+    }
+
+    struct stats {
+        counter_int_type _count;
+        counter_int_type _byte_count;
+    };
+
+    struct stats_atomic {
+        counter_atomic_int_type _count;
+        counter_atomic_int_type _byte_count;
+    };
+
+    /**
+     * Read state in a non-atomic way, as fast as possible. Value of the ATOMIC
+     *   parameter does not change this. Avoid locks, etc, just give a plausible
+     *   value.
+     */
+
+    stats read() {
+        return {_mmapped_stats->_count, _mmapped_stats->_byte_count};
+    }
+
+    /**
+     * Atomic read. Atomicity level depends on the ATOMIC parameter.
+     */
+
+    stats atomic_read() {  //This is NOT atomic between the two fields
+        return {_mmapped_stats->_count, _mmapped_stats->_byte_count};
+    }
+
+    /**
+     * Add something to the counter, allowing stale and inconsistent data but
+     *   still thread safe (the final total must be good)
+     */
+
+    void add(stats s) {
+        _mmapped_stats->_count += s._count;
+        _mmapped_stats->_byte_count += s._byte_count;
+    }
+
+    /**
+     * Add in an atomic way.
+     */
+
+    void atomic_add(stats s) {
+        _mmapped_stats->_count += s._count;
+        _mmapped_stats->_byte_count += s._byte_count;
+    }
+
+    bool do_mt_safe_check(ErrorHandler* errh);
+
+    //Only per-counter atomic
+    int can_atomic() { return 1; } CLICK_COLD;
+
+    void reset();
+
+    Packet *simple_action(Packet *);
+#if HAVE_BATCH
+    PacketBatch *simple_action_batch(PacketBatch* batch);
+#endif
+
+    int configure(Vector<String> &, ErrorHandler *) CLICK_COLD;
+    int initialize(ErrorHandler *) CLICK_COLD;
+    void cleanup() CLICK_COLD;
+    void add_handlers() CLICK_COLD;
+
+  protected:
+
+    bool _batch_precise;
+    String _filename;
+    stats_atomic *_mmapped_stats;
+    static String read_handler(Element *, void *) CLICK_COLD;
+    static int write_handler(const String&, Element*, void*, ErrorHandler*) CLICK_COLD;
+};
+
+CLICK_ENDDECLS
+#endif


### PR DESCRIPTION
CounterFile element writes packet and byte counts to a mmapped-file
providing external processes a fast and low-overhead way to read
counter values.