### PR TITLE
Conditional kill of packet in ensure DPDK buffer

### DIFF
--- a/elements/userlevel/ensuredpdkbuffer.cc
+++ b/elements/userlevel/ensuredpdkbuffer.cc
@@ -65,14 +65,14 @@ EnsureDPDKBuffer::smaction(Packet* p) {
     } else if (_noalloc) {
         p->kill();
         if (_warn_count++ < 5)
-            click_chatter("%p{element} : Not a DPDK packet",this);
+            click_chatter("%p{element}: Not a DPDK packet", this);
         return 0;
     } else {
         struct rte_mbuf* mbuf = DPDKDevice::get_pkt();
         if (!mbuf) {
             p->kill();
             if (_warn_count++ < 5)
-                click_chatter("%s : No more DPDK Buffer ! Dropping packet.",name().c_str());
+                click_chatter("%s: No more DPDK buffer! Dropping packet.", name().c_str());
             return 0;
         }
         WritablePacket* q = WritablePacket::make(
@@ -103,7 +103,7 @@ PacketBatch*
 EnsureDPDKBuffer::simple_action_batch(PacketBatch *head)
 {
 #if HAVE_ZEROCOPY
-    EXECUTE_FOR_EACH_PACKET_DROPPABLE(smaction,head,[](Packet* p) {click_chatter("No more DPDK buffer ! Dropping packet %p !",p);});
+    EXECUTE_FOR_EACH_PACKET_DROPPABLE(smaction,head,[](Packet* p) {click_chatter("No more DPDK buffer! Dropping packet %p!", p);});
 #endif
     return head;
 }

--- a/elements/userlevel/ensuredpdkbuffer.cc
+++ b/elements/userlevel/ensuredpdkbuffer.cc
@@ -88,7 +88,10 @@ EnsureDPDKBuffer::smaction(Packet* p) {
             p->kill();
             return q;
         } else {
-            p->kill();
+            click_chatter("[%s] Could not ensure buffer for packet with length %d bytes. Dropped!", name().c_str(), p->length());
+            if (p->length() <= (DPDKDevice::MBUF_DATA_SIZE - RTE_PKTMBUF_HEADROOM)) {
+                p->kill();
+            }
             q->kill();
             return 0;
         }


### PR DESCRIPTION
This is a way to circumvent memory corruption when trying to ensure the buffer space of large DPDK frames