### PR TITLE
Enabling/disabling VLAN offload features in FromDPDKDevice

### DIFF
--- a/elements/userlevel/fromdpdkdevice.cc
+++ b/elements/userlevel/fromdpdkdevice.cc
@@ -125,7 +125,7 @@ int FromDPDKDevice::initialize(ErrorHandler *errh)
     if (ret != 0) return ret;
 
     for (unsigned i = (unsigned)firstqueue; i <= (unsigned)lastqueue; i++) {
-        ret = _dev->add_rx_queue(i , _promisc, ndesc, errh);
+        ret = _dev->add_rx_queue(i , _promisc, _vlan_filter, _vlan_strip, ndesc, errh);
         if (ret != 0) return ret;
     }
 

--- a/elements/userlevel/queuedevice.cc
+++ b/elements/userlevel/queuedevice.cc
@@ -102,8 +102,12 @@ int RXQueueDevice::parse(Vector<String> &conf, ErrorHandler *errh) {
     QueueDevice::parse(conf, errh);
 
 	_promisc = true;
+	_vlan_filter = true;
+	_vlan_strip = true;
     if (Args(this, errh).bind(conf)
 	.read_p("PROMISC", _promisc)
+	.read_p("VLAN_FILTER", _vlan_filter)
+	.read_p("VLAN_STRIP", _vlan_strip)
         .consume() < 0)
         return -1;
 

--- a/elements/userlevel/queuedevice.hh
+++ b/elements/userlevel/queuedevice.hh
@@ -200,6 +200,8 @@ protected:
 class RXQueueDevice : public QueueDevice {
 protected:
 	bool _promisc;
+	bool _vlan_filter;
+	bool _vlan_strip;
 	bool _set_rss_aggregate;
 	bool _set_paint_anno;
 	int _threadoffset;

--- a/include/click/dpdkdevice.hh
+++ b/include/click/dpdkdevice.hh
@@ -71,8 +71,9 @@ public:
     struct DevInfo {
         inline DevInfo() :
             vendor_id(PCI_ANY_ID), vendor_name(), device_id(PCI_ANY_ID), driver(0),
-            rx_queues(0,false), tx_queues(0,false), promisc(false), n_rx_descs(0),
-            n_tx_descs(0),
+            rx_queues(0,false), tx_queues(0,false),
+            promisc(false), vlan_filter(false), vlan_strip(false),
+            n_rx_descs(0), n_tx_descs(0),
             init_mac(), init_mtu(0), init_fc_mode(FC_UNSET) {
             rx_queues.reserve(128);
             tx_queues.reserve(128);
@@ -84,6 +85,8 @@ public:
             click_chatter("   Device   ID: %d", device_id);
             click_chatter("   Driver Name: %s", driver);
             click_chatter("Promisc   Mode: %s", promisc? "true":"false");
+            click_chatter("Vlan Filtering: %s", vlan_filter? "true":"false");
+            click_chatter("Vlan Stripping: %s", vlan_strip? "true":"false");
             click_chatter("   MAC Address: %s", init_mac.unparse().c_str());
             click_chatter("# of Rx Queues: %d", rx_queues.size());
             click_chatter("# of Tx Queues: %d", tx_queues.size());
@@ -98,6 +101,8 @@ public:
         Vector<bool> rx_queues;
         Vector<bool> tx_queues;
         bool promisc;
+        bool vlan_filter;
+        bool vlan_strip;
         unsigned n_rx_descs;
         unsigned n_tx_descs;
         EtherAddress init_mac;
@@ -106,7 +111,7 @@ public:
     };
 
     int add_rx_queue(
-        unsigned &queue_id, bool promisc,
+        unsigned &queue_id, bool promisc, bool vlan_filter, bool vlan_strip,
         unsigned n_desc, ErrorHandler *errh
     ) CLICK_COLD;
 
@@ -239,7 +244,7 @@ private:
     static bool no_more_buffer_msg_printed;
 
     int initialize_device(ErrorHandler *errh) CLICK_COLD;
-    int add_queue(Dir dir, unsigned &queue_id, bool promisc,
+    int add_queue(Dir dir, unsigned &queue_id, bool promisc, bool vlan_filter, bool vlan_strip,
                    unsigned n_desc, ErrorHandler *errh) CLICK_COLD;
 
     static int alloc_pktmbufs(ErrorHandler* errh) CLICK_COLD;

--- a/lib/dpdkdevice.cc
+++ b/lib/dpdkdevice.cc
@@ -373,7 +373,36 @@ int DPDKDevice::initialize_device(ErrorHandler *errh)
 #endif
 
 #if RTE_VERSION >= RTE_VERSION_NUM(18,02,0,0)
-    rx_conf.offloads = dev_conf.rxmode.offloads;
+
+	int diag;
+	int vlan_offload;
+
+	rx_conf.offloads = dev_conf.rxmode.offloads;
+	vlan_offload = rte_eth_dev_get_vlan_offload(port_id);
+
+	if (info.vlan_filter) {
+		vlan_offload |= ETH_VLAN_FILTER_OFFLOAD;
+		rx_conf.offloads |= DEV_RX_OFFLOAD_VLAN_FILTER;
+	} else {
+		vlan_offload &= ~ETH_VLAN_FILTER_OFFLOAD;
+		rx_conf.offloads &= ~DEV_RX_OFFLOAD_VLAN_FILTER;
+	}
+
+	if (info.vlan_strip) {
+		vlan_offload |= ETH_VLAN_STRIP_OFFLOAD;
+		rx_conf.offloads |= DEV_RX_OFFLOAD_VLAN_STRIP;
+	} else {
+		vlan_offload &= ~ETH_VLAN_STRIP_OFFLOAD;
+		rx_conf.offloads &= ~DEV_RX_OFFLOAD_VLAN_STRIP;
+	}
+
+	diag = rte_eth_dev_set_vlan_offload(port_id, vlan_offload);
+	if (diag < 0)
+		printf("rx_vlan_offload_set(port_pi=%d, vlan_filter=%s, vlan_strip=%s) failed "
+				"diag=%d\n", port_id, info.vlan_filter ? "true" : "false", info.vlan_strip ? "true" : "false", diag);
+
+	dev_conf.rxmode.offloads = rx_conf.offloads;
+
 #endif
 
     struct rte_eth_txconf tx_conf;
@@ -511,7 +540,7 @@ bool set_slot(Vector<bool> &v, unsigned &id) {
 }
 
 int DPDKDevice::add_queue(DPDKDevice::Dir dir,
-                           unsigned &queue_id, bool promisc, unsigned n_desc,
+                           unsigned &queue_id, bool promisc, bool vlan_filter, bool vlan_strip, unsigned n_desc,
                            ErrorHandler *errh)
 {
     if (_is_initialized) {
@@ -525,6 +554,19 @@ int DPDKDevice::add_queue(DPDKDevice::Dir dir,
                 "Some elements disagree on whether or not device %u should"
                 " be in promiscuous mode", port_id);
         info.promisc |= promisc;
+
+		if (info.rx_queues.size() > 0 && vlan_filter != info.vlan_filter)
+			return errh->error(
+					"Some elements disagree on whether or not device %u should"
+							" filter vlan tagged packets", port_id);
+		info.vlan_filter |= vlan_filter;
+
+		if (info.rx_queues.size() > 0 && vlan_strip != info.vlan_strip)
+			return errh->error(
+					"Some elements disagree on whether or not device %u should"
+							" strip vlan tagged packets", port_id);
+		info.vlan_strip |= vlan_strip;
+
         if (n_desc > 0) {
             if (n_desc != info.n_rx_descs && info.rx_queues.size() > 0)
                 return errh->error(
@@ -553,16 +595,16 @@ int DPDKDevice::add_queue(DPDKDevice::Dir dir,
     return 0;
 }
 
-int DPDKDevice::add_rx_queue(unsigned &queue_id, bool promisc,
+int DPDKDevice::add_rx_queue(unsigned &queue_id, bool promisc, bool vlan_filter, bool vlan_strip,
                               unsigned n_desc, ErrorHandler *errh)
 {
-    return add_queue(DPDKDevice::RX, queue_id, promisc, n_desc, errh);
+    return add_queue(DPDKDevice::RX, queue_id, promisc, vlan_filter, vlan_strip, n_desc, errh);
 }
 
 int DPDKDevice::add_tx_queue(unsigned &queue_id, unsigned n_desc,
                               ErrorHandler *errh)
 {
-    return add_queue(DPDKDevice::TX, queue_id, false, n_desc, errh);
+    return add_queue(DPDKDevice::TX, queue_id, false, false, false, n_desc, errh);
 }
 
 int DPDKDevice::static_initialize(ErrorHandler* errh) {
@@ -848,3 +890,4 @@ unsigned DPDKDevice::_nr_pktmbuf_pools;
 bool DPDKDevice::no_more_buffer_msg_printed = false;
 
 CLICK_ENDDECLS
+


### PR DESCRIPTION
Adding support of VLAN offload features such as filtering of received VLAN packets and VLAN header stripping by hardware in received VLAN tagged packets.
This commit changes the default behavior and enables turning on/off these offloads, by adding two new boolean arguments to FromDPDKDevice element: VLAN_STRIP and VLAN_FILTER.