### PR TITLE
Timed source Segmentation Fault

### DIFF
--- a/elements/standard/timedsource.cc
+++ b/elements/standard/timedsource.cc
@@ -48,13 +48,15 @@ TimedSource::configure(Vector<String> &conf, ErrorHandler *errh)
     _data = data;
     if (_packet)
 	_packet->kill();
-    _packet = Packet::make(_headroom, _data.data(), _data.length(), 0);
     return 0;
 }
 
 int
 TimedSource::initialize(ErrorHandler *)
 {
+  WritablePacket *q = Packet::make(_headroom, _data.data(), _data.length(), 0);
+  _packet = q;
+
   _timer.initialize(this);
   if (_active)
     _timer.schedule_after(_interval);


### PR DESCRIPTION
Timed source seg faults when Click is built with DPDK (appears to work without DPDK).  It appears the cause is attempting to create the "source packet" before the packet pool is ready.  Moving packet creation from Configure to Initialize (similar to other sources) solves the issue.