### PR TITLE
Support DPDK 19.05

### DIFF
--- a/configure
+++ b/configure
@@ -777,6 +777,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -927,6 +928,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1179,6 +1181,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1316,7 +1327,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1469,6 +1480,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]

--- a/configure
+++ b/configure
@@ -705,8 +705,8 @@ minios_dir
 xen_dir
 INCLUDE_KSYMS
 LINUXMODULE_FIXINCLUDES
-DPDK_INCLUDES
 USE_DPDK
+DPDK_INCLUDES
 RTE_VER_MONTH
 RTE_VER_YEAR
 RTE_VER_MINOR
@@ -1576,7 +1576,7 @@ Optional Features:
   --enable-task-heap      use heap for task list
   --enable-dmalloc        enable debugging malloc
   --enable-hash-iterator-epochs
-                          hash iterator epoch
+                          hash iterator epochs
   --enable-force-expensive
                           force expensive packet operations
   --enable-valgrind       extra support for debugging with valgrind
@@ -6813,11 +6813,70 @@ fi
 
 done
 
-#if test "$ac_have_libpthread$ac_have_pthread_h" = yesyes; then
-if test "$ac_have_libmicrohttpd$ac_have_microhttpd_h" = yesyes; then
+if test "x$ac_have_libmicrohttpd$ac_have_microhttpd_h" = "xyesyes"; then
     $as_echo "#define HAVE_MICROHTTPD 1" >>confdefs.h
 
 fi
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lre2" >&5
+$as_echo_n "checking for main in -lre2... " >&6; }
+if ${ac_cv_lib_re2_main+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lre2  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+
+int
+main ()
+{
+return main ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_link "$LINENO"; then :
+  ac_cv_lib_re2_main=yes
+else
+  ac_cv_lib_re2_main=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_re2_main" >&5
+$as_echo "$ac_cv_lib_re2_main" >&6; }
+if test "x$ac_cv_lib_re2_main" = xyes; then :
+  ac_have_re2=yes
+else
+  ac_have_re2=no
+fi
+
+for ac_header in re2/re2.h
+do :
+  ac_fn_cxx_check_header_mongrel "$LINENO" "re2/re2.h" "ac_cv_header_re2_re2_h" "$ac_includes_default"
+if test "x$ac_cv_header_re2_re2_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_RE2_RE2_H 1
+_ACEOF
+ ac_have_re2_h=yes
+else
+  ac_have_re2_h=no
+fi
+
+done
+
+if test "x$ac_have_re2$ac_have_re2_h" = "xyesyes"; then
+    have_re2=yes
+    LIBS="$LIBS -lre2"
+    $as_echo "#define HAVE_RE2 1" >>confdefs.h
+
+else
+    have_re2=no
+fi
+
 
 
 # Check whether --enable-select was given.
@@ -6897,6 +6956,10 @@ if test "x$enable_dpdk" = "xyes"; then
         RTE_LIBNAME=dpdk
     fi
 
+    if test -z "$RTE_SRCDIR"; then
+        RTE_SRCDIR=$RTE_SDK
+    fi
+
     if test "x$enable_user_multithread" != "xyes"; then
         as_fn_error $? "
 =========================================
@@ -6905,37 +6968,50 @@ if test "x$enable_dpdk" = "xyes"; then
 
 =========================================" "$LINENO" 5
     fi
-    if test ! -f "$RTE_SDK_BIN/include/rte_eal.h"; then
+
+
+    if pkg-config --exists libdpdk ; then
+        :
+    else
+      if test ! -f "$RTE_SDK_BIN/include/rte_eal.h"; then
         as_fn_error $? "
 =========================================
 
 Cannot find \$RTE_SDK_BIN/include/rte_eal.h for DPDK.
-Define \$RTE_SDK and \$RTE_TARGET as per DPDK documentation.
+Define \$RTE_SDK and \$RTE_TARGET as per DPDK documentation,
+or install DPDK using meson, or he system package manager.
 
 =========================================" "$LINENO" 5
+      fi
+      if test -e "$RTE_SRCDIR/VERSION"; then
+        rte_ver_year=`cat $RTE_SRCDIR/VERSION | sed -e 's/-rc/.-rc./' -e 's/$/..99/' | awk -F '.' '{print int($1)}'`
+        rte_ver_month=`cat $RTE_SRCDIR/VERSION | sed -e 's/-rc/.-rc./' -e 's/$/..99/' | awk -F '.' '{print int($2)}'`
+        rte_ver_minor=`cat $RTE_SRCDIR/VERSION | sed -e 's/-rc/.-rc./' -e 's/$/..99/' | awk -F '.' '{print int($3)}'`
+      else
+        rte_ver_major=`grep "#define RTE_VER_MAJOR" "$RTE_SDK_BIN/include/rte_version.h" | head -n 1 | awk '{print $3}'`
+        rte_ver_minor=`grep "#define RTE_VER_MINOR" "$RTE_SDK_BIN/include/rte_version.h" | head -n 1 | awk '{print $3}'`
+        rte_ver_year=`grep "#define RTE_VER_YEAR" "$RTE_SDK_BIN/include/rte_version.h" | head -n 1 | awk '{print $3}'`
+        rte_ver_month=`grep "#define RTE_VER_MONTH" "$RTE_SDK_BIN/include/rte_version.h" | head -n 1 | awk '{print $3}'`
+      fi
+
+
+
+      RTE_VER_MAJOR=$rte_ver_major
+
+      RTE_VER_MINOR=$rte_ver_minor
+
+      RTE_VER_YEAR=$rte_ver_year
+
+      RTE_VER_MONTH=$rte_ver_month
+
+      DPDK_INCLUDES=-I${RTE_SDK_BIN}/include/
+
     fi
-    rte_ver_major=`grep "#define RTE_VER_MAJOR" "$RTE_SDK_BIN/include/rte_version.h" | head -n 1 | awk '{print $3}'`
-    rte_ver_minor=`grep "#define RTE_VER_MINOR" "$RTE_SDK_BIN/include/rte_version.h" | head -n 1 | awk '{print $3}'`
-    rte_ver_year=`grep "#define RTE_VER_YEAR" "$RTE_SDK_BIN/include/rte_version.h" | head -n 1 | awk '{print $3}'`
-    rte_ver_month=`grep "#define RTE_VER_MONTH" "$RTE_SDK_BIN/include/rte_version.h" | head -n 1 | awk '{print $3}'`
-
-
-
-
-    RTE_VER_MAJOR=$rte_ver_major
-
-    RTE_VER_MINOR=$rte_ver_minor
-
-    RTE_VER_YEAR=$rte_ver_year
-
-    RTE_VER_MONTH=$rte_ver_month
 
     $as_echo "#define HAVE_DPDK 1" >>confdefs.h
 
-
     USE_DPDK=yes
 
-    DPDK_INCLUDES=-I${RTE_SDK_BIN}/include/
 
 fi
 
@@ -10101,6 +10177,8 @@ main ()
     if (*(data + i) != *(data3 + i))
       return 14;
   close (fd);
+  free (data);
+  free (data3);
   return 0;
 }
 _ACEOF
@@ -10637,6 +10715,7 @@ else
 =========================================" "$LINENO" 5
 fi
 
+
 # Check whether --enable-stride was given.
 if test "${enable_stride+set}" = set; then :
   enableval=$enable_stride; :
@@ -10688,6 +10767,37 @@ if test $enable_dmalloc = yes; then
 $as_echo "#define CLICK_DMALLOC 1" >>confdefs.h
 
 fi
+
+
+
+
+# Check whether --enable-hash-iterator-epochs was given.
+if test "${enable_hash_iterator_epochs+set}" = set; then :
+  enableval=$enable_hash_iterator_epochs; :
+else
+  enable_hash_iterator_epochs=no
+fi
+
+if test $enable_hash_iterator_epochs = yes; then
+
+$as_echo "#define CLICK_HASH_ITERATOR_EPOCHS 1" >>confdefs.h
+
+fi
+
+
+# Check whether --enable-force-expensive was given.
+if test "${enable_force_expensive+set}" = set; then :
+  enableval=$enable_force_expensive; :
+else
+  enable_force_expensive=no
+fi
+
+if test $enable_force_expensive = yes; then
+
+$as_echo "#define CLICK_FORCE_EXPENSIVE 1" >>confdefs.h
+
+fi
+
 
 
 # Check whether --enable-valgrind was given.
@@ -14120,6 +14230,13 @@ fi
 
 if test "x$HAVE_PCAP" = xyes; then
     provisions="$provisions pcap"
+    have_pcap=yes
+else
+    have_pcap=no
+fi
+
+if test "x$have_re2" == xyes; then
+    provisions="$provisions re2"
 fi
 
 if test "$enable_multithread" != no; then
@@ -15507,12 +15624,15 @@ fi
 
 echo "
 
-Configuration:
+Configuration Summary:
     C Compiler:                  ${CC}
     C++ Compiler:                ${CXX}
 
     DPDK support:                ${enable_dpdk}
     Netmap support:              ${HAVE_NETMAP}
+    PCAP support:                ${have_pcap}
+
+    RE2 support:                 ${have_re2}
 "
 
 echo "Now type make to build FastClick..."

--- a/configure.in
+++ b/configure.in
@@ -261,6 +261,10 @@ if test "x$enable_dpdk" = "xyes"; then
         RTE_LIBNAME=dpdk
     fi
 
+    if test -z "$RTE_SRCDIR"; then
+        RTE_SRCDIR=$RTE_SDK
+    fi
+
     if test "x$enable_user_multithread" != "xyes"; then
         AC_MSG_ERROR([
 =========================================
@@ -269,31 +273,44 @@ if test "x$enable_dpdk" = "xyes"; then
 
 =========================================])
     fi
-    if test ! -f "$RTE_SDK_BIN/include/rte_eal.h"; then
+
+
+    if pkg-config --exists libdpdk ; then
+        :
+    else
+      if test ! -f "$RTE_SDK_BIN/include/rte_eal.h"; then
         AC_MSG_ERROR([
 =========================================
 
 Cannot find \$RTE_SDK_BIN/include/rte_eal.h for DPDK.
-Define \$RTE_SDK and \$RTE_TARGET as per DPDK documentation.
+Define \$RTE_SDK and \$RTE_TARGET as per DPDK documentation,
+or install DPDK using meson, or he system package manager.
 
 =========================================])
+      fi
+      if test -e "$RTE_SRCDIR/VERSION"; then
+        rte_ver_year=`cat $RTE_SRCDIR/VERSION | sed -e 's/-rc/.-rc./' -e 's/$/..99/' | awk -F '.' '{print int($1)}'`
+        rte_ver_month=`cat $RTE_SRCDIR/VERSION | sed -e 's/-rc/.-rc./' -e 's/$/..99/' | awk -F '.' '{print int($2)}'`
+        rte_ver_minor=`cat $RTE_SRCDIR/VERSION | sed -e 's/-rc/.-rc./' -e 's/$/..99/' | awk -F '.' '{print int($3)}'`
+      else
+        rte_ver_major=`grep "#define RTE_VER_MAJOR" "$RTE_SDK_BIN/include/rte_version.h" | head -n 1 | awk '{print $3}'`
+        rte_ver_minor=`grep "#define RTE_VER_MINOR" "$RTE_SDK_BIN/include/rte_version.h" | head -n 1 | awk '{print $3}'`
+        rte_ver_year=`grep "#define RTE_VER_YEAR" "$RTE_SDK_BIN/include/rte_version.h" | head -n 1 | awk '{print $3}'`
+        rte_ver_month=`grep "#define RTE_VER_MONTH" "$RTE_SDK_BIN/include/rte_version.h" | head -n 1 | awk '{print $3}'`
+      fi
+      AC_SUBST(RTE_SDK)
+      AC_SUBST(RTE_TARGET)
+      AC_SUBST(RTE_SDK_BIN)
+      AC_SUBST(RTE_VER_MAJOR, $rte_ver_major)
+      AC_SUBST(RTE_VER_MINOR, $rte_ver_minor)
+      AC_SUBST(RTE_VER_YEAR, $rte_ver_year)
+      AC_SUBST(RTE_VER_MONTH, $rte_ver_month)
+      AC_SUBST(DPDK_INCLUDES, -I${RTE_SDK_BIN}/include/)
     fi
-    rte_ver_major=`grep "#define RTE_VER_MAJOR" "$RTE_SDK_BIN/include/rte_version.h" | head -n 1 | awk '{print $3}'`
-    rte_ver_minor=`grep "#define RTE_VER_MINOR" "$RTE_SDK_BIN/include/rte_version.h" | head -n 1 | awk '{print $3}'`
-    rte_ver_year=`grep "#define RTE_VER_YEAR" "$RTE_SDK_BIN/include/rte_version.h" | head -n 1 | awk '{print $3}'`
-    rte_ver_month=`grep "#define RTE_VER_MONTH" "$RTE_SDK_BIN/include/rte_version.h" | head -n 1 | awk '{print $3}'`
 
-    AC_SUBST(RTE_SDK)
-    AC_SUBST(RTE_TARGET)
-    AC_SUBST(RTE_SDK_BIN)
-    AC_SUBST(RTE_VER_MAJOR, $rte_ver_major)
-    AC_SUBST(RTE_VER_MINOR, $rte_ver_minor)
-    AC_SUBST(RTE_VER_YEAR, $rte_ver_year)
-    AC_SUBST(RTE_VER_MONTH, $rte_ver_month)
     AC_DEFINE([HAVE_DPDK])
-
     AC_SUBST(USE_DPDK, yes)
-    AC_SUBST(DPDK_INCLUDES, -I${RTE_SDK_BIN}/include/)
+
 fi
 
 if test "x$enable_dpdk_pool" = "xyes"; then
@@ -2315,6 +2332,9 @@ fi
 dnl add 'pcap' if libpcap is available
 if test "x$HAVE_PCAP" = xyes; then
     provisions="$provisions pcap"
+    have_pcap=yes
+else
+    have_pcap=no
 fi
 
 dnl add 're2' if re2 is available
@@ -2382,7 +2402,7 @@ Configuration Summary:
 
     DPDK support:                ${enable_dpdk}
     Netmap support:              ${HAVE_NETMAP}
-    PCAP support:                ${HAVE_PCAP}
+    PCAP support:                ${have_pcap}
 
     RE2 support:                 ${have_re2}
 "

--- a/include/click/dpdkdevice.hh
+++ b/include/click/dpdkdevice.hh
@@ -22,7 +22,7 @@
 #include <rte_pci.h>
 #include <rte_version.h>
 
-#if RTE_VERSION >= RTE_VERSION_NUM(17,11,0,0)
+#if RTE_VERSION >= RTE_VERSION_NUM(17,11,0,0) && RTE_VERSION < RTE_VERSION_NUM(19,2,0,0)
     #include <rte_bus_pci.h>
 #endif
 

--- a/userlevel/Makefile.in
+++ b/userlevel/Makefile.in
@@ -103,6 +103,11 @@ LINK = $(CCLD) $(CFLAGS) $(LDFLAGS) -o $@
 
 USE_DPDK = @USE_DPDK@
 ifeq ($(USE_DPDK),yes)
+ifeq ($(shell pkg-config --exists libdpdk && echo 1), 1)
+CFLAGS := $(CFLAGS) $(shell pkg-config --cflags libdpdk)
+CXXFLAGS := $(CFLAGS) $(shell pkg-config --cflags libdpdk)
+LDFLAGS := $(LDFLAGS) $(shell pkg-config --libs libdpdk) -Wl,-Bstatic $(shell pkg-config --static --libs libdpdk)
+else
 RTE_SDK = @RTE_SDK@
 RTE_TARGET = @RTE_TARGET@
 RTE_VER_MAJOR = @RTE_VER_MAJOR@
@@ -110,6 +115,7 @@ RTE_VER_MINOR = @RTE_VER_MINOR@
 RTE_VER_YEAR = @RTE_VER_YEAR@
 RTE_VER_MONTH = @RTE_VER_MONTH@
 include dpdk.mk
+endif
 EXTRA_DRIVER_OBJS := dpdkdevice.o $(EXTRA_DRIVER_OBJS)
 endif
 

--- a/userlevel/dpdk.mk
+++ b/userlevel/dpdk.mk
@@ -38,6 +38,10 @@ _LDLIBS-$(CONFIG_RTE_LIBRTE_KNI)            += -lrte_kni
 _LDLIBS-$(CONFIG_RTE_LIBRTE_IVSHMEM)        += -lrte_ivshmem
 endif
 
+ifeq ($(CONFIG_RTE_LIBRTE_PMD_OCTEONTX_CRYPTO),y)
+_LDLIBS-y += -lrte_common_cpt
+endif
+
 ifeq ($(CONFIG_RTE_LIBRTE_PMD_OCTEONTX_SSOVF)$(CONFIG_RTE_LIBRTE_OCTEONTX_MEMPOOL)$(shell [ -n "$(RTE_VER_YEAR)" ] && ( ( [ "$(RTE_VER_YEAR)" -ge 18 ] && [ "$(RTE_VER_MONTH)" -ge 08 ] ) || [ $(RTE_VER_YEAR) -ge 19 ] ) && echo true),yytrue)
 	_LDLIBS-y += -lrte_common_octeontx
 endif
@@ -54,6 +58,7 @@ _LDLIBS-$(CONFIG_RTE_LIBRTE_BPF)            += -lrte_bpf
 ifeq ($(CONFIG_RTE_LIBRTE_BPF_ELF),y)
 _LDLIBS-$(CONFIG_RTE_LIBRTE_BPF)            += -lelf
 endif
+_LDLIBS-$(CONFIG_RTE_LIBRTE_IPSEC)            += -lrte_ipsec
 _LDLIBS-$(CONFIG_RTE_LIBRTE_CFGFILE)        += -lrte_cfgfile
 _LDLIBS-$(CONFIG_RTE_LIBRTE_GRO)            += -lrte_gro
 _LDLIBS-$(CONFIG_RTE_LIBRTE_GSO)            += -lrte_gso
@@ -106,6 +111,7 @@ _LDLIBS-$(CONFIG_RTE_LIBRTE_IP_FRAG)        += -lrte_ip_frag
 
 ifeq ($(shell [ -n "$(RTE_VER_YEAR)" ] && ( ( [ "$(RTE_VER_YEAR)" -ge 16 ] && [ "$(RTE_VER_MONTH)" -ge 11 ] ) || [ $(RTE_VER_YEAR) -ge 17 ] ) && echo true),true)
 _LDLIBS-$(CONFIG_RTE_LIBRTE_ETHER)          += -lrte_ethdev
+_LDLIBS-$(CONFIG_RTE_LIBRTE_BBDEV)          += -lrte_bbdev
 _LDLIBS-$(CONFIG_RTE_LIBRTE_NET)            += -lrte_net
 else
 _LDLIBS-$(CONFIG_RTE_LIBRTE_ETHER)          += -lethdev
@@ -131,18 +137,22 @@ endif # CONFIG_RTE_LIBRTE_IFPGA_BUS
 endif # CONFIG_RTE_LIBRTE_RAWDEV
 _LDLIBS-$(CONFIG_RTE_LIBRTE_TIMER)          += -lrte_timer
 _LDLIBS-$(CONFIG_RTE_LIBRTE_MEMPOOL)        += -lrte_mempool
+_LDLIBS-$(CONFIG_RTE_LIBRTE_STACK)          += -lrte_stack
+_LDLIBS-$(CONFIG_RTE_DRIVER_MEMPOOL_RING)   += -lrte_mempool_ring
 _LDLIBS-$(CONFIG_RTE_LIBRTE_MEMPOOL_RING)   += -lrte_mempool_ring
 _LDLIBS-$(CONFIG_RTE_LIBRTE_RING)           += -lrte_ring
 _LDLIBS-$(CONFIG_RTE_LIBRTE_PCI)            += -lrte_pci
 _LDLIBS-$(CONFIG_RTE_LIBRTE_EAL)            += -lrte_eal
 _LDLIBS-$(CONFIG_RTE_LIBRTE_CMDLINE)        += -lrte_cmdline
-ifeq ($(CONFIG_RTE_LIBRTE_DPAA_BUS),y)
- _LDLIBS-$(CONFIG_RTE_LIBRTE_COMMON_DPAAX)   += -lrte_common_dpaax
-endif
 ifeq ($(CONFIG_RTE_LIBRTE_FSLMC_BUS),y)
 _LDLIBS-$(CONFIG_RTE_LIBRTE_COMMON_DPAAX)   += -lrte_common_dpaax
 endif
-
+ifeq ($(CONFIG_RTE_LIBRTE_DPAA_BUS),y)
+_LDLIBS-$(CONFIG_RTE_LIBRTE_COMMON_DPAAX)   += -lrte_common_dpaax
+endif
+ifeq ($(CONFIG_RTE_LIBRTE_MVPP2_PMD),y)
+_LDLIBS-y += -lrte_common_mvep -L$(LIBMUSDK_PATH)/lib -lmusdk
+endif
 _LDLIBS-$(CONFIG_RTE_LIBRTE_PCI_BUS)        += -lrte_bus_pci
 _LDLIBS-$(CONFIG_RTE_LIBRTE_VDEV_BUS)       += -lrte_bus_vdev
 
@@ -183,6 +193,7 @@ _LDLIBS-$(CONFIG_RTE_LIBRTE_DPAA2_PMD)      += -lrte_pmd_dpaa2
 _LDLIBS-$(CONFIG_RTE_LIBRTE_ENIC_PMD)       += -lrte_pmd_enic
 _LDLIBS-$(CONFIG_RTE_LIBRTE_PMD_FAILSAFE)   += -lrte_pmd_failsafe
 _LDLIBS-$(CONFIG_RTE_LIBRTE_I40E_PMD)       += -lrte_pmd_i40e
+_LDLIBS-$(CONFIG_RTE_LIBRTE_ICE_PMD)        += -lrte_pmd_ice
 _LDLIBS-$(CONFIG_RTE_LIBRTE_FM10K_PMD)      += -lrte_pmd_fm10k
 _LDLIBS-$(CONFIG_RTE_LIBRTE_IXGBE_PMD)      += -lrte_pmd_ixgbe
 ifeq ($(CONFIG_RTE_LIBRTE_KNI),y)
@@ -191,9 +202,19 @@ endif
 _LDLIBS-$(CONFIG_RTE_LIBRTE_LIO_PMD)        += -lrte_pmd_lio
 _LDLIBS-$(CONFIG_RTE_LIBRTE_E1000_PMD)      += -lrte_pmd_e1000
 _LDLIBS-$(CONFIG_RTE_LIBRTE_ENA_PMD)        += -lrte_pmd_ena
+_LDLIBS-$(CONFIG_RTE_LIBRTE_ENETC_PMD)      += -lrte_pmd_enetc
 _LDLIBS-$(CONFIG_RTE_LIBRTE_LIO_PMD)        += -lrte_pmd_lio
-_LDLIBS-$(CONFIG_RTE_LIBRTE_MLX4_PMD)       += -lrte_pmd_mlx4 -libverbs
-_LDLIBS-$(CONFIG_RTE_LIBRTE_MLX5_PMD)       += -lrte_pmd_mlx5 -libverbs
+_LDLIBS-$(CONFIG_RTE_LIBRTE_MLX4_PMD)       += -lrte_pmd_mlx4
+_LDLIBS-$(CONFIG_RTE_LIBRTE_MLX5_PMD)       += -lrte_pmd_mlx5
+ifeq ($(CONFIG_RTE_IBVERBS_LINK_STATIC),y)
+LIBS_IBVERBS_STATIC = $(shell $(RTE_SDK)/buildtools/options-ibverbs-static.sh)
+_LDLIBS-$(CONFIG_RTE_LIBRTE_MLX4_PMD)       += $(LIBS_IBVERBS_STATIC)
+_LDLIBS-$(CONFIG_RTE_LIBRTE_MLX5_PMD)       += $(LIBS_IBVERBS_STATIC)
+else
+_LDLIBS-$(CONFIG_RTE_LIBRTE_MLX4_PMD)       += -libverbs -lmlx4
+_LDLIBS-$(CONFIG_RTE_LIBRTE_MLX5_PMD)       += -libverbs -lmlx5
+endif
+
 # DPDK 17.11 or beyond requires additional libraries for Mellanox NICs
 ifeq ($(shell [ -n "$(RTE_VER_YEAR)" ] && ( ( [ "$(RTE_VER_YEAR)" -ge 17 ] && [ "$(RTE_VER_MONTH)" -ge 11 ] ) || [ $(RTE_VER_YEAR) -ge 18 ] ) && echo true),true)
 _LDLIBS-$(CONFIG_RTE_LIBRTE_MLX4_PMD)       += -lmlx4
@@ -221,7 +242,12 @@ _LDLIBS-$(CONFIG_RTE_LIBRTE_SFC_EFX_PMD)    += -lrte_pmd_sfc_efx
 _LDLIBS-$(CONFIG_RTE_LIBRTE_PMD_TAP)        += -lrte_pmd_tap
 _LDLIBS-$(CONFIG_RTE_LIBRTE_PMD_PCAP)       += -lrte_pmd_pcap
 _LDLIBS-$(CONFIG_RTE_LIBRTE_PMD_AF_PACKET)  += -lrte_pmd_af_packet
+_LDLIBS-$(CONFIG_RTE_LIBRTE_PMD_AF_XDP)     += -lrte_pmd_af_xdp -lbpf
 _LDLIBS-$(CONFIG_RTE_LIBRTE_ARK_PMD)        += -lrte_pmd_ark
+_LDLIBS-$(CONFIG_RTE_LIBRTE_ATLANTIC_PMD)   += -lrte_pmd_atlantic
+_LDLIBS-$(CONFIG_RTE_LIBRTE_AVF_PMD)        += -lrte_pmd_avf
+_LDLIBS-$(CONFIG_RTE_LIBRTE_AVF_PMD)        += -lrte_pmd_avf
+_LDLIBS-$(CONFIG_RTE_LIBRTE_IAVF_PMD)       += -lrte_pmd_iavf
 _LDLIBS-$(CONFIG_RTE_LIBRTE_AVP_PMD)        += -lrte_pmd_avp
 _LDLIBS-$(CONFIG_RTE_LIBRTE_PMD_NULL)       += -lrte_pmd_null
 _LDLIBS-$(CONFIG_RTE_LIBRTE_VMXNET3_PMD)    += -lrte_pmd_vmxnet3_uio
@@ -240,6 +266,7 @@ _LDLIBS-$(CONFIG_RTE_LIBRTE_PMD_NULL_CRYPTO) += -lrte_pmd_null_crypto
 ifeq ($(shell [ -n "$(RTE_VER_YEAR)" ] && ( ( [ "$(RTE_VER_YEAR)" -ge 18 ] && [ "$(RTE_VER_MONTH)" -ge 08 ] ) || [ $(RTE_VER_YEAR) -ge 19 ] ) && echo true),true)
 ifeq ($(CONFIG_RTE_LIBRTE_PMD_QAT),y)
 _LDLIBS-$(CONFIG_RTE_LIBRTE_PMD_QAT_SYM)     += -lrte_pmd_qat -lcrypto
+_LDLIBS-$(CONFIG_RTE_LIBRTE_PMD_QAT_ASYM)    += -lrte_pmd_qat -lcrypto
 endif # CONFIG_RTE_LIBRTE_PMD_QAT
 else
 _LDLIBS-$(CONFIG_RTE_LIBRTE_PMD_QAT)        += -lrte_pmd_qat -lcrypto


### PR DESCRIPTION
Also switch to meson when available. In the future DPDK plan to switch
to meson and we will use pkg-config to get dependencies.

This allows to remove the ugly code of dpdk.mk. It will be removed when
DPDK will fully move to meson.

Parallel development with Georgios Katsikas <katsikas.gp@gmail.com>
