### PR TITLE
Series of patches for 100G Trace capture

### DIFF
--- a/configure
+++ b/configure
@@ -6983,8 +6983,9 @@ if test "x$enable_dpdk" = "xyes"; then
 
 
     if pkg-config --exists libdpdk ; then
-        :
+      RTE_LIB=pkg-config --variable=libdir libdpdk
     else
+      RTE_LIB="$RTE_SDK_BIN/lib"
       if test ! -f "$RTE_SDK_BIN/include/rte_eal.h"; then
         as_fn_error $? "
 =========================================
@@ -7018,6 +7019,18 @@ or install DPDK using meson, or he system package manager.
 
       DPDK_INCLUDES=-I${RTE_SDK_BIN}/include/
 
+
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether DPDK has rte_eth_read_clock" >&5
+$as_echo_n "checking whether DPDK has rte_eth_read_clock... " >&6; }
+      if readelf -Ws "$RTE_LIB/librte_ethdev.a" | grep rte_eth_read_clock &> /dev/null ; then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+        $as_echo "#define HAVE_DPDK_READ_CLOCK 1" >>confdefs.h
+
+      else
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+      fi
     fi
 
     $as_echo "#define HAVE_DPDK 1" >>confdefs.h

--- a/configure.in
+++ b/configure.in
@@ -276,8 +276,9 @@ if test "x$enable_dpdk" = "xyes"; then
 
 
     if pkg-config --exists libdpdk ; then
-        :
+      RTE_LIB=pkg-config --variable=libdir libdpdk
     else
+      RTE_LIB="$RTE_SDK_BIN/lib"
       if test ! -f "$RTE_SDK_BIN/include/rte_eal.h"; then
         AC_MSG_ERROR([
 =========================================
@@ -306,6 +307,14 @@ or install DPDK using meson, or he system package manager.
       AC_SUBST(RTE_VER_YEAR, $rte_ver_year)
       AC_SUBST(RTE_VER_MONTH, $rte_ver_month)
       AC_SUBST(DPDK_INCLUDES, -I${RTE_SDK_BIN}/include/)
+
+      AC_MSG_CHECKING([whether DPDK has rte_eth_read_clock])
+      if readelf -Ws "$RTE_LIB/librte_ethdev.a" | grep rte_eth_read_clock &> /dev/null ; then
+        AC_MSG_RESULT([yes])
+        AC_DEFINE([HAVE_DPDK_READ_CLOCK])
+      else
+        AC_MSG_RESULT([no])
+      fi
     fi
 
     AC_DEFINE([HAVE_DPDK])

--- a/elements/analysis/recordtimestamp.hh
+++ b/elements/analysis/recordtimestamp.hh
@@ -15,9 +15,9 @@ class NumberPacket;
 
 RecordTimestamp([I<keywords> N])
 
-Record timestamp in memory
-
 =s timestamps
+
+Record timestamp in memory
 
 =d
 

--- a/elements/analysis/timestampaccum.hh
+++ b/elements/analysis/timestampaccum.hh
@@ -22,7 +22,13 @@ timestamp. Keeps track of the total elapsed time accumulated over all packets.
 Returns the number of packets that have passed.
 
 =h time read-only
-Returns the accumulated timestamp difference for all passing packets.
+Returns the accumulated timestamp difference for all passing packets in seconds.
+
+=h min read-only
+Returns the minimal timestamp difference across all passing packets in seconds.
+
+=h max read-only
+Returns the maximal timestamp difference across all passing packets in seconds.
 
 =h average_time read-only
 Returns the average timestamp difference over all passing packets.
@@ -49,6 +55,8 @@ class TimestampAccum : public SimpleElement<TimestampAccum> { public:
 
     double _usec_accum;
     uint64_t _count;
+    double _min;
+    double _max;
 
     static String read_handler(Element *, void *) CLICK_COLD;
     static int reset_handler(const String &, Element *, void *, ErrorHandler *);

--- a/elements/analysis/timestampaccum.hh
+++ b/elements/analysis/timestampaccum.hh
@@ -1,7 +1,7 @@
 // -*- c-basic-offset: 4 -*-
 #ifndef CLICK_TIMESTAMPACCUM_HH
 #define CLICK_TIMESTAMPACCUM_HH
-#include <click/element.hh>
+#include <click/batchelement.hh>
 CLICK_DECLS
 
 /*
@@ -32,7 +32,7 @@ Resets C<count> and C<time> counters to zero when written.
 
 =a SetCycleCount, RoundTripCycleCount, SetPerfCount, PerfCountAccum */
 
-class TimestampAccum : public Element { public:
+class TimestampAccum : public SimpleElement<TimestampAccum> { public:
 
     TimestampAccum() CLICK_COLD;
     ~TimestampAccum() CLICK_COLD;

--- a/elements/analysis/timestampdiff.hh
+++ b/elements/analysis/timestampdiff.hh
@@ -13,9 +13,9 @@ class RecordTimestamp;
 
 TimestampDiff()
 
-Compute the RTT of packets marked with RecordTimestamp
-
 =s timestamps
+
+Compute the RTT of packets marked with RecordTimestamp
 
 =d
 

--- a/elements/standard/pipeliner.cc
+++ b/elements/standard/pipeliner.cc
@@ -21,7 +21,7 @@ Pipeliner::Pipeliner()
         _home_thread_id(0), _block(false),
         _active(true),_nouseless(false),_always_up(false),
         _allow_direct_traversal(true), _verbose(true),
-        sleepiness(0),_sleep_threshold(0),
+        sleepiness(0),_sleep_threshold(0), _highwater(0),
         _task(this), _last_start(0)
 {
 #if HAVE_BATCH
@@ -244,6 +244,8 @@ Pipeliner::run_task(Task* t)
             r = true;
 #endif
         }
+        if (s.count() > _highwater)
+            _highwater = s.count();
 
 #if HAVE_BATCH
         if (out) {
@@ -293,6 +295,7 @@ Pipeliner::add_handlers()
     add_read_handler("count", count_handler, 0);
     add_data_handlers("active", Handler::OP_READ, &_active);
     add_write_handler("active", write_handler, 0);
+    add_data_handlers("highwater", Handler::OP_READ, &_highwater);
 }
 
 CLICK_ENDDECLS

--- a/elements/standard/pipeliner.cc
+++ b/elements/standard/pipeliner.cc
@@ -42,7 +42,10 @@ Pipeliner::get_spawning_threads(Bitvector& b, bool, int port) {
 }
 
 void Pipeliner::cleanup(CleanupStage) {
-    for (unsigned i = 0; i < storage.weight(); i++) {
+    if (storage.initialized()) {
+      for (unsigned i = 0; i < storage.weight(); i++) {
+        if (!storage.get_value(i).initialized())
+            continue;
         Packet* p;
         while ((p = storage.get_value(i).extract()) != 0) {
 #if HAVE_BATCH
@@ -52,6 +55,7 @@ void Pipeliner::cleanup(CleanupStage) {
 #endif
                 p->kill();
         }
+      }
     }
 }
 

--- a/elements/standard/pipeliner.hh
+++ b/elements/standard/pipeliner.hh
@@ -16,22 +16,23 @@ Pipeliner
 
 =s storage
 
+Full-push Queue
+
 =d
 
 Fast version of ThreadSafeQueue->Unqueue, allowing to offload processing
-of packets pushed to this element to another one, without the inherent
+of packets pushed to this element to another core, without the inherent
 scheduling cost of normal queues. Multiple thread can push packets to
 this queue, and the home thread of this element will push packet out.
 
+
+=a StaticThreadSched, Queue
 
 */
 
 
 
 class Pipeliner: public BatchElement {
-
-
-
 public:
 
     Pipeliner();

--- a/elements/standard/pipeliner.hh
+++ b/elements/standard/pipeliner.hh
@@ -108,6 +108,7 @@ public:
     per_thread_oread<struct stats> stats;
     volatile int sleepiness;
     int _sleep_threshold;
+    unsigned long _highwater; //Not volatile, if not exact we don't care much
 
   protected:
     Task _task;

--- a/elements/tunnel/erspandecap.cc
+++ b/elements/tunnel/erspandecap.cc
@@ -1,8 +1,8 @@
 /*
- * gtpdecap.{cc,hh}
+ * erspandecap.{cc,hh}
  * Tom Barbette
  *
- * Copyright (c) 2018 University of Liege
+ * Copyright (c) 2019 KTH Royal Institute of Techonology
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/elements/userlevel/dpdkinfo.cc
+++ b/elements/userlevel/dpdkinfo.cc
@@ -65,7 +65,7 @@ String DPDKInfo::read_handler(Element *e, void * thunk)
 #else
                 int avail = rte_mempool_avail_count(DPDKDevice::_pktmbuf_pools[i]);
 #endif
-                acc << "0 " << String(avail) << "\n";
+                acc << String(i) << " " << String(avail) << "\n";
             }
             break;
         case h_pools:

--- a/elements/userlevel/fromdpdkdevice.cc
+++ b/elements/userlevel/fromdpdkdevice.cc
@@ -123,6 +123,7 @@ int FromDPDKDevice::configure(Vector<String> &conf, ErrorHandler *errh)
     return 0;
 }
 
+#if HAVE_DPDK_READ_CLOCK
 uint64_t FromDPDKDevice::read_clock(void* thunk) {
     FromDPDKDevice* fd = (FromDPDKDevice*)thunk;
     uint64_t clock;
@@ -134,15 +135,17 @@ uint64_t FromDPDKDevice::read_clock(void* thunk) {
     return -1;
 }
 
-
 struct UserClockSource dpdk_clock {
     .get_current_tick = &FromDPDKDevice::read_clock,
     .get_tick_hz = 0,
 };
+#endif
 
 void* FromDPDKDevice::cast(const char* name) {
+#if HAVE_DPDK_READ_CLOCK
     if (String(name) == "UserClockSource")
         return &dpdk_clock;
+#endif
     return RXQueueDevice::cast(name);
 }
 
@@ -180,6 +183,7 @@ int FromDPDKDevice::initialize(ErrorHandler *errh)
     }
 
     if (_set_timestamp) {
+#if HAVE_DPDK_READ_CLOCK
         uint64_t t;
         int err;
 #pragma GCC diagnostic push
@@ -188,6 +192,7 @@ int FromDPDKDevice::initialize(ErrorHandler *errh)
             return errh->error("Device does not support queryig internal time ! Disable hardware timestamping. Error %d", err);
         }
 #pragma GCC diagnostic pop
+#endif
     }
 
     return ret;

--- a/elements/userlevel/fromdpdkdevice.cc
+++ b/elements/userlevel/fromdpdkdevice.cc
@@ -84,6 +84,8 @@ int FromDPDKDevice::configure(Vector<String> &conf, ErrorHandler *errh)
 
     if (_use_numa) {
         numa_node = DPDKDevice::get_port_numa_node(_dev->port_id);
+        if (_numa_node_override > -1)
+            numa_node = _numa_node_override;
     }
 
     int r;

--- a/elements/userlevel/fromdpdkdevice.hh
+++ b/elements/userlevel/fromdpdkdevice.hh
@@ -163,7 +163,9 @@ public:
     void add_handlers() CLICK_COLD;
     void cleanup(CleanupStage) CLICK_COLD;
     bool run_task(Task *);
+#if HAVE_DPDK_READ_CLOCK
     static uint64_t read_clock(void* thunk);
+#endif
 
 private:
 

--- a/elements/userlevel/fromdpdkdevice.hh
+++ b/elements/userlevel/fromdpdkdevice.hh
@@ -151,6 +151,8 @@ public:
     const char *class_name() const { return "FromDPDKDevice"; }
     const char *port_count() const { return PORTS_0_1; }
     const char *processing() const { return PUSH; }
+    void* cast(const char* name) override;
+
     int configure_phase() const {
         return CONFIGURE_PHASE_PRIVILEGED - 5;
     }
@@ -161,7 +163,8 @@ public:
     void add_handlers() CLICK_COLD;
     void cleanup(CleanupStage) CLICK_COLD;
     bool run_task(Task *);
-    
+    static uint64_t read_clock(void* thunk);
+
 private:
 
     static String read_handler(Element *, void *) CLICK_COLD;
@@ -184,6 +187,7 @@ private:
     };
 
     DPDKDevice* _dev;
+    bool _set_timestamp;
 };
 
 CLICK_ENDDECLS

--- a/elements/userlevel/linuxclock.cc
+++ b/elements/userlevel/linuxclock.cc
@@ -1,5 +1,5 @@
 /*
- * mbgclock.{cc,hh} -- Meinberg-based clock
+ * linuxclock.{cc,hh} -- User Clock wrapper for Linux
  * Tom Barbette
  *
  * Copyright (c) 2017 University of Liege

--- a/elements/userlevel/linuxclock.hh
+++ b/elements/userlevel/linuxclock.hh
@@ -10,7 +10,8 @@ CLICK_DECLS
  * Use Linux to get time
  * =d
  *
- * Click needs to be compiled with --enable-user-timestamp for this to be used.
+ * Click needs to be compiled with --enable-user-timestamp for this to be
+ * used. This Clock can be used as a BASE of TSCClock
  *
  */
 

--- a/elements/userlevel/queuedevice.cc
+++ b/elements/userlevel/queuedevice.cc
@@ -122,11 +122,13 @@ int RXQueueDevice::parse(Vector<String> &conf, ErrorHandler *errh) {
 	String scale;
 	bool has_scale = false;
 	_scale_parallel = false;
+    _numa_node_override = -1;
 
     if (Args(this, errh).bind(conf)
             .read("RSS_AGGREGATE", _set_rss_aggregate)
             .read("PAINT_QUEUE", _set_paint_anno)
             .read("NUMA", _use_numa)
+            .read("NUMA_NODE", _numa_node_override)
 			.read("SCALE", scale).read_status(has_scale)
             .read("THREADOFFSET", _threadoffset)
             .consume() < 0) {

--- a/elements/userlevel/queuedevice.hh
+++ b/elements/userlevel/queuedevice.hh
@@ -206,6 +206,7 @@ protected:
 	bool _set_paint_anno;
 	int _threadoffset;
 	bool _use_numa;
+    int _numa_node_override;
 	bool _scale_parallel;
 
     /**

--- a/elements/userlevel/tscclock.cc
+++ b/elements/userlevel/tscclock.cc
@@ -24,10 +24,25 @@
 #include <click/master.hh>
 CLICK_DECLS
 
+
+inline uint64_t get_current_tick_tsc(void*) {
+    return click_get_cycles();
+}
+
+inline uint64_t get_tick_hz_tsc(void*) {
+    return cycles_hz();
+}
+
+struct UserClockSource tsc_source {
+    .get_current_tick = &get_current_tick_tsc,
+    .get_tick_hz = &get_tick_hz_tsc
+};
+
 TSCClock::TSCClock() :
 _verbose(1), _install(true), _nowait(false), _allow_offset(false),_correction_timer(this), _sync_timers(0), _base(0)
 {
-
+    _source = tsc_source;
+    _source_thunk = this;
 }
 
 void *
@@ -42,17 +57,28 @@ TSCClock::configure(Vector<String> &conf, ErrorHandler *errh)
     _allow_offset = true;
 #endif
     Element* basee = 0;
+    Element* sourcee = 0;
     if (Args(conf, this, errh)
             .read("VERBOSE", _verbose)
             .read("INSTALL", _install)
             .read("NOWAIT", _nowait)
             .read("BASE",basee)
+            .read("SOURCE", sourcee)
             .complete() < 0)
         return -1;
 
     if (basee)
         if (!(_base = static_cast<UserClock*>(basee->cast("UserClock"))))
             return errh->error("%p{element} is not a UserClock",basee);
+
+    if (sourcee) {
+        struct UserClockSource* ssource;
+        if (!(ssource = static_cast<struct UserClockSource*>(sourcee->cast("UserClockSource"))))
+            return errh->error("%p{element} is not a UserClockSource",sourcee);
+        _source = *ssource;
+        _source_thunk = sourcee;
+    }
+
 
     if (_nowait && !_install)
         return errh->error("You want to install without waiting but do not want to install?!");
@@ -67,7 +93,7 @@ int64_t TSCClock::now(void* user, bool steady) {
 }
 
 /**
- * Return real current time
+ * Return real current time, without this element's approximation
  */
 inline int64_t TSCClock::get_real_timestamp(bool steady) {
     Timestamp t;
@@ -95,7 +121,20 @@ inline int64_t TSCClock::get_real_timestamp(bool steady) {
  */
 int
 TSCClock::initialize(ErrorHandler*) {
-    tsc_freq = cycles_hz();
+    if (_source.get_tick_hz == 0) {
+        uint64_t hz = 0;
+        for (int i = 0; i < 10; i++) {
+            uint64_t beg = _source.get_current_tick(_source_thunk);
+            usleep(100000);
+            uint64_t turn_hz = (_source.get_current_tick(_source_thunk) - beg) * 100;
+            if (hz == 0)
+                hz = turn_hz;
+            else
+                hz = (7 * min(hz,turn_hz) + 3 * max(hz, turn_hz)) / 10;
+        }
+        tsc_freq = hz / 10;
+    } else
+        tsc_freq = _source.get_tick_hz(this);
 
     int64_t mult;
     cycles_per_subsec_shift = 1;
@@ -119,7 +158,7 @@ TSCClock::initialize(ErrorHandler*) {
 
     //Initialize real clock
     last_timestamp[0] = get_real_timestamp();
-    last_cycles[0] = click_get_cycles();
+    last_cycles[0] = _source.get_current_tick(_source_thunk);
 
     max_precision = 100 * (double)Timestamp::subsec_per_sec/(double)tsc_freq;
     //Need to converge quickly enough, but have a period large enough so that the cycle is still correct
@@ -142,11 +181,11 @@ TSCClock::initialize(ErrorHandler*) {
 void TSCClock::initialize_clock() {
             //Initialize steady clock
             steady_timestamp[current_clock] = get_real_timestamp(true);
-            steady_cycle[current_clock] = click_get_cycles();
+            steady_cycle[current_clock] = _source.get_current_tick(_source_thunk);
             steady_cycles_per_subsec_mult = cycles_per_subsec_mult[current_clock];
 
             //Initialize wall clock
-            last_cycles[current_clock] = click_get_cycles();
+            last_cycles[current_clock] = _source.get_current_tick(_source_thunk);
             last_timestamp[current_clock] = get_real_timestamp(false);
 }
 
@@ -156,7 +195,7 @@ void TSCClock::initialize_clock() {
  * measured frequency to the base value until the final value is good enough.
  */
 bool TSCClock::stabilize_tick() {
-    int64_t cur_cycles = click_get_cycles();
+    int64_t cur_cycles = _source.get_current_tick(_source_thunk);
     int64_t real_current_timestamp = get_real_timestamp();
 
     //Number of ticks during last period
@@ -216,7 +255,7 @@ bool TSCClock::accumulate_tick(Timer* t) {
 
     unsigned next_clock = (current_clock == 0? 1 : 0);
 
-    steady_cycle[next_clock] = click_get_cycles();
+    steady_cycle[next_clock] = _source.get_current_tick(_source_thunk);
     steady_timestamp[next_clock] = steady_timestamp[current_clock] + tick_to_subsec_steady(steady_cycle[next_clock] - steady_cycle[current_clock]);
     //Check that the timer period was not too high, as this could cause TSC computation overflow in tick_to_subsec
     if ((steady_timestamp[next_clock] - steady_timestamp[current_clock]) > (update_period_subsec * 2)) {
@@ -236,7 +275,7 @@ bool TSCClock::accumulate_tick(Timer* t) {
     }
 
     //We want to always take current cycle as close as possible to real timestamp, so we read it again just before get real timestamp
-    int64_t cur_cycles = click_get_cycles();
+    int64_t cur_cycles = _source.get_current_tick(_source_thunk);
     int64_t real_current_timestamp = get_real_timestamp();
 
     int64_t delta_tick = cur_cycles - last_cycles[current_clock];
@@ -284,7 +323,7 @@ bool TSCClock::accumulate_tick(Timer* t) {
      * function, to prevent jump we recompute the current approximated
      * time again and use that as a basis for next new frequency
      * multiplication.*/
-    last_cycles[next_clock] = click_get_cycles();
+    last_cycles[next_clock] = _source.get_current_tick(_source_thunk);
     last_timestamp[next_clock] = last_timestamp[current_clock] + tick_to_subsec_wall(last_cycles[next_clock] - last_cycles[current_clock]);
 
     //Swap clock
@@ -402,6 +441,25 @@ void TSCClock::run_timer(Timer* timer) {
     timer->schedule_after_msec(update_period_msec);
 }
 
+void
+TSCClock::push(int, Packet* p) {
+    unsigned clock = current_clock;
+    int64_t translated = last_timestamp[clock] + tick_to_subsec_wall(p->timestamp_anno().longval() + tstate->local_tsc_offset - last_cycles[clock]);
+    p->timestamp_anno().assignlong(translated);
+    output_push(0, p);
+}
+
+#if HAVE_BATCH
+void TSCClock::push_batch(int port, PacketBatch* batch) {
+    FOR_EACH_PACKET(batch, p) {
+        unsigned clock = current_clock;
+        int64_t translated = last_timestamp[clock] + tick_to_subsec_wall(p->timestamp_anno().longval() + tstate->local_tsc_offset - last_cycles[clock]);
+        p->timestamp_anno().assignlong(translated);
+    }
+    output_push_batch(0, batch);
+}
+#endif
+
 void TSCClock::cleanup(CleanupStage) {
     if (_sync_timers) {
         for (int i = 0; i < master()->nthreads(); i++)
@@ -419,7 +477,7 @@ TSCClock::read_handler(Element *e, void *thunk) {
         case h_now_steady:
             return String(c->compute_now_steady());
         case h_cycles:
-            return String(click_get_cycles() + c->tstate->local_tsc_offset);
+            return String(c->_source.get_current_tick(c) + c->tstate->local_tsc_offset);
         case h_cycles_hz:
             return String(c->tsc_freq);
         case h_phase:

--- a/elements/userlevel/tscclock.hh
+++ b/elements/userlevel/tscclock.hh
@@ -1,11 +1,19 @@
 #ifndef CLICK_TSCCLOCK_HH
 #define CLICK_TSCCLOCK_HH
-#include <click/element.hh>
+#include <click/batchelement.hh>
 #include <click/timer.hh>
 #include <click/task.hh>
 #include <click/sync.hh>
 #include <click/timestamp.hh>
 CLICK_DECLS
+
+class TSCClock;
+
+struct UserClockSource {
+    uint64_t (*get_current_tick)(void*);
+    uint64_t (*get_tick_hz)(void*);
+};
+
 
 /* =c
  * TSCClock()
@@ -21,14 +29,36 @@ CLICK_DECLS
  *
  * Click needs to be compiled with --enable-user-timestamp for this to be used.
  *
+ * If packets go through this element, the element will consider the
+ * timestamp field is in ticks (eg TSC by default), and convert it to the
+ * real time.
+ *
+ * Arguments:
+ *
+ * =over 20
+ *
+ * =item BASE
+ * Element. Take the base time from a given source instead of get_timeofday. Eg NTP.
+ * MBGClock is the only acceptable implementation for now, taking the source
+ * from a MBG PCIe GPS clock. Optional.
+ *
+ * =item SOURCE
+ * Element. Instead of using the TSC as clock, use the given source element. Eg.
+ * FromDPDKDevice for device that support rte_eth_read_clock. Optional.
+ *
  */
 
-class TSCClock : public Element { public:
+class TSCClock : public BatchElement { public:
 
   TSCClock() CLICK_COLD;
 
   const char *class_name() const        { return "TSCClock"; }
-  const char *port_count() const        { return PORTS_0_0; }
+  const char *port_count() const        { return PORTS_1_1; }
+  const char *processing() const        { return PUSH; }
+
+  int configure_phase() const {
+        return CONFIGURE_PHASE_LAST;
+  }
 
   void *cast(const char *name);
 
@@ -43,10 +73,14 @@ class TSCClock : public Element { public:
   static String read_handler(Element *e, void *thunk);
   void add_handlers() CLICK_COLD;
 
+  void push(int, Packet* p);
+#if HAVE_BATCH
+  void push_batch(int, PacketBatch* batch);
+#endif
 
   static int64_t now(void* user, bool steady);
 
-private:
+protected:
   int _verbose;
   bool _install;
   bool _nowait;
@@ -107,11 +141,11 @@ private:
   inline double delta_to_freq(int64_t tick, int64_t time);
 
   inline int64_t compute_now_steady() {
-      return steady_timestamp[current_clock] + tick_to_subsec_steady(click_get_cycles() + tstate->local_tsc_offset - steady_cycle[current_clock]);
+      return steady_timestamp[current_clock] + tick_to_subsec_steady(_source.get_current_tick(_source_thunk) + tstate->local_tsc_offset - steady_cycle[current_clock]);
   }
 
   inline int64_t compute_now_wall(int clock) {
-      return last_timestamp[clock] + tick_to_subsec_wall(click_get_cycles() + tstate->local_tsc_offset- last_cycles[clock]);
+      return last_timestamp[clock] + tick_to_subsec_wall(_source.get_current_tick(_source_thunk) + tstate->local_tsc_offset - last_cycles[clock]);
   }
 
   inline int64_t compute_now_wall() {
@@ -123,6 +157,9 @@ private:
   bool accumulate_tick(Timer*);
 
   int64_t get_real_timestamp(bool steady=false);
+
+  struct UserClockSource _source;
+  void* _source_thunk;
 };
 
 inline int64_t TSCClock::tick_to_subsec(int64_t delta, int64_t mult) {

--- a/elements/userlevel/tscclock.hh
+++ b/elements/userlevel/tscclock.hh
@@ -5,6 +5,8 @@
 #include <click/task.hh>
 #include <click/sync.hh>
 #include <click/timestamp.hh>
+#include <click/handlercall.hh>
+
 CLICK_DECLS
 
 class TSCClock;
@@ -160,6 +162,8 @@ protected:
 
   struct UserClockSource _source;
   void* _source_thunk;
+
+  HandlerCall _ready_h;
 };
 
 inline int64_t TSCClock::tick_to_subsec(int64_t delta, int64_t mult) {

--- a/elements/userlevel/tscclock.hh
+++ b/elements/userlevel/tscclock.hh
@@ -87,6 +87,7 @@ protected:
   bool _install;
   bool _nowait;
   bool _allow_offset;
+  bool _convert_steady;
 
   typedef enum {STABILIZE,SYNCHRONIZE,RUNNING} phase_t;
   phase_t _phase = STABILIZE;

--- a/include/click/dpdkdevice.hh
+++ b/include/click/dpdkdevice.hh
@@ -74,7 +74,7 @@ public:
             rx_queues(0,false), tx_queues(0,false),
             promisc(false), vlan_filter(false), vlan_strip(false),
             n_rx_descs(0), n_tx_descs(0),
-            init_mac(), init_mtu(0), init_fc_mode(FC_UNSET) {
+            init_mac(), init_mtu(0), init_fc_mode(FC_UNSET), offload(0)  {
             rx_queues.reserve(128);
             tx_queues.reserve(128);
         }
@@ -108,6 +108,7 @@ public:
         EtherAddress init_mac;
         uint16_t init_mtu;
         FlowControlMode init_fc_mode;
+        uint64_t offload;
     };
 
     int add_rx_queue(
@@ -124,6 +125,7 @@ public:
     void set_init_mac(EtherAddress mac);
     void set_init_mtu(uint16_t mtu);
     void set_init_fc_mode(FlowControlMode fc);
+    void set_offload(uint64_t offload);
 
     unsigned int get_nb_txdesc();
 

--- a/include/click/multithread.hh
+++ b/include/click/multithread.hh
@@ -36,6 +36,10 @@ class per_thread_oread : public per_thread<T> { public:
         per_thread<T>::_size = id;
     }
 
+    inline bool initialized() {
+        return mapping.size() > 0;
+    }
+
     inline T& get_value(int i) const{
         return per_thread<T>::storage[mapping[i]].v;
     }

--- a/include/click/packet.hh
+++ b/include/click/packet.hh
@@ -807,11 +807,16 @@ class Packet { public:
 	unsigned char *nh;
 	unsigned char *h;
 	Packet::PacketType pkt_type;
+#if !CLICK_PACKET_USE_DPDK
 	Timestamp timestamp;
+#endif
 	Packet *next;
 	Packet *prev;
 	AllAnno()
-	    : timestamp(Timestamp::uninitialized_t()) {
+#if !CLICK_PACKET_USE_DPDK
+	    : timestamp(Timestamp::uninitialized_t())
+#endif
+	{
 	}
     };
 
@@ -1012,6 +1017,7 @@ Packet::clear_annotations(bool all)
     }
 #elif CLICK_PACKET_USE_DPDK
     memset(all_anno(), 0, all ? sizeof(AllAnno) : sizeof(Anno));
+    set_timestamp_anno(Timestamp());
 #else
     memset(&_aa, 0, all ? sizeof(AllAnno) : sizeof(Anno));
 #endif

--- a/include/click/timestamp.hh
+++ b/include/click/timestamp.hh
@@ -750,6 +750,7 @@ class Timestamp { public:
 };
 
 class UserClock {public:
+    enum {h_now, h_now_steady};
     virtual int64_t now(bool steady) = 0;
 };
 

--- a/lib/dpdkdevice.cc
+++ b/lib/dpdkdevice.cc
@@ -264,6 +264,14 @@ int DPDKDevice::initialize_device(ErrorHandler *errh)
     dev_conf.rx_adv_conf.rss_conf.rss_hf = ETH_RSS_IP | ETH_RSS_UDP | ETH_RSS_TCP;
     dev_conf.rx_adv_conf.rss_conf.rss_hf &= dev_info.flow_type_rss_offloads;
 
+    if (info.offload & DEV_RX_OFFLOAD_TIMESTAMP) {
+        if (!(dev_info.rx_offload_capa & DEV_RX_OFFLOAD_TIMESTAMP)) {
+            return errh->error("Hardware timestamp offloading is not supported by this device !");
+        } else {
+            dev_conf.rxmode.offloads |= DEV_RX_OFFLOAD_TIMESTAMP;
+        }
+    }
+
 #if RTE_VERSION < RTE_VERSION_NUM(18,05,0,0)
     // Obtain general device information
     if (dev_info.pci_dev) {
@@ -504,6 +512,11 @@ void DPDKDevice::set_init_mtu(uint16_t mtu) {
 void DPDKDevice::set_init_fc_mode(FlowControlMode fc) {
     assert(!_is_initialized);
     info.init_fc_mode = fc;
+}
+
+void DPDKDevice::set_offload(uint64_t offload) {
+    assert(!_is_initialized);
+    info.offload |= offload;
 }
 
 

--- a/lib/dpdkdevice.cc
+++ b/lib/dpdkdevice.cc
@@ -264,6 +264,7 @@ int DPDKDevice::initialize_device(ErrorHandler *errh)
     dev_conf.rx_adv_conf.rss_conf.rss_hf = ETH_RSS_IP | ETH_RSS_UDP | ETH_RSS_TCP;
     dev_conf.rx_adv_conf.rss_conf.rss_hf &= dev_info.flow_type_rss_offloads;
 
+#if RTE_VERSION >= RTE_VERSION_NUM(18,02,0,0)
     if (info.offload & DEV_RX_OFFLOAD_TIMESTAMP) {
         if (!(dev_info.rx_offload_capa & DEV_RX_OFFLOAD_TIMESTAMP)) {
             return errh->error("Hardware timestamp offloading is not supported by this device !");
@@ -271,6 +272,7 @@ int DPDKDevice::initialize_device(ErrorHandler *errh)
             dev_conf.rxmode.offloads |= DEV_RX_OFFLOAD_TIMESTAMP;
         }
     }
+#endif
 
 #if RTE_VERSION < RTE_VERSION_NUM(18,05,0,0)
     // Obtain general device information


### PR DESCRIPTION
This serie adds support for timestamp hardware offloading (when DPDK is patched, hopefully, they will accept my patch upstream). 


ConnectX5 NIC can write the device's internal Clock value (much like the TSC of x86 CPUs) to the packet timestamp field. From there TSCClock can be used to convert the clock ticks to real time.

Example : 
```
fd :: FromDPDKDevice($port, BURST 32, PROMISC true, VERBOSE 99, PAUSE none, 
     MAXTHREADS 4, MTU $mtu, SCALE parallel, NUMA true, NUMA_NODE 1, TIMESTAMP true, 
     NDESC 4096); 
        -> tc :: TSCClock(INSTALL false, SOURCE fd, READY_CALL sl.run)  
        -> ... // ToDump etc

sl :: Script(TYPE PASSIVE,                
        wait 1s,                            
        print "Now recording!"
        write sact.switch 0 //To avoid writing packets with random timestamp, we have a Switch element to drop packet until the TSCClock has converged
);   
```

Then a few fixes and features encountered when doing high speed trace capture.