### PR TITLE
DPDK device based clock

### DIFF
--- a/elements/userlevel/dpdkdevclock.cc
+++ b/elements/userlevel/dpdkdevclock.cc
@@ -1,0 +1,77 @@
+/*
+ * dpdkdevclock.{cc,hh} -- Clock using NIC hardware timestamp_
+ * Tom Barbette
+ *
+ * Copyright (c) 2019 KTH Royal Institute of Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
+#include <click/config.h>
+#include "dpdkdevclock.hh"
+#include <click/glue.hh>
+#include <click/args.hh>
+#include <click/error.hh>
+#include <click/dpdkdevice.hh>
+#include <rte_ethdev.h>
+CLICK_DECLS
+
+inline uint64_t get_current_tick_dpdk(TSCClock* thunk) {
+    uint64_t t;
+    if (rte_eth_read_clock(((DPDKDeviceClock*)thunk)->_dev->port_id, &t) != 0)
+        return 0;
+    return t;
+}
+
+inline uint64_t get_tick_hz_dpdk(TSCClock* thunk) {
+    uint64_t begin = get_current_tick_dpdk(thunk);
+    rte_delay_ms(100);
+    uint64_t end = get_current_tick_dpdk(thunk);
+    //Substract the time to get the time itself
+    uint64_t freq = (end - begin) - (get_current_tick_dpdk(thunk) - get_current_tick_dpdk(thunk));
+    return freq * 10;
+}
+
+DPDKDeviceClock::DPDKDeviceClock()
+{
+    _source.get_current_tick = &get_current_tick_dpdk;
+    _source.get_tick_hz = &get_tick_hz_dpdk;
+}
+
+DPDKDeviceClock::~DPDKDeviceClock()
+{
+
+}
+
+int
+DPDKDeviceClock::configure(Vector<String> &conf, ErrorHandler *errh)
+{
+    if (Args(conf, this, errh)
+            .read_mp("PORT", _dev)
+            .read("VERBOSE", _verbose)
+            .read("INSTALL", _install)
+            .complete() < 0)
+        return -1;
+    return 0;
+}
+
+int
+DPDKDeviceClock::initialize(ErrorHandler *errh)
+{
+    return TSCClock::initialize(errh);
+}
+
+
+
+CLICK_ENDDECLS
+ELEMENT_REQUIRES(usertiming)
+EXPORT_ELEMENT(DPDKDeviceClock)
+ELEMENT_MT_SAFE(DPDKDeviceClock)

--- a/elements/userlevel/dpdkdevclock.hh
+++ b/elements/userlevel/dpdkdevclock.hh
@@ -1,0 +1,33 @@
+#ifndef CLICK_DPDKDEVCLOCK_HH
+#define CLICK_DPDKDEVCLOCK_HH
+#include "tscclock.hh"
+#include <click/dpdkdevice.hh>
+
+CLICK_DECLS
+
+/* =c
+ * DPDKDeviceClock()
+ * =s
+ * Use DPDK device to get time
+ * =d
+ *
+ * Click needs to be compiled with --enable-user-timestamp for this to be used.
+ *
+ */
+
+class DPDKDeviceClock : public TSCClock { public:
+
+  DPDKDeviceClock() CLICK_COLD;
+  ~DPDKDeviceClock() CLICK_COLD;
+
+  const char *class_name() const        { return "DPDKDeviceClock"; }
+
+  int configure(Vector<String> &, ErrorHandler *) CLICK_COLD;
+  int initialize(ErrorHandler *) CLICK_COLD;
+
+  DPDKDevice* _dev;
+};
+
+
+CLICK_ENDDECLS
+#endif //CLICK_DPDKDEVCLOCK_HH


### PR DESCRIPTION
This Clock will convert the timestamp of packets passing by from the
hardware timestamp to the current wall clock time using the new
rte_eth_read_clock API.

It inherits TSCClock, so it could be used (with INSTALL to true) to have the whole Click use the hardware as the unique source of time. It's probably a bad idea though, as reading the time through PCIe is slower than rdtsc.

