### PR TITLE
LRO, Rx jumbo frames, and VLAN extend offloading

### DIFF
--- a/elements/userlevel/fromdpdkdevice.cc
+++ b/elements/userlevel/fromdpdkdevice.cc
@@ -120,7 +120,7 @@ int FromDPDKDevice::configure(Vector<String> &conf, ErrorHandler *errh)
         _dev->set_rx_offload(DEV_RX_OFFLOAD_TIMESTAMP);
         _set_timestamp = true;
 #else
-        errh->error("HW Timestamping is not supported before DPDK 18.02");
+        errh->error("Hardware timestamping is not supported before DPDK 18.02");
 #endif
     }
 
@@ -166,7 +166,7 @@ int FromDPDKDevice::initialize(ErrorHandler *errh)
     if (ret != 0) return ret;
 
     for (unsigned i = (unsigned)firstqueue; i <= (unsigned)lastqueue; i++) {
-        ret = _dev->add_rx_queue(i , _promisc, _vlan_filter, _vlan_strip, ndesc, errh);
+        ret = _dev->add_rx_queue(i , _promisc, _vlan_filter, _vlan_strip, _vlan_extend, _lro, _jumbo, ndesc, errh);
         if (ret != 0) return ret;
     }
 

--- a/elements/userlevel/queuedevice.cc
+++ b/elements/userlevel/queuedevice.cc
@@ -1,8 +1,10 @@
 // -*- c-basic-offset: 4; related-file-name: "queuedevice.hh" -*-
 /*
  * queuedevice.{cc,hh} -- Base element for multiqueue/multichannel device
+ * Tom Barbette, Georgios Katsikas
  *
- * Copyright (c) 2014 Tom Barbette, University of Liège
+ * Copyright (c) 2014-2018 University of Liège
+ * Copyright (c) 2018-2019 KTH Royal Institute of Technology
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -30,9 +32,10 @@ Vector<int> QueueDevice::inputs_count = Vector<int>();
 Vector<int> QueueDevice::shared_offset = Vector<int>();
 
 QueueDevice::QueueDevice() : _minqueues(0),_maxqueues(128), usable_threads(),
-	queue_per_threads(1), queue_share(1), ndesc(0), allow_nonexistent(false), _maxthreads(-1),_minthreads(0),firstqueue(-1),lastqueue(-1),n_queues(-1),thread_share(1),
-	_this_node(0), _active(true) {
-	_verbose = 1;
+    queue_per_threads(1), queue_share(1), ndesc(0), allow_nonexistent(false),
+    _maxthreads(-1), _minthreads(0), firstqueue(-1), lastqueue(-1), n_queues(-1),
+    thread_share(1), _this_node(0), _active(true) {
+    _verbose = 1;
 }
 void QueueDevice::static_initialize() {
 #if HAVE_NUMA
@@ -53,13 +56,13 @@ int QueueDevice::parse(Vector<String> &conf, ErrorHandler *errh) {
     if (Args(this, errh).bind(conf)
             .read_p("QUEUE", firstqueue)
             .read("N_QUEUES",n_queues)
-            .read("MINTHREADS", _minthreads)
-            .read("MAXTHREADS", _maxthreads)
-            .read("BURST", _burst)
-            .read("VERBOSE", _verbose)
-            .read("ACTIVE", _active)
-            .read("ALLOW_NONEXISTENT", allow_nonexistent)
-            .consume() < 0)
+           .read("MINTHREADS", _minthreads)
+           .read("MAXTHREADS", _maxthreads)
+           .read("BURST", _burst)
+           .read("VERBOSE", _verbose)
+           .read("ACTIVE", _active)
+           .read("ALLOW_NONEXISTENT", allow_nonexistent)
+           .consume() < 0)
         return -1;
 
     n_elements ++;
@@ -101,99 +104,106 @@ void QueueDevice::cleanup_tasks() {
 int RXQueueDevice::parse(Vector<String> &conf, ErrorHandler *errh) {
     QueueDevice::parse(conf, errh);
 
-	_promisc = true;
-	_vlan_filter = true;
-	_vlan_strip = true;
+    _promisc = true;
+    _vlan_filter = false;
+    _vlan_strip = false;
+    _vlan_extend = false;
+    _lro = false;
+    _jumbo = false;
+
     if (Args(this, errh).bind(conf)
-	.read_p("PROMISC", _promisc)
-	.read_p("VLAN_FILTER", _vlan_filter)
-	.read_p("VLAN_STRIP", _vlan_strip)
-        .consume() < 0)
+           .read_p("PROMISC", _promisc)
+           .read_p("VLAN_FILTER", _vlan_filter)
+           .read_p("VLAN_STRIP", _vlan_strip)
+           .read_p("VLAN_EXTEND", _vlan_extend)
+           .read_p("LRO", _lro)
+           .read_p("JUMBO", _jumbo)
+           .consume() < 0)
         return -1;
 
 #if HAVE_NUMA
-	_use_numa = true;
+    _use_numa = true;
 #else
-	_use_numa = false;
+    _use_numa = false;
 #endif
-	_threadoffset = -1;
-	_set_rss_aggregate = false;
-	_set_paint_anno = false;
-	String scale;
-	bool has_scale = false;
-	_scale_parallel = false;
-    _numa_node_override = -1;
+    _threadoffset = -1;
+    _set_rss_aggregate = false;
+    _set_paint_anno = false;
+    String scale;
+    bool has_scale = false;
+    _scale_parallel = false;
+        _numa_node_override = -1;
 
     if (Args(this, errh).bind(conf)
-            .read("RSS_AGGREGATE", _set_rss_aggregate)
-            .read("PAINT_QUEUE", _set_paint_anno)
-            .read("NUMA", _use_numa)
-            .read("NUMA_NODE", _numa_node_override)
-			.read("SCALE", scale).read_status(has_scale)
-            .read("THREADOFFSET", _threadoffset)
+        .read("RSS_AGGREGATE", _set_rss_aggregate)
+        .read("PAINT_QUEUE", _set_paint_anno)
+        .read("NUMA", _use_numa)
+        .read("NUMA_NODE", _numa_node_override)
+        .read("SCALE", scale).read_status(has_scale)
+        .read("THREADOFFSET", _threadoffset)
             .consume() < 0) {
         return -1;
     }
 
-	if (has_scale) {
-		if (scale.lower() == "parallel") {
-			_scale_parallel = true;
-		} else if (scale.lower() == "share") {
-			_scale_parallel = false;
-		} else {
-			return errh->error("Unknown scaling mode %s !",scale.c_str());
-		}
-	}
+    if (has_scale) {
+        if (scale.lower() == "parallel") {
+            _scale_parallel = true;
+        } else if (scale.lower() == "share") {
+            _scale_parallel = false;
+        } else {
+            return errh->error("Unknown scaling mode %s !",scale.c_str());
+        }
+    }
 
 #if !HAVE_NUMA
-	if (_use_numa) {
-		click_chatter("Cannot use numa if --enable-numa wasn't set during compilation time !");
-	}
-	_use_numa = false;
+    if (_use_numa) {
+        click_chatter("Cannot use numa if --enable-numa wasn't set during compilation time !");
+    }
+    _use_numa = false;
 #endif
-	return 0;
+    return 0;
 }
 
 int TXQueueDevice::parse(Vector<String> &conf, ErrorHandler* errh) {
-        QueueDevice::parse(conf, errh);
-        Args args(this, errh);
-        if (args.bind(conf).read("IQUEUE", _internal_tx_queue_size)
-            .read("BLOCKING", _blocking)
-            .consume() < 0)
-            return -1;
-        if ((_internal_tx_queue_size & (_internal_tx_queue_size - 1)) != 0) {
-            errh->error("IQUEUE must be a power of 2");
-        }
-        return 0;
+    QueueDevice::parse(conf, errh);
+    Args args(this, errh);
+    if (args.bind(conf).read("IQUEUE", _internal_tx_queue_size)
+        .read("BLOCKING", _blocking)
+        .consume() < 0)
+        return -1;
+    if ((_internal_tx_queue_size & (_internal_tx_queue_size - 1)) != 0) {
+        errh->error("IQUEUE must be a power of 2");
+    }
+    return 0;
 }
 
 int RXQueueDevice::configure_rx(int numa_node, int minqueues, int maxqueues, ErrorHandler *) {
-	_minqueues = minqueues;
-	_maxqueues = maxqueues;
+    _minqueues = minqueues;
+    _maxqueues = maxqueues;
 #if !HAVE_NUMA
-	(void)numa_node;
-	_this_node = 0;
-	usable_threads.assign(master()->nthreads(),false);
+    (void)numa_node;
+    _this_node = 0;
+    usable_threads.assign(master()->nthreads(),false);
 #else
-	usable_threads.assign(min(Numa::get_max_cpus(), master()->nthreads()),false);
-	if (numa_node < 0) numa_node = 0;
-	_this_node = numa_node;
+    usable_threads.assign(min(Numa::get_max_cpus(), master()->nthreads()),false);
+    if (numa_node < 0) numa_node = 0;
+    _this_node = numa_node;
 #endif
 
-	if (_maxthreads == -1 || _threadoffset == -1) {
-		inputs_count[_this_node] ++;
-		if (inputs_count[_this_node] == 1) {
-			use_nodes++;
+    if (_maxthreads == -1 || _threadoffset == -1) {
+        inputs_count[_this_node] ++;
+        if (inputs_count[_this_node] == 1) {
+            use_nodes++;
         }
-	}
+    }
 
-	return 0;
+    return 0;
 }
 
 int TXQueueDevice::configure_tx(int minqueues, int maxqueues,ErrorHandler *) {
-	_minqueues = minqueues;
-	_maxqueues = maxqueues;
-	return 0;
+    _minqueues = minqueues;
+    _maxqueues = maxqueues;
+    return 0;
 }
 
 int TXQueueDevice::initialize_tx(ErrorHandler * errh) {
@@ -236,17 +246,17 @@ int TXQueueDevice::initialize_tx(ErrorHandler * errh) {
     }
     n_initialized++;
     if (_verbose > 1) {
-		if (input_is_push(0))
-			click_chatter("%s : %d threads can end up in this output devices. %d queues will be used, so %d queues for %d thread",name().c_str(),n_threads,n_queues,queue_per_threads,thread_share);
-		else
-			click_chatter("%s : %d threads will be used to pull packets upstream. %d queues will be used, so %d queues for %d thread",name().c_str(),n_threads,n_queues,queue_per_threads,thread_share);
+        if (input_is_push(0))
+            click_chatter("%s : %d threads can end up in this output devices. %d queues will be used, so %d queues for %d thread",name().c_str(),n_threads,n_queues,queue_per_threads,thread_share);
+        else
+            click_chatter("%s : %d threads will be used to pull packets upstream. %d queues will be used, so %d queues for %d thread",name().c_str(),n_threads,n_queues,queue_per_threads,thread_share);
     }
     return 0;
 }
 
 int RXQueueDevice::initialize_rx(ErrorHandler *errh) {
-	int n_threads;
-	int cores_in_node;
+    int n_threads;
+    int cores_in_node;
     int count = 0;
     int offset = 0;
 
@@ -263,27 +273,27 @@ int RXQueueDevice::initialize_rx(ErrorHandler *errh) {
         queue_per_threads = n_queues / n_threads;
         lastqueue = firstqueue + n_queues - 1;
 
-	    click_chatter(
-				"%s : remove StaticThreadSched to use FastClick's "
-				"auto-thread assignment", class_name());
-		goto end;
-	};
+        click_chatter(
+                "%s : remove StaticThreadSched to use FastClick's "
+                "auto-thread assignment", class_name());
+        goto end;
+    };
 
     {
 #if HAVE_NUMA
-	NumaCpuBitmask b = NumaCpuBitmask::allocate();
+        NumaCpuBitmask b = NumaCpuBitmask::allocate();
 
-    if (numa_available()==0 && _use_numa) {
-        if (_this_node >= 0) {
-            b = Numa::node_to_cpus(_this_node);
+        if (numa_available()==0 && _use_numa) {
+            if (_this_node >= 0) {
+                b = Numa::node_to_cpus(_this_node);
+            } else
+                b = Numa::all_cpu();
+            b.toBitvector( usable_threads);
         } else
-            b = Numa::all_cpu();
-        b.toBitvector( usable_threads);
-    } else
 #endif
-    {
-        usable_threads.negate();
-    }
+        {
+            usable_threads.negate();
+        }
     }
 
     for (int i = click_max_cpu_ids(); i < usable_threads.size(); i++)
@@ -316,162 +326,162 @@ int RXQueueDevice::initialize_rx(ErrorHandler *errh) {
         }
     }
 
-       cores_in_node = usable_threads.weight();
+    cores_in_node = usable_threads.weight();
 
-       //click_chatter("_maxthreads %d, cores_in_node %d, nthreads() %d, use_nodes %d, _this_node %d, inputs_count %d",_maxthreads,cores_in_node,master()->nthreads(),use_nodes,_this_node,inputs_count[_this_node]);
-       if (_maxthreads == -1) {
-           assert(use_nodes > 0);
-           if (_scale_parallel)
-               n_threads = cores_in_node;
-           else {
-               assert(inputs_count[_this_node] > 0);
-               n_threads = min(cores_in_node,master()->nthreads() / use_nodes) / inputs_count[_this_node];
-           }
-       } else {
-           n_threads = min(cores_in_node,_maxthreads);
+    //click_chatter("_maxthreads %d, cores_in_node %d, nthreads() %d, use_nodes %d, _this_node %d, inputs_count %d",_maxthreads,cores_in_node,master()->nthreads(),use_nodes,_this_node,inputs_count[_this_node]);
+    if (_maxthreads == -1) {
+       assert(use_nodes > 0);
+       if (_scale_parallel)
+           n_threads = cores_in_node;
+       else {
+           assert(inputs_count[_this_node] > 0);
+           n_threads = min(cores_in_node,master()->nthreads() / use_nodes) / inputs_count[_this_node];
        }
+    } else {
+       n_threads = min(cores_in_node,_maxthreads);
+    }
 
-       if (n_threads == 0) {
-           n_threads = 1;
-           if (cores_in_node == 0) {
-               click_chatter("%s : No cores available on the same NUMA node, I'll use a core from another NUMA node, this will reduce performances.",name().c_str());
-               usable_threads[0] = 1;
-               cores_in_node = 1;
-               if (use_nodes > 1)
-                   use_nodes = 1;
-           }
-           if (!_scale_parallel) {
-               if (use_nodes == 0)
-                   use_nodes = 1;
-		       thread_share = inputs_count[_this_node] / min(cores_in_node,master()->nthreads() / use_nodes);
-           } else
-		       thread_share = min(cores_in_node,master()->nthreads());
-           if (thread_share == 0)
-               thread_share = 1;
+    if (n_threads == 0) {
+       n_threads = 1;
+       if (cores_in_node == 0) {
+           click_chatter("%s : No cores available on the same NUMA node, I'll use a core from another NUMA node, this will reduce performances.",name().c_str());
+           usable_threads[0] = 1;
+           cores_in_node = 1;
+           if (use_nodes > 1)
+               use_nodes = 1;
        }
-
-       if (n_threads > _maxqueues) {
-           assert(_maxqueues > 0);
-           queue_share = n_threads / _maxqueues;
-       }
-
-       if (_threadoffset == -1) {
-           if (!_scale_parallel) {
-               _threadoffset = shared_offset[_this_node];
-               shared_offset[_this_node] += n_threads;
-           } else {
-                _threadoffset = 0;
-           }
-       }
-
-       if (thread_share > 1) {
-           if (_threadoffset != -1) {
-               errh->warning("Thread offset %d will be ignored because the numa node has not enough cores.",_threadoffset);
-           }
-           if (!_scale_parallel) {
-               assert(thread_share > 0);
-		       _threadoffset = _threadoffset % (inputs_count[_this_node] / thread_share);
-           }
+       if (!_scale_parallel) {
+           if (use_nodes == 0)
+               use_nodes = 1;
+           thread_share = inputs_count[_this_node] / min(cores_in_node,master()->nthreads() / use_nodes);
        } else
-           if (n_threads + _threadoffset > master()->nthreads())
-               _threadoffset = master()->nthreads() - n_threads;
+           thread_share = min(cores_in_node,master()->nthreads());
+       if (thread_share == 0)
+           thread_share = 1;
+    }
 
-       if (n_threads >= _maxqueues)
-           n_queues = _maxqueues;
-       else
-           n_queues = max(_minqueues,n_threads);
+    if (n_threads > _maxqueues) {
+       assert(_maxqueues > 0);
+       queue_share = n_threads / _maxqueues;
+    }
 
-       assert(n_threads > 0);
-       queue_per_threads = n_queues / n_threads;
-
-       if (queue_per_threads * n_threads < n_queues) queue_per_threads ++;
-       lastqueue = firstqueue + n_queues - 1;
-
-       for (int b = 0; b < usable_threads.size(); b++) {
-           if (count >= n_threads) {
-               usable_threads[b] = false;
-           } else {
-               if (usable_threads[b]) {
-                   if (offset < _threadoffset) {
-                       usable_threads[b] = false;
-                       offset++;
-                   } else {
-                       count++;
-                   }
-               }
-           }
+    if (_threadoffset == -1) {
+       if (!_scale_parallel) {
+           _threadoffset = shared_offset[_this_node];
+           shared_offset[_this_node] += n_threads;
+       } else {
+            _threadoffset = 0;
        }
+    }
 
-       if (count < n_threads) {
-           return errh->error("Node has not enough threads for device !");
+    if (thread_share > 1) {
+       if (_threadoffset != -1) {
+           errh->warning("Thread offset %d will be ignored because the numa node has not enough cores.",_threadoffset);
        }
+       if (!_scale_parallel) {
+           assert(thread_share > 0);
+           _threadoffset = _threadoffset % (inputs_count[_this_node] / thread_share);
+       }
+    } else
+       if (n_threads + _threadoffset > master()->nthreads())
+           _threadoffset = master()->nthreads() - n_threads;
 
-       if (_verbose > 1) {
-           if (n_threads >= n_queues)
-               click_chatter("%s : %d threads will be used to push packets downstream. %d queues will be used meaning that each queue will be shared by %d threads.",name().c_str(),n_threads,n_queues,queue_share);
-           else
-               click_chatter("%s : %d threads will be used to push packets downstream. %d queues will be used meaning that each thread will handle up to %d queues",name().c_str(),n_threads,n_queues,queue_per_threads);
-       }
+    if (n_threads >= _maxqueues)
+       n_queues = _maxqueues;
+    else
+       n_queues = max(_minqueues,n_threads);
+
+    assert(n_threads > 0);
+    queue_per_threads = n_queues / n_threads;
+
+    if (queue_per_threads * n_threads < n_queues) queue_per_threads ++;
+    lastqueue = firstqueue + n_queues - 1;
+
+    for (int b = 0; b < usable_threads.size(); b++) {
+        if (count >= n_threads) {
+            usable_threads[b] = false;
+        } else {
+            if (usable_threads[b]) {
+                if (offset < _threadoffset) {
+                    usable_threads[b] = false;
+                    offset++;
+                } else {
+                     count++;
+                }
+            }
+        }
+    }
+
+    if (count < n_threads) {
+        return errh->error("Node has not enough threads for device !");
+    }
+
+    if (_verbose > 1) {
+        if (n_threads >= n_queues)
+           click_chatter("%s : %d threads will be used to push packets downstream. %d queues will be used meaning that each queue will be shared by %d threads.",name().c_str(),n_threads,n_queues,queue_share);
+        else
+           click_chatter("%s : %d threads will be used to push packets downstream. %d queues will be used meaning that each thread will handle up to %d queues",name().c_str(),n_threads,n_queues,queue_per_threads);
+        }
 
     end:
-       n_initialized++;
-       return 0;
+        n_initialized++;
+        return 0;
 }
 
 int QueueDevice::initialize_tasks(bool schedule, ErrorHandler *errh) {
-	_tasks.resize(usable_threads.weight());
-	_locks.resize(usable_threads.weight());
-	_thread_to_firstqueue.resize(master()->nthreads());
-	_queue_to_thread.resize(firstqueue + n_queues);
+    _tasks.resize(usable_threads.weight());
+    _locks.resize(usable_threads.weight());
+    _thread_to_firstqueue.resize(master()->nthreads());
+    _queue_to_thread.resize(firstqueue + n_queues);
 
-	int th_num = 0;
-	int qu_num = firstqueue;
-	if (_verbose > 2)
-		click_chatter("%s : using queues from %d to %d",name().c_str(),firstqueue,firstqueue+n_queues-1);
+    int th_num = 0;
+    int qu_num = firstqueue;
+    if (_verbose > 2)
+        click_chatter("%s : using queues from %d to %d",name().c_str(),firstqueue,firstqueue+n_queues-1);
 
-	//If there is multiple threads per queue, share_idx will be in [0,thread_share[, thread_share being the amount of queues that needs to be shared between threads
-	int th_share_idx = 0;
-	int qu_share_idx = 0;
-	for (int th_id = 0; th_id < master()->nthreads(); th_id++) {
-		if (!usable_threads[th_id])
-			continue;
+    //If there is multiple threads per queue, share_idx will be in [0,thread_share[, thread_share being the amount of queues that needs to be shared between threads
+    int th_share_idx = 0;
+    int qu_share_idx = 0;
+    for (int th_id = 0; th_id < master()->nthreads(); th_id++) {
+        if (!usable_threads[th_id])
+            continue;
 
-		if (th_share_idx % thread_share != 0) {
-			--th_num;
-			if (_locks[th_num] == NO_LOCK) {
-				_locks[th_num] = 0;
-			}
-		} else {
-			_tasks[th_num] = (new Task(this));
-			ScheduleInfo::initialize_task(this, _tasks[th_num], schedule, errh);
-			_tasks[th_num]->move_thread(th_id);
-			_locks[th_num] = NO_LOCK;
-		}
-		th_share_idx++;
+        if (th_share_idx % thread_share != 0) {
+            --th_num;
+            if (_locks[th_num] == NO_LOCK) {
+                _locks[th_num] = 0;
+            }
+        } else {
+            _tasks[th_num] = (new Task(this));
+            ScheduleInfo::initialize_task(this, _tasks[th_num], schedule, errh);
+            _tasks[th_num]->move_thread(th_id);
+            _locks[th_num] = NO_LOCK;
+        }
+        th_share_idx++;
 
-		_thread_to_firstqueue[th_id] = qu_num;
+        _thread_to_firstqueue[th_id] = qu_num;
 
-		for (int j = 0; j < queue_per_threads; j++) {
-			if (_verbose > 2)
-				click_chatter("%s : Queue %d handled by th %d",name().c_str(),qu_num,th_id);
-			_queue_to_thread[qu_num] = th_id;
-			//If queue are shared, this mapping is loosy : _queue_to_thread will map to the last thread. That's fine, we only want to retrieve one to find one thread to finish some job
-			qu_share_idx++;
-			if (qu_share_idx % queue_share == 0)
-				qu_num++;
-			if (qu_num == firstqueue + n_queues) break;
-		}
+        for (int j = 0; j < queue_per_threads; j++) {
+            if (_verbose > 2)
+                click_chatter("%s : Queue %d handled by th %d",name().c_str(),qu_num,th_id);
+            _queue_to_thread[qu_num] = th_id;
+            //If queue are shared, this mapping is loosy : _queue_to_thread will map to the last thread. That's fine, we only want to retrieve one to find one thread to finish some job
+            qu_share_idx++;
+            if (qu_share_idx % queue_share == 0)
+                qu_num++;
+            if (qu_num == firstqueue + n_queues) break;
+        }
 
-		if (queue_share > 1) {
-			_locks[th_num] = 0;
-		}
+        if (queue_share > 1) {
+            _locks[th_num] = 0;
+        }
 
 
-		if (qu_num == firstqueue + n_queues) break;
-		++th_num;
-	}
+        if (qu_num == firstqueue + n_queues) break;
+        ++th_num;
+    }
 
-	return 0;
+    return 0;
 
 }
 

--- a/elements/userlevel/queuedevice.hh
+++ b/elements/userlevel/queuedevice.hh
@@ -199,20 +199,23 @@ protected:
 
 class RXQueueDevice : public QueueDevice {
 protected:
-	bool _promisc;
-	bool _vlan_filter;
-	bool _vlan_strip;
-	bool _set_rss_aggregate;
-	bool _set_paint_anno;
-	int _threadoffset;
-	bool _use_numa;
+    bool _promisc;
+    bool _vlan_filter;
+    bool _vlan_strip;
+    bool _vlan_extend;
+    bool _lro;
+    bool _jumbo;
+    bool _set_rss_aggregate;
+    bool _set_paint_anno;
+    int _threadoffset;
+    bool _use_numa;
     int _numa_node_override;
-	bool _scale_parallel;
+    bool _scale_parallel;
 
     /**
      * Common parsing for all RXQueueDevice
      */
-	int parse(Vector<String> &conf, ErrorHandler *errh);
+    int parse(Vector<String> &conf, ErrorHandler *errh);
 
     /*
      * Configure a RX side of a queuedevice. Take cares of setting user max
@@ -227,8 +230,8 @@ protected:
 
 class TXQueueDevice : public QueueDevice {
 protected:
-	bool _blocking;
-	int _internal_tx_queue_size;
+    bool _blocking;
+    int _internal_tx_queue_size;
 
     /**
      * Common parsing for all RXQueueDevice

--- a/include/click/dpdkdevice.hh
+++ b/include/click/dpdkdevice.hh
@@ -76,9 +76,10 @@ public:
     struct DevInfo {
         inline DevInfo() :
             vendor_id(PCI_ANY_ID), vendor_name(), device_id(PCI_ANY_ID), driver(0),
-            rx_queues(0,false), tx_queues(0,false),
+            rx_queues(0, false), tx_queues(0, false),
             promisc(false),
-            vlan_filter(false), vlan_strip(false),
+            vlan_filter(false), vlan_strip(false), vlan_extend(false),
+            lro(false), jumbo(false),
             n_rx_descs(0), n_tx_descs(0),
             init_mac(), init_mtu(0), init_fc_mode(FC_UNSET), rx_offload(0), tx_offload(0) {
             rx_queues.reserve(128);
@@ -86,18 +87,21 @@ public:
         }
 
         void print_device_info() {
-            click_chatter("   Vendor   ID: %d", vendor_id);
-            click_chatter("   Vendor Name: %s", vendor_name.c_str());
-            click_chatter("   Device   ID: %d", device_id);
-            click_chatter("   Driver Name: %s", driver);
-            click_chatter("Promisc   Mode: %s", promisc? "true":"false");
-            click_chatter("Vlan Filtering: %s", vlan_filter? "true":"false");
-            click_chatter("Vlan Stripping: %s", vlan_strip? "true":"false");
-            click_chatter("   MAC Address: %s", init_mac.unparse().c_str());
-            click_chatter("# of Rx Queues: %d", rx_queues.size());
-            click_chatter("# of Tx Queues: %d", tx_queues.size());
-            click_chatter("# of Rx  Descs: %d", n_rx_descs);
-            click_chatter("# of Tx  Descs: %d", n_tx_descs);
+            click_chatter("                Vendor   ID: %d", vendor_id);
+            click_chatter("                Vendor Name: %s", vendor_name.c_str());
+            click_chatter("                Device   ID: %d", device_id);
+            click_chatter("                Driver Name: %s", driver);
+            click_chatter("           Promiscuous Mode: %s", promisc? "true":"false");
+            click_chatter("          VLAN    Filtering: %s", vlan_filter? "true":"false");
+            click_chatter("          VLAN    Stripping: %s", vlan_strip? "true":"false");
+            click_chatter("          VLAN QinQ(extend): %s", vlan_extend? "true":"false");
+            click_chatter("Large Receive Offload (LRO): %s", lro ? "true":"false");
+            click_chatter("    Rx Jumbo Frames Offload: %s", jumbo ? "true":"false");
+            click_chatter("                MAC Address: %s", init_mac.unparse().c_str());
+            click_chatter("             # of Rx Queues: %d", rx_queues.size());
+            click_chatter("             # of Tx Queues: %d", tx_queues.size());
+            click_chatter("             # of Rx  Descs: %d", n_rx_descs);
+            click_chatter("             # of Tx  Descs: %d", n_tx_descs);
         }
 
         uint16_t vendor_id;
@@ -109,6 +113,9 @@ public:
         bool promisc;
         bool vlan_filter;
         bool vlan_strip;
+        bool vlan_extend;
+        bool lro;
+        bool jumbo;
         unsigned n_rx_descs;
         unsigned n_tx_descs;
         EtherAddress init_mac;
@@ -119,8 +126,8 @@ public:
     };
 
     int add_rx_queue(
-        unsigned &queue_id, bool promisc, bool vlan_filter, bool vlan_strip,
-        unsigned n_desc, ErrorHandler *errh
+        unsigned &queue_id, bool promisc, bool vlan_filter, bool vlan_strip, bool vlan_extend,
+        bool lro, bool jumbo, unsigned n_desc, ErrorHandler *errh
     ) CLICK_COLD;
 
     int add_tx_queue(
@@ -254,8 +261,9 @@ private:
     static bool no_more_buffer_msg_printed;
 
     int initialize_device(ErrorHandler *errh) CLICK_COLD;
-    int add_queue(Dir dir, unsigned &queue_id, bool promisc, bool vlan_filter, bool vlan_strip,
-                   unsigned n_desc, ErrorHandler *errh) CLICK_COLD;
+    int add_queue(Dir dir, unsigned &queue_id,
+                    bool promisc, bool vlan_filter, bool vlan_strip, bool vlan_extend,
+                    bool lro, bool jumbo, unsigned n_desc, ErrorHandler *errh) CLICK_COLD;
 
     static int alloc_pktmbufs(ErrorHandler* errh) CLICK_COLD;
 


### PR DESCRIPTION
To allow Rx jumbo frames offloading it is necessary
to set max_rx_pkt_len, which was not set by FastClick.
Also, fixed the initial VLAN filter and strip configuration
status (which was mistakenly set to true).
Messages are added to notify users about the status of
the offloading features when turned on.

Signed-off-by: Georgios Katsikas <katsikas.gp@gmail.com>