### PR TITLE
Additional statistics for AverageBatchCounter

### DIFF
--- a/elements/analysis/averagebatchcounter.cc
+++ b/elements/analysis/averagebatchcounter.cc
@@ -1,9 +1,10 @@
 // -*- c-basic-offset: 4 -*-
 /*
- * averagebatchcounter.{cc,hh} -- anonymize packet IP addresses
- * Tom Barbette
+ * averagebatchcounter.{cc,hh} -- provides batch-related statistics
+ * Tom Barbette, Georgios Katsikas
  *
  * Copyright (c) 2017 University of Liege
+ * Copyright (c) 2019 KTH Royal Institute of Technology
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -21,25 +22,30 @@
 #include <click/string.hh>
 #include <click/straccum.hh>
 #include <click/args.hh>
+#include <click/error.hh>
+#include <click/routervisitor.hh>
+#include <click/router.hh>
 
 CLICK_DECLS
 
-AverageBatchCounter::AverageBatchCounter() : _interval(1000), _timer(this)
+AverageBatchCounter::AverageBatchCounter() : _interval(1000), _frame_len_stats(false), _timer(this)
 {
     in_batch_mode = BATCH_MODE_NEEDED;
 }
 
 AverageBatchCounter::~AverageBatchCounter()
 {
+
 }
+
 int
 AverageBatchCounter::configure(Vector<String> &conf, ErrorHandler *errh)
 {
-
     if (Args(conf, this, errh)
-            .read_p("INTERVAL", _interval)
-	.complete() < 0)
-	return -1;
+        .read_p("INTERVAL", _interval)
+        .read("LENGTH_STATS", _frame_len_stats)
+        .complete() < 0)
+        return -1;
 
     return 0;
 }
@@ -47,9 +53,19 @@ AverageBatchCounter::configure(Vector<String> &conf, ErrorHandler *errh)
 int
 AverageBatchCounter::initialize(ErrorHandler *errh)
 {
-    (void)errh;
+    // Uses an upstream AggregateLength to get frame length
+    if (_frame_len_stats) {
+        ElementCastTracker filter(router(), "AggregateLength");
+        int found = router()->visit_upstream(this, 0, &filter);
+        if (filter.elements().size() == 0) {
+            errh->error("Could not find upstream AggregateLength element: LENGTH_STATS not available");
+            _frame_len_stats = false;
+        }
+    }
+
     _timer.initialize(this);
     _timer.schedule_after_msec(_interval);
+
     return 0;
 }
 
@@ -60,19 +76,35 @@ AverageBatchCounter::cleanup(CleanupStage)
 }
 
 void
-AverageBatchCounter::run_timer(Timer* t)
+AverageBatchCounter::run_timer(Timer *t)
 {
     BatchStats &total = _stats_total.write_begin();
     BatchStats &last_tick = _stats_last_tick.write_begin();
     total.count_batches += last_tick.count_batches;
     total.count_packets += last_tick.count_packets;
+    if (_frame_len_stats) {
+        if (last_tick.count_packets > 0) {
+            total.agg_frame_len += last_tick.agg_frame_len;
+            total.avg_frame_len = (float) total.agg_frame_len / (float) total.count_packets;
+        }
+    }
     last_tick.count_batches = 0;
     last_tick.count_packets = 0;
+    last_tick.agg_frame_len = 0;
+    last_tick.avg_frame_len = 0;
     for (unsigned i = 0; i < _stats.weight(); i++) {
         last_tick.count_batches += _stats.get_value(i).count_batches;
         last_tick.count_packets += _stats.get_value(i).count_packets;
+        if (_frame_len_stats) {
+            if (last_tick.count_packets > 0) {
+                last_tick.agg_frame_len += _stats.get_value(i).agg_frame_len;
+                last_tick.avg_frame_len = (float) last_tick.agg_frame_len / (float) last_tick.count_packets;
+            }
+        }
         _stats.get_value(i).count_batches = 0;
         _stats.get_value(i).count_packets = 0;
+        _stats.get_value(i).agg_frame_len = 0;
+        _stats.get_value(i).avg_frame_len = 0;
     }
     _stats_total.write_commit();
     _stats_last_tick.write_commit();
@@ -80,13 +112,37 @@ AverageBatchCounter::run_timer(Timer* t)
     t->reschedule_after_msec(_interval);
 }
 
-PacketBatch*
-AverageBatchCounter::simple_action_batch(PacketBatch* b)
+PacketBatch *
+AverageBatchCounter::simple_action_batch(PacketBatch *b)
 {
     BatchStats &stat = *_stats;
     stat.count_batches ++;
     stat.count_packets += b->count();
+    if (_frame_len_stats) {
+        if (b->count() > 0) {
+            stat.agg_frame_len += compute_agg_frame_len(b);
+            stat.avg_frame_len = (float) stat.agg_frame_len / (float) stat.count_packets;
+        }
+    }
+
     return b;
+}
+
+uint32_t
+AverageBatchCounter::compute_agg_frame_len(PacketBatch *batch)
+{
+    uint32_t len = 0;
+    for(Packet *p = batch; p != 0; p = p->next()) {
+        uint32_t value = AGGREGATE_ANNO(p);
+        if (value > 0) {
+            len += value;
+        } else {
+            // The upstream AggregateLength must prevent this from happening
+            assert(false);
+        }
+    }
+
+    return len;
 }
 
 String
@@ -94,36 +150,45 @@ AverageBatchCounter::read_handler(Element *e, void *thunk)
 {
     AverageBatchCounter *fd = static_cast<AverageBatchCounter *>(e);
     switch ((intptr_t)thunk) {
-      case H_AVERAGE: {
-          BatchStats stat = fd->_stats_last_tick.read();
-          if (stat.count_batches == 0)
-              return 0;
-          return String(stat.count_packets / stat.count_batches);
-      }
-      case H_AVERAGE_TOTAL: {
-          BatchStats stat = fd->_stats_total.read();
-          if (stat.count_batches == 0)
+        case H_AVERAGE: {
+            BatchStats stat = fd->_stats_last_tick.read();
+            if (stat.count_batches == 0)
                 return 0;
-          return String(stat.count_packets / stat.count_batches);
-      }
-      case H_COUNT_BATCHES: {
-          BatchStats stat = fd->_stats_last_tick.read();
-          return String(stat.count_batches);
-      }
-      case H_COUNT_BATCHES_TOTAL: {
-          BatchStats stat = fd->_stats_total.read();
-          return String(stat.count_batches);
-      }
-      case H_COUNT_PACKETS: {
-          BatchStats stat = fd->_stats_last_tick.read();
-          return String(stat.count_packets);
-      }
-      case H_COUNT_PACKETS_TOTAL: {
-          BatchStats stat = fd->_stats_total.read();
-          return String(stat.count_packets);
-      }
-      default:
-      return "-1";
+            return String(stat.count_packets / stat.count_batches);
+        }
+        case H_AVERAGE_TOTAL: {
+            BatchStats stat = fd->_stats_total.read();
+            if (stat.count_batches == 0)
+                return 0;
+            return String(stat.count_packets / stat.count_batches);
+        }
+        case H_COUNT_BATCHES: {
+            BatchStats stat = fd->_stats_last_tick.read();
+            return String(stat.count_batches);
+        }
+        case H_COUNT_BATCHES_TOTAL: {
+            BatchStats stat = fd->_stats_total.read();
+            return String(stat.count_batches);
+        }
+        case H_COUNT_PACKETS: {
+            BatchStats stat = fd->_stats_last_tick.read();
+            return String(stat.count_packets);
+        }
+        case H_COUNT_PACKETS_TOTAL: {
+            BatchStats stat = fd->_stats_total.read();
+            return String(stat.count_packets);
+        }
+        case H_AVG_FRAME_LEN: {
+            BatchStats stat = fd->_stats_last_tick.read();
+            return String(stat.avg_frame_len);
+        }
+        case H_AVG_FRAME_LEN_TOTAL: {
+            BatchStats stat = fd->_stats_total.read();
+            return String(stat.avg_frame_len);
+        }
+        default: {
+            return "-1";
+        }
     }
 }
 
@@ -136,6 +201,8 @@ AverageBatchCounter::add_handlers()
     add_read_handler("count_packets_total", read_handler, H_COUNT_PACKETS_TOTAL);
     add_read_handler("count_batches", read_handler, H_COUNT_BATCHES);
     add_read_handler("count_batches_total", read_handler, H_COUNT_BATCHES_TOTAL);
+    add_read_handler("average_frame_len", read_handler, H_AVG_FRAME_LEN);
+    add_read_handler("average_frame_len_total", read_handler, H_AVG_FRAME_LEN_TOTAL);
 }
 
 

--- a/elements/analysis/averagebatchcounter.hh
+++ b/elements/analysis/averagebatchcounter.hh
@@ -9,11 +9,63 @@ CLICK_DECLS
 /*
 =c
 
-AverageBatchCounter
+AverageBatchCounter([INTERVAL, LENGTH_STATS])
 
 =s counters
 
 keep average statistics about batching since last reset and last tick
+
+=d
+
+Expects Ethernet frames as input. Computes statistics related to the batches
+being created either since the last tick or since the initialization of the
+element.
+
+Keyword arguments are:
+
+=over 2
+
+=item INTERVAL
+
+Integer. Time interval to reschedule the computation of the statistics.
+Defaults to 1000 ms.
+
+=item LENGTH_STATS
+
+Boolean. If set, provides additional statistics regarding frames' length.
+Defaults to false.
+
+=h average read-only
+
+Returns the average batch size (packets/batch) since the last tick.
+
+=h average_total read-only
+
+Returns the total average batch size (packets/batch).
+
+=h count_packets read-only
+
+Returns the number of packets seen since the last tick.
+
+=h count_packets_total read-only
+
+Returns the total number of packets seen.
+
+=h count_batches read-only
+
+Returns the number of batches created since the last tick.
+
+=h count_batches_total read-only
+
+Returns the total number of batches.
+
+=h average_frame_len read-only
+
+Returns the average frame length in bytes since the last tick.
+
+=h average_frame_len_total read-only
+
+Returns the total average frame length in bytes.
 
  */
 
@@ -39,13 +91,17 @@ private:
     struct BatchStats {
         uint64_t count_batches;
         uint64_t count_packets;
+        uint32_t agg_frame_len;
+        float avg_frame_len;
 
-        BatchStats() : count_batches(0), count_packets(0) {
+        BatchStats() : count_batches(0), count_packets(0), agg_frame_len(0), avg_frame_len(0.0f) {
 
         }
     };
     per_thread<BatchStats> _stats;
     static String read_handler(Element *e, void *thunk);
+
+    uint32_t compute_agg_frame_len(PacketBatch *batch);
 
     /*
      * Unprotected RCU is fine as the stats will be written once every _interval, no way a handler stays
@@ -55,9 +111,15 @@ private:
     unprotected_rcu_singlewriter<BatchStats,2> _stats_total;
 
     int _interval;
+    bool _frame_len_stats;
     Timer _timer;
 
-    enum {H_AVERAGE, H_AVERAGE_TOTAL, H_COUNT_PACKETS, H_COUNT_PACKETS_TOTAL, H_COUNT_BATCHES, H_COUNT_BATCHES_TOTAL };
+    enum {
+        H_AVERAGE, H_AVERAGE_TOTAL,
+        H_COUNT_PACKETS, H_COUNT_PACKETS_TOTAL,
+        H_COUNT_BATCHES, H_COUNT_BATCHES_TOTAL,
+        H_AVG_FRAME_LEN, H_AVG_FRAME_LEN_TOTAL
+    };
 
 };
 


### PR DESCRIPTION
These statistics are related to the frame lengths being
observed either since the last tick or since the initialization
of this element. An input parameter defines whether these extra
statistics will be provided or not. Also, the element's documentation
is improved.

Signed-off-by: Georgios Katsikas <katsikas.gp@gmail.com>