### PR TITLE
Metron extensions and bug fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ cache:
   directories:
     - dpdk-2.2.0
     - dpdk-16.04
+    - dpdk-17.05
     - dpdk-17.08
     - dpdk-17.11
     - dpdk-18.02

--- a/elements/userlevel/fromdpdkdevice.hh
+++ b/elements/userlevel/fromdpdkdevice.hh
@@ -37,48 +37,48 @@ you can pin to different thread using StaticThreadSched.
 
 Arguments:
 
-=over 20
+=over 31
 
 =item PORT
 
-Integer or PCI address.  Port identifier of the device, or a PCI address in the
+Integer or PCI address. Port identifier of the device or a PCI address in the
 format fffff:ff:ff.f
 
 =item QUEUE
 
-Integer.  A specific hardware queue to use. Default is 0.
+Integer. A specific hardware queue to use. Default is 0.
 
 =item N_QUEUES
 
-Integer.  Number of hardware queues to use. -1 or default is to use as many queues
+Integer. Number of hardware queues to use. -1 or default is to use as many queues
 as threads assigned to this element.
 
 =item PROMISC
 
-Boolean.  FromDPDKDevice puts the device in promiscuous mode if PROMISC is
+Boolean. FromDPDKDevice puts the device in promiscuous mode if PROMISC is
 true. The default is false.
 
 =item BURST
 
-Integer.  Maximal number of packets that will be processed before rescheduling.
+Integer. Maximal number of packets that will be processed before rescheduling.
 The default is 32.
 
 =item MAXTHREADS
 
-Maximal number of threads that this element will take to read packets from
+Integer. Maximal number of threads that this element will take to read packets from
 the input queue. If unset (or negative) all threads not pinned with a
 ThreadScheduler element will be shared among FromDPDKDevice elements and
 other input elements supporting multiqueue (extending QueueDevice)
 
 =item THREADOFFSET
 
-Specify which Click thread will handle this element. If multiple
+Integer. Specify which Click thread will handle this element. If multiple
 j threads are used, threads with id THREADOFFSET+j will be used. Default is
 to share the threads available on the device's NUMA node equally.
 
 =item NDESC
 
-Integer.  Number of descriptors per ring. The default is 256.
+Integer. Number of descriptors per ring. The default is 256.
 
 =item MAC
 
@@ -99,6 +99,13 @@ supported.
 String. For DPDK version >= 17.05, if MODE is set to flow_dir, a path to
 a file with Flow Director rules can be supplied to the device.
 These rules are installed in the NIC using DPDK's flow API.
+
+=item FLOW_DIR_ISOLATE
+
+Boolean. Requires MODE flow_dir. Isolated mode guarantees that all ingress
+traffic comes from defined flow rules only (current and future).
+If ingress traffic does not match any of the defined rules, it will be
+discarded by the NIC. Defaults to false.
 
 =item VF_POOLS
 
@@ -132,25 +139,50 @@ field of each packet. Defaults to False.
 
 Boolean. If True, allocates CPU cores in a NUMA-aware fashion.
 
+=item NUMA_NODE
+
+Integer. Specify the NUMA node to undertake packet processing.
+
+=item RX_INTR
+
+Integer. Enables Rx interrupts if non-negative value is given.
+Defaults to -1 (no interrupts).
+
+=item SCALE
+
+String. Defines the scaling policy. Can be parallel or share.
+Scaling is disabled by default.
+
+=item TIMESTAMP
+
+Boolean. Enables hardware timestamping. Defaults to false.
+
+=item VLAN_FILTER
+
+Boolean. Per queue ability to filter received VLAN packets by the hardware. Defaults to false.
+
+=item VLAN_STRIP
+
+Boolean. Per queue ability to strip VLAN header by the hardware in received VLAN packets. Defaults to false.
+
+=item VLAN_EXTEND
+
+Boolean. Per queue ability to extend VLAN tagged packets via QinQ. Defaults to false.
+
+=item LRO
+
+Boolean. Enables hardware-based Large Receive Offloading (LRO).
+When set to true, the NIC coalesces consecutive frames of the same flow into larger frames.
+Defaults to false.
+
+=item JUMBO
+
+Boolean. Enables the reception of Jumbo frames by the hardware. Defaults to false.
+
 =item ACTIVE
 
 Boolean. If False, the device is only initialized. Use this when you want
 to read packet using secondary DPDK applications.
-
-=item TCO
-
-Boolean. If True, enables TCP Checksum Offload. Packets must be set with the
-checksum flag, eg with ResetTCPChecksum. Defaults to False.
-
-=item TSO
-
-Boolean. If True, enables TCP Segmentation Offload. Packets must be configured
-individually as per DPDK documentation. Defaults to False.
-
-=item IPCO
-
-Booelan. If True, enables IP checksum offload alone (not L4 as TCO).
-Defaults to False.
 
 =item VERBOSE
 
@@ -166,13 +198,208 @@ support.
 
   FromDPDKDevice(3, QUEUE 1) -> ...
 
+=h device read-only
+
+Returns the device number.
+
+=h duplex read-only
+
+Returns whether link is duplex (1) or not (0) for an active link (status is up).
+
+=h autoneg read-only
+
+Returns whether device supports auto negotiation.
+
+=h speed read-only
+
+Returns the device's link speed in Mbps.
+
+=h carrier read-only
+
+Returns the device's link status (1 for link up, otherwise 0).
+
+=h type read-only
+
+Returns the device's link type (only fiber is currently supported).
+
+=h xstats read-only
+
+Returns a device's detailed packet and byte counters.
+
+=h queue_count read-only
+
+Returns the number of used descriptors of a specific Rx queue.
+If no queue is specified, all queues' used descriptors are returned.
+
+=h queue_packets read-only
+
+Returns the number of packets of a specific Rx queue.
+If no queue is specified, all queues' packets are returned.
+
+=h queue_bytes read-only
+
+Returns the number of bytes of a specific Rx queue.
+If no queue is specified, all queues' bytes are returned.
+
+=h rule_packet_hits read-only
+
+Returns the number of packets matched by a specific rule.
+If no rule number is specified, an error is returned (aggregate statistics not supported).
+
+=h rule_byte_count read-only
+
+Returns the number of bytes matched by a specific rule.
+If no rule number is specified, an error is returned (aggregate statistics not supported).
+
+=h rules_aggr_stats read-only
+
+Returns aggregate rule statistics.
+
+=h active read-only
+
+Returns the status of the device (1 for active, otherwise 0).
+
+=h active/safe_active write-only
+
+Sets the status of the device (1 for active, otherwise 0).
+
 =h count read-only
 
 Returns the number of packets read by the device.
 
-=h reset_count write-only
+=h useful read-only
+
+Returns the number of useful runs of this device.
+This number corresponds to the number of times that the element is successfully scheduled to receive input packets.
+
+=h useless read-only
+
+Returns the number of useless runs of this device.
+This number corresponds to the number of times that the element is scheduled to receive input packets,
+but no packets are being received (idle CPU spinning).
+
+=h reset_counts write-only
 
 Resets "count" to zero.
+
+=h reset_load write-only
+
+Resets load counters to zero.
+
+=h nb_rx_queues read-only
+
+Returns the number of Rx queues of this device.
+
+=h nb_tx_queues read-only
+
+Returns the number of Tx queues of this device.
+
+=h nb_vf_pools read-only
+
+Returns the number of Virtual Function pools of this device.
+
+=h nb_rx_desc read-only
+
+Returns the number of Rx descriptors of this device.
+
+=h mac read-only
+
+Returns the Ethernet address of this device.
+
+=h vendor read-only
+
+Returns the vendor of this device.
+
+=h driver read-only
+
+Returns the driver of this device.
+
+=h add_mac write-only
+
+Sets the Ethernet address of this device.
+
+=h remove_mac write-only
+
+Removes the Ethernet address of this device.
+
+=h vf_mac_addr read-only
+
+Returns the Ethernet addresses of the Virtual Functions of this device.
+If JSON is supported, the return format is JSON, otherwise a string is returned.
+
+=h max_rss write-only
+
+Reconfigures the size of the RSS table.
+
+=h hw_count read-only
+
+Returns the number of packets received by this device, as computed by the hardware.
+
+=h hw_bytes read-only
+
+Returns the number of bytes received by this device, as computed by the hardware.
+
+=h hw_dropped read-only
+
+Returns the number of packets dropped by this device, as computed by the hardware.
+
+=h hw_errors read-only
+
+Returns the number of errors of this device, as computed by the hardware.
+
+=h nombufs read-only
+
+Returns the number of mbufs allocated for this devce.
+
+=h rule_add write-only
+
+Inserts a new rule into this device's rule table.
+The format of the rule must comply with testpmd. If so, the rule is translated into DPDK's Flow API format.
+For example: rule_add ingress pattern eth / ipv4 src is 192.168.100.7 dst is 192.168.1.7 / udp src is 53 / end actions queue index 3 / count / end
+A rule could be optionally prepended with the pattern 'flow create X' (where X is the correct port number), otherwise this pattern will be automatically prepended.
+Upon success, the ID of the added rule is returned, otherwise an error is returned.
+
+=h rules_del write-only
+
+Deletes a (set of) rule(s) from this device's rule table.
+Rule numbers to be deleted are specified as a space-separated list (e.g., rules_del 0 1 2).
+Upon success, the number of deleted flow rules is returned, otherwise an error is returned.
+
+=h rules_isolate write-only
+
+Enables/Disables Flow Director's isolation mode.
+Isolated mode guarantees that all ingress traffic comes from defined flow rules only (current and future).
+Usage:
+    'rules_isolate 0' disables isolation.
+    'rules_isolate 1' enables isolation.
+
+=h rules_flush write-only
+
+Deletes all of the rules from this device's rule table.
+Upon success, the number of deleted flow rules is returned.
+
+=h rules_ids_global read-only
+
+Returns a string of space-separated global rule IDs that correspond to the rules being installed.
+
+=h rules_ids_internal read-only
+
+Returns a string of space-separated internal rule IDs that correspond to the rules being installed.
+
+=h rules_list read-only
+
+Returns the list of flow rules being installed along with statistics per rule.
+
+=h rules_list_with_hits read-only
+
+Returns the list of flow rules being installed that exhibit at least one hit.
+This list is a subset of the list returned by rules_list handler.
+
+=h rules_count read-only
+
+Returns the number of flow rules being installed.
+
+=h
 
 =a DPDKInfo, ToDPDKDevice */
 
@@ -242,9 +469,9 @@ private:
         h_mtu,
         h_device,
     #if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
-        h_rule_add, h_rules_del, h_rules_flush,
-        h_rules_list, h_rules_ids_global, h_rules_ids_internal, h_rules_count,
-        h_rule_packet_hits, h_rule_byte_count, h_rules_aggr_stats
+        h_rule_add, h_rules_del, h_rules_isolate, h_rules_flush,
+        h_rules_list, h_rules_list_with_hits, h_rules_ids_global, h_rules_ids_internal,
+        h_rules_count, h_rule_packet_hits, h_rule_byte_count, h_rules_aggr_stats
     #endif
     };
 

--- a/elements/userlevel/metron.hh
+++ b/elements/userlevel/metron.hh
@@ -641,7 +641,6 @@ class ServiceChain {
 =c
 
 Metron */
-
 class Metron : public Element {
     public:
         Metron() CLICK_COLD;

--- a/elements/userlevel/queuedevice.cc
+++ b/elements/userlevel/queuedevice.cc
@@ -151,13 +151,13 @@ int RXQueueDevice::parse(Vector<String> &conf, ErrorHandler *errh) {
         } else if (scale.lower() == "share") {
             _scale_parallel = false;
         } else {
-            return errh->error("Unknown scaling mode %s !",scale.c_str());
+            return errh->error("Unknown scaling mode %s!",scale.c_str());
         }
     }
 
 #if !HAVE_NUMA
     if (_use_numa) {
-        click_chatter("Cannot use numa if --enable-numa wasn't set during compilation time !");
+        click_chatter("Cannot use numa if --enable-numa wasn't set during compilation time!");
     }
     _use_numa = false;
 #endif

--- a/elements/userlevel/todpdkdevice.cc
+++ b/elements/userlevel/todpdkdevice.cc
@@ -75,9 +75,9 @@ int ToDPDKDevice::configure(Vector<String> &conf, ErrorHandler *errh)
     if (firstqueue == -1)
        firstqueue = 0;
     if (n_queues == -1) {
-	configure_tx(1,maxqueues,errh);
+        configure_tx(1, maxqueues, errh);
     } else {
-        configure_tx(n_queues,n_queues,errh);
+        configure_tx(n_queues, n_queues, errh);
     }
 
     if (_tso)

--- a/elements/userlevel/todpdkdevice.hh
+++ b/elements/userlevel/todpdkdevice.hh
@@ -17,7 +17,7 @@ ToDPDKDevice(PORT [, QUEUE, N_QUEUES, I<keywords> IQUEUE, BLOCKING, etc.])
 
 =s netdevices
 
-sends packets to network device using Intel's DPDK (user-level)
+sends packets to network device using DPDK (user-level)
 
 =d
 
@@ -30,38 +30,44 @@ BURST packets.
 
 Arguments:
 
-=over 8
+=over 14
 
 =item PORT
 
-Integer or PCI address.  Port identifier of the device, or a PCI address in the
+Integer or PCI address. Port identifier of the device or a PCI address in the
 format fffff:ff:ff.f
 
 =item QUEUE
 
-Integer.  A specific hardware queue to use. Default is 0.
+Integer. A specific hardware queue to use. Default is 0.
 
 =item N_QUEUES
 
-Integer.  Number of hardware queues to use. -1 or default is to use as many
+Integer. Number of hardware queues to use. -1 or default is to use as many
 queues as threads which can end up in this element.
+
+=item MAXQUEUES
+
+Integer. Set the maximum number of hardware queues to be used for transmission.
+If N_QUEUES is not set, the minimum number of queues is 1 and the maximum is MAXQUEUES.
+Defaults to 128.
 
 =item IQUEUE
 
-Integer.  Size of the internal queue, i.e. number of packets that we can buffer
+Integer. Size of the internal queue, i.e. number of packets that we can buffer
 before pushing them to the DPDK framework. If IQUEUE is bigger than BURST,
 some packets could be buffered in the internal queue when the output ring is
 full. Defaults to 1024.
 
 =item BLOCKING
 
-Boolean.  If true, when there is no more space in the output device ring, and
+Boolean. If true, when there is no more space in the output device ring, and
 the IQUEUE is full, we'll block until some packet could be sent. If false the
 packet will be dropped. Defaults to true.
 
 =item BURST
 
-Integer.  Number of packets to batch before sending them out. A bigger BURST
+Integer. Number of packets to batch before sending them out. A bigger BURST
 leads to more latency, but a better throughput. The default value of 32 is
 recommended as it is what DPDK will do under the hood. Prefer to set the
 TIMEOUT parameter to 0 if the throughput is low as it will maintain
@@ -69,7 +75,7 @@ performance.
 
 =item TIMEOUT
 
-Integer.  Set a timeout to flush the internal queue. It is useful under low
+Integer. Set a timeout to flush the internal queue. It is useful under low
 throughput as it could take a long time before reaching BURST packet in the
 internal queue. The timeout is expressed in milliseconds. Setting the timer to
 0 is not a bad idea as it will schedule after the source element (such as a
@@ -84,12 +90,32 @@ packets will never wait in the internal queue.
 
 =item NDESC
 
-Integer.  Number of descriptors per ring. The default is 1024.
+Integer. Number of descriptors per ring. The default is 1024.
 
 =item ALLOW_NONEXISTENT
 
-Boolean.  Do not fail if the PORT do not existent. If it's the case the task
+Boolean. Do not fail if the PORT do not existent. If it's the case the task
 will never run and this element will behave like Idle.
+
+=item ALLOC
+
+Boolean. If true, packets hosted in non-DPDK buffers are copied into newly-allocated
+DPDK mbufs.
+
+=item TCO
+
+Boolean. If True, enables TCP Checksum Offload. Packets must be set with the
+checksum flag, eg with ResetTCPChecksum. Defaults to False.
+
+=item TSO
+
+Boolean. If True, enables TCP Segmentation Offload. Packets must be configured
+individually as per DPDK documentation. Defaults to False.
+
+=item IPCO
+
+Booelan. If True, enables IP checksum offload alone (not L4 as TCO).
+Defaults to False.
 
 =back
 

--- a/include/click/dpdkdevice.hh
+++ b/include/click/dpdkdevice.hh
@@ -86,16 +86,21 @@ public:
             num_pools(0), vf_vlan(), vlan_filter(false), vlan_strip(false), vlan_extend(false),
             lro(false), jumbo(false),
             n_rx_descs(0), n_tx_descs(0),
-            init_mac(), init_mtu(0), init_rss(-1), init_fc_mode(FC_UNSET), rx_offload(0), tx_offload(0) {
+            init_mac(), init_mtu(0), init_rss(-1), init_fc_mode(FC_UNSET), rx_offload(0), tx_offload(0)
+        {
             rx_queues.reserve(128);
             tx_queues.reserve(128);
         }
 
         void print_device_info() {
+            if (device_id == PCI_ANY_ID) {
+                return;
+            }
             click_chatter("                Vendor   ID: %d", vendor_id);
             click_chatter("                Vendor Name: %s", vendor_name.c_str());
             click_chatter("                Device   ID: %d", device_id);
             click_chatter("                Driver Name: %s", driver);
+            click_chatter("             Reception Mode: %s", mq_mode_str.c_str());
             click_chatter("           Promiscuous Mode: %s", promisc? "true":"false");
             click_chatter("          VLAN    Filtering: %s", vlan_filter? "true":"false");
             click_chatter("          VLAN    Stripping: %s", vlan_strip? "true":"false");
@@ -187,7 +192,7 @@ public:
 #if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
     int set_mode(
         String mode, int num_pools, Vector<int> vf_vlan,
-        const String &rules_path, ErrorHandler *errh
+        const String &fd_rules_filename, const bool &fd_isolate, ErrorHandler *errh
     );
 #else
     int set_mode(

--- a/include/click/flowdirector.hh
+++ b/include/click/flowdirector.hh
@@ -173,10 +173,11 @@ class FlowDirector {
         static String FLOW_RULE_IDS_INT;
         static String FLOW_RULE_PACKET_HITS;
         static String FLOW_RULE_BYTE_COUNT;
-        static String FLOW_RULE_STATS;
         static String FLOW_RULE_AGGR_STATS;
         static String FLOW_RULE_LIST;
+        static String FLOW_RULE_LIST_WITH_HITS;
         static String FLOW_RULE_COUNT;
+        static String FLOW_RULE_ISOLATE;
         static String FLOW_RULE_FLUSH;
 
         // For debugging
@@ -239,6 +240,17 @@ class FlowDirector {
         };
         inline String rules_filename() { return _rules_filename; };
 
+        // Flow rules' isolation mode
+        inline void set_isolation_mode(const bool &isolated) {
+            _isolated = isolated;
+            if (_isolated) {
+                flow_rules_isolate(1);
+            } else {
+                flow_rules_isolate(0);
+            }
+        };
+        inline bool isolated() { return _isolated; };
+
         // Calibrates flow rule cache before inserting new rules
         void calibrate_cache(const uint32_t *int_rule_ids, const uint32_t &rules_nb);
         void calibrate_cache(const HashMap<long, String> &rules_map);
@@ -292,7 +304,7 @@ class FlowDirector {
         void nic_and_cache_counts_agree();
 
         // Lists all NIC flow rules
-        String flow_rules_list();
+        String flow_rules_list(const bool only_matching_rules = false);
 
         // Lists all installed (internal + global flow rule IDs along with counters
         String flow_rule_ids_internal_counters();
@@ -345,6 +357,9 @@ class FlowDirector {
         // Indicates whether Flow Director is active for a given device
         bool _active;
 
+        // Isolated mode guarantees that all ingress traffic comes from defined flow rules only (current and future)
+        bool _isolated;
+
         // Set stdout verbosity
         bool _verbose;
         bool _debug_mode;
@@ -367,6 +382,9 @@ class FlowDirector {
 
         // Pre-populate the supported matches and actions on relevant maps
         void populate_supported_flow_items_and_actions();
+
+        // Restrict ingress traffic to the defined flow rules
+        int flow_rules_isolate(int set);
 
         // Sorts a list of flow rules by group, priority, and ID
         void flow_rules_sort(struct rte_port *port, struct port_flow **sorted_rules);

--- a/include/click/flowdirector.hh
+++ b/include/click/flowdirector.hh
@@ -241,15 +241,15 @@ class FlowDirector {
         inline String rules_filename() { return _rules_filename; };
 
         // Flow rules' isolation mode
-        inline void set_isolation_mode(const bool &isolated) {
-            _isolated = isolated;
-            if (_isolated) {
-                flow_rules_isolate(1);
+        static inline void set_isolation_mode(const portid_t &port_id, const bool &isolated) {
+            _isolated.insert(port_id, isolated);
+            if (_isolated[port_id]) {
+                flow_rules_isolate(port_id, 1);
             } else {
-                flow_rules_isolate(0);
+                flow_rules_isolate(port_id, 0);
             }
         };
-        inline bool isolated() { return _isolated; };
+        static inline bool isolated(const portid_t &port_id) { return _isolated[port_id]; };
 
         // Calibrates flow rule cache before inserting new rules
         void calibrate_cache(const uint32_t *int_rule_ids, const uint32_t &rules_nb);
@@ -357,9 +357,6 @@ class FlowDirector {
         // Indicates whether Flow Director is active for a given device
         bool _active;
 
-        // Isolated mode guarantees that all ingress traffic comes from defined flow rules only (current and future)
-        bool _isolated;
-
         // Set stdout verbosity
         bool _verbose;
         bool _debug_mode;
@@ -373,6 +370,9 @@ class FlowDirector {
         // A low rule cache associated with the port of this Flow Director
         FlowCache *_flow_cache;
 
+        // Isolated mode guarantees that all ingress traffic comes from defined flow rules only (current and future)
+        static HashMap<portid_t, bool> _isolated;
+
         // Flow rule commands' parser
         static struct cmdline *_parser;
 
@@ -380,11 +380,11 @@ class FlowDirector {
         static HashMap<portid_t, Vector<RuleTiming>> _rule_inst_stats_map;
         static HashMap<portid_t, Vector<RuleTiming>> _rule_del_stats_map;
 
+        // Restrict ingress traffic to the defined flow rules
+        static int flow_rules_isolate(const portid_t &port_id, const int &set);
+
         // Pre-populate the supported matches and actions on relevant maps
         void populate_supported_flow_items_and_actions();
-
-        // Restrict ingress traffic to the defined flow rules
-        int flow_rules_isolate(int set);
 
         // Sorts a list of flow rules by group, priority, and ID
         void flow_rules_sort(struct rte_port *port, struct port_flow **sorted_rules);

--- a/lib/flowdirector.cc
+++ b/lib/flowdirector.cc
@@ -1960,6 +1960,7 @@ FlowDirector::flow_rules_delete(uint32_t *int_rule_ids, const uint32_t &rules_nb
 int
 FlowDirector::flow_rules_isolate(const portid_t &port_id, const int &set)
 {
+#if RTE_VERSION >= RTE_VERSION_NUM(17,8,0,0)
     if (port_flow_isolate(port_id, set) != FLOWDIR_SUCCESS) {
         ErrorHandler *errh = ErrorHandler::default_handler();
         return errh->error(
@@ -1968,7 +1969,14 @@ FlowDirector::flow_rules_isolate(const portid_t &port_id, const int &set)
     }
 
     return 0;
+#else
+    ErrorHandler *errh = ErrorHandler::default_handler();
+    return errh->error(
+        "Flow Director (port %u): Flow isolation is supported since DPDK 17.08", port_id
+    );
+#endif
 }
+
 
 /**
  * Queries the statistics of a NIC flow rule.

--- a/userlevel/dpdk.mk
+++ b/userlevel/dpdk.mk
@@ -469,8 +469,9 @@ ifeq ($(shell [ -n $(RTE_VER_YEAR) ] && ( ( [ $(RTE_VER_YEAR) -eq 18 ] && [ $(RT
 endif
 	touch $(PARSE_PATH)/.sentinel
 
-
+ifeq ($(shell [ -n $(RTE_VER_YEAR) ] && ( ( [ $(RTE_VER_YEAR) -eq 19 ] && [ $(RTE_VER_MONTH) -le 08 ] ) || [ $(RTE_VER_YEAR) -lt 19 ] ) && echo true),true)
 .NOTPARALLEL: ${PARSE_PATH}.sentinel
+endif
 
 test-pmd/%.o: ${PARSE_PATH}.sentinel
 	cp -u $(RTE_SDK)/app/test-pmd/$*.c $(PARSE_PATH)

--- a/userlevel/dpdk.mk
+++ b/userlevel/dpdk.mk
@@ -411,7 +411,7 @@ endif
 ############################################################
 ## Flow director library available at or after DPDK v17.05
 ############################################################
-ifeq ($(shell [ -n "$(RTE_VER_YEAR)" ] && ( ( [ "$(RTE_VER_YEAR)" -ge 17 ] && [ "$(RTE_VER_MONTH)" -ge 05 ] ) || [ $(RTE_VER_YEAR) -ge 18 ] ) && echo true),true)
+ifeq ($(shell [ -n $(RTE_VER_YEAR) ] && ( ( [ $(RTE_VER_YEAR) -ge 17 ] && [ $(RTE_VER_MONTH) -ge 05 ] ) || [ $(RTE_VER_YEAR) -ge 18 ] ) && echo true),true)
 
 $(debug LIBRTE_PARSE=YES)
 
@@ -430,32 +430,42 @@ ${PARSE_PATH}.sentinel:
 	sed -i '/main(int/Q' $(PARSE_PATH)/testpmd.c
 	head -n -1 $(PARSE_PATH)/testpmd.c > $(PARSE_PATH)/testpmd_t.c;
 	mv $(PARSE_PATH)/testpmd_t.c $(PARSE_PATH)/testpmd.c
+	# Strip off testpmd report messages as our library prints its own report messages
 	sed -i '/printf("Flow rule #\%u created\\n", pf->id);/d' $(PARSE_PATH)/config.c
 	sed -i '/printf("Flow rule #\%u destroyed\\n", pf->id);/d' $(PARSE_PATH)/config.c
-	sed -i '120i uint8_t port_numa[RTE_MAX_ETHPORTS];' $(PARSE_PATH)/testpmd.c
-	sed -i '121i uint8_t rxring_numa[RTE_MAX_ETHPORTS];' $(PARSE_PATH)/testpmd.c
-	sed -i '122i uint8_t txring_numa[RTE_MAX_ETHPORTS];' $(PARSE_PATH)/testpmd.c
-ifeq ($(shell [ -n "$(RTE_VER_YEAR)" ] && ( ( [ "$(RTE_VER_YEAR)" -ge 18 ] && [ "$(RTE_VER_MONTH)" -ge 11 ] ) || [ $(RTE_VER_YEAR) -ge 19 ] ) && echo true),true)
-	sed -i '123i struct l2_decap_conf l2_decap_conf;' $(PARSE_PATH)/testpmd.c
-	sed -i '124i struct l2_encap_conf l2_encap_conf;' $(PARSE_PATH)/testpmd.c
-	sed -i '125i struct mplsogre_decap_conf mplsogre_decap_conf;' $(PARSE_PATH)/testpmd.c
-	sed -i '126i struct mplsogre_encap_conf mplsogre_encap_conf;' $(PARSE_PATH)/testpmd.c
-	sed -i '127i struct mplsoudp_decap_conf mplsoudp_decap_conf;' $(PARSE_PATH)/testpmd.c
-	sed -i '128i struct mplsoudp_encap_conf mplsoudp_encap_conf;' $(PARSE_PATH)/testpmd.c
-endif
+# Until DPDK 17.11 these structs need to be declared as extern in testpmd.h and be defined in testpmd.c. Our patch in DPDK 18.02 solves this issue :)
+ifeq ($(shell [ -n $(RTE_VER_YEAR) ] && ( ( [ $(RTE_VER_YEAR) -eq 17 ] ) ) && echo true),true)
+	# Deal with .h
 	sed -i 's/^uint8_t\sport_numa\[RTE_MAX_ETHPORTS\]\;/extern uint8_t port_numa[RTE_MAX_ETHPORTS];/g' $(PARSE_PATH)/testpmd.h
 	sed -i 's/^uint8_t\srxring_numa\[RTE_MAX_ETHPORTS\]\;/extern uint8_t rxring_numa[RTE_MAX_ETHPORTS];/g' $(PARSE_PATH)/testpmd.h
 	sed -i 's/^uint8_t\stxring_numa\[RTE_MAX_ETHPORTS\]\;/extern uint8_t txring_numa[RTE_MAX_ETHPORTS];/g' $(PARSE_PATH)/testpmd.h
 	sed -i '/extern\senum\sdcb_queue_mapping_mode\sdcb_q_mapping\;/d' $(PARSE_PATH)/testpmd.h
+	# Deal with .c
+	sed -i '120i uint8_t port_numa[RTE_MAX_ETHPORTS];' $(PARSE_PATH)/testpmd.c
+	sed -i '121i uint8_t rxring_numa[RTE_MAX_ETHPORTS];' $(PARSE_PATH)/testpmd.c
+	sed -i '122i uint8_t txring_numa[RTE_MAX_ETHPORTS];' $(PARSE_PATH)/testpmd.c
+endif
+# Between DPDK 18.08 and 19.08 these structs need to be declared as external in testpmd.h. DPDK 19.11 solves this issue :)
+ifeq ($(shell [ -n $(RTE_VER_YEAR) ] && ( ( [ $(RTE_VER_YEAR) -eq 18 ] && [ $(RTE_VER_MONTH) -eq 08 ] ) || ( [ $(RTE_VER_YEAR) -eq 19 ] && [ $(RTE_VER_MONTH) -le 08 ] ) ) && echo true),true)
 	sed -i 's/struct\snvgre_encap_conf\snvgre_encap_conf;/extern struct nvgre_encap_conf nvgre_encap_conf;/g' $(PARSE_PATH)/testpmd.h
 	sed -i 's/struct\svxlan_encap_conf\svxlan_encap_conf;/extern struct vxlan_encap_conf vxlan_encap_conf;/g' $(PARSE_PATH)/testpmd.h
-ifeq ($(shell [ -n "$(RTE_VER_YEAR)" ] && ( ( [ "$(RTE_VER_YEAR)" -ge 18 ] && [ "$(RTE_VER_MONTH)" -ge 11 ] ) || [ $(RTE_VER_YEAR) -ge 19 ] ) && echo true),true)
+endif
+# Between DPDK 18.11 and 19.08 these structs need to be declared as external in testpmd.h. DPDK 19.11 solves this issue :)
+ifeq ($(shell [ -n $(RTE_VER_YEAR) ] && ( ( [ $(RTE_VER_YEAR) -eq 18 ] && [ $(RTE_VER_MONTH) -ge 11 ] ) || ( [ $(RTE_VER_YEAR) -eq 19 ] && [ $(RTE_VER_MONTH) -le 08 ] ) ) && echo true),true)
+	# Deal with .h
 	sed -i 's/struct\sl2_decap_conf\sl2_decap_conf;/extern struct l2_decap_conf l2_decap_conf;/g' $(PARSE_PATH)/testpmd.h
 	sed -i 's/struct\sl2_encap_conf\sl2_encap_conf;/extern struct l2_encap_conf l2_encap_conf;/g' $(PARSE_PATH)/testpmd.h
 	sed -i 's/struct\smplsogre_decap_conf\smplsogre_decap_conf;/extern struct mplsogre_decap_conf mplsogre_decap_conf;/g' $(PARSE_PATH)/testpmd.h
 	sed -i 's/struct\smplsogre_encap_conf\smplsogre_encap_conf;/extern struct mplsogre_encap_conf mplsogre_encap_conf;/g' $(PARSE_PATH)/testpmd.h
 	sed -i 's/struct\smplsoudp_decap_conf\smplsoudp_decap_conf;/extern struct mplsoudp_decap_conf mplsoudp_decap_conf;/g' $(PARSE_PATH)/testpmd.h
 	sed -i 's/struct\smplsoudp_encap_conf\smplsoudp_encap_conf;/extern struct mplsoudp_encap_conf mplsoudp_encap_conf;/g' $(PARSE_PATH)/testpmd.h
+	# Deal with .c
+	sed -i '133i struct l2_decap_conf l2_decap_conf;' $(PARSE_PATH)/testpmd.c
+	sed -i '134i struct l2_encap_conf l2_encap_conf;' $(PARSE_PATH)/testpmd.c
+	sed -i '135i struct mplsogre_decap_conf mplsogre_decap_conf;' $(PARSE_PATH)/testpmd.c
+	sed -i '136i struct mplsogre_encap_conf mplsogre_encap_conf;' $(PARSE_PATH)/testpmd.c
+	sed -i '137i struct mplsoudp_decap_conf mplsoudp_decap_conf;' $(PARSE_PATH)/testpmd.c
+	sed -i '138i struct mplsoudp_encap_conf mplsoudp_encap_conf;' $(PARSE_PATH)/testpmd.c
 endif
 	touch $(PARSE_PATH)/.sentinel
 
@@ -474,27 +484,27 @@ PARSE_OBJS = \
 	test-pmd/rxonly.o \
 
 # Additional object files, present at or after DPDK v17.11 but not at or after 18.08
-ifeq ($(shell [ -n "$(RTE_VER_YEAR)" ] && ( ( [ $(RTE_VER_YEAR) -eq 17 ] && [ $(RTE_VER_MONTH) -ge 11 ] ) || ( [ $(RTE_VER_YEAR) -eq 18 ] && [ $(RTE_VER_MONTH) -lt 08 ] ) ) && echo true),true)
+ifeq ($(shell [ -n $(RTE_VER_YEAR) ] && ( ( [ $(RTE_VER_YEAR) -eq 17 ] && [ $(RTE_VER_MONTH) -ge 11 ] ) || ( [ $(RTE_VER_YEAR) -eq 18 ] && [ $(RTE_VER_MONTH) -lt 08 ] ) ) && echo true),true)
 PARSE_OBJS += test-pmd/tm.o
 endif
 
 # Additional object files, present at or after DPDK v17.11
-ifeq ($(shell [ -n "$(RTE_VER_YEAR)" ] && ( ( [ $(RTE_VER_YEAR) -eq 17 ] && [ $(RTE_VER_MONTH) -ge 11 ] ) || [ $(RTE_VER_YEAR) -ge 18 ] ) && echo true),true)
+ifeq ($(shell [ -n $(RTE_VER_YEAR) ] && ( ( [ $(RTE_VER_YEAR) -eq 17 ] && [ $(RTE_VER_MONTH) -ge 11 ] ) || [ $(RTE_VER_YEAR) -ge 18 ] ) && echo true),true)
 PARSE_OBJS += test-pmd/cmdline_mtr.o test-pmd/cmdline_tm.o
 endif
 
 # Additional object files, present at or after DPDK v18.05
-ifeq ($(shell [ -n "$(RTE_VER_YEAR)" ] && ( ( [ $(RTE_VER_YEAR) -eq 18 ] && [ $(RTE_VER_MONTH) -ge 05 ] ) || [ $(RTE_VER_YEAR) -ge 19 ] ) && echo true),true)
+ifeq ($(shell [ -n $(RTE_VER_YEAR) ] && ( ( [ $(RTE_VER_YEAR) -eq 18 ] && [ $(RTE_VER_MONTH) -ge 05 ] ) || [ $(RTE_VER_YEAR) -ge 19 ] ) && echo true),true)
 PARSE_OBJS += test-pmd/bpf_cmd.o
 endif
 
 # Additional object files, present at or after DPDK v18.08
-ifeq ($(shell [ -n "$(RTE_VER_YEAR)" ] && ( ( [ $(RTE_VER_YEAR) -eq 18 ] && [ $(RTE_VER_MONTH) -ge 08 ] ) || [ $(RTE_VER_YEAR) -ge 19 ] ) && echo true),true)
+ifeq ($(shell [ -n $(RTE_VER_YEAR) ] && ( ( [ $(RTE_VER_YEAR) -eq 18 ] && [ $(RTE_VER_MONTH) -ge 08 ] ) || [ $(RTE_VER_YEAR) -ge 19 ] ) && echo true),true)
 PARSE_OBJS += test-pmd/parameters.o test-pmd/softnicfwd.o
 endif
 
 # Additional object files, present at or after DPDK v18.11
-ifeq ($(shell [ -n "$(RTE_VER_YEAR)" ] && ( ( [ $(RTE_VER_YEAR) -eq 18 ] && [ $(RTE_VER_MONTH) -ge 11 ] ) || [ $(RTE_VER_YEAR) -ge 19 ] ) && echo true),true)
+ifeq ($(shell [ -n $(RTE_VER_YEAR) ] && ( ( [ $(RTE_VER_YEAR) -eq 18 ] && [ $(RTE_VER_MONTH) -ge 11 ] ) || [ $(RTE_VER_YEAR) -ge 19 ] ) && echo true),true)
 PARSE_OBJS += test-pmd/noisy_vnf.o test-pmd/util.o
 endif
 


### PR DESCRIPTION
New configuration parameters FLOW_DIR_ISOLATE in FromDPDKDevice.
If set != 0, this parameter guarantees that all ingress traffic
comes from defined flow rules only (current and future), thus
rendering PMD more deterministic. It can be configured only if the
device is in MODE flow_dir. Handlers are added in FromDPDKDevice to
read the current value of this parameter and reset it at will.

Fixed bug in FromDPDKDevice queue_count and queue_bytes handlers.

Impoved the documentation of FromDPDKDevice and ToDPDKDevice elements
by adding description for all configuration parameters and handlers.
Some parameters mentioned in FromDPDKDevice element belong to ToDPDKDevice,
therefore they are moved accordingly.

FlowDirector supports flow isolation through the abovementioned
FromDPDKDevice handler. Also, handler 'rules_list_with_hits' is
added to display only the rules that exhibit packet hits.
The output of handler 'rules_aggr_stats' is nicely formatted to
display per queue load balancing statistics as well as aggregate
statistics.

Signed-off-by: Georgios Katsikas <katsikas.gp@gmail.com>