### PR TITLE
Load tracking: Allows to compute the load of each thread

### DIFF
--- a/config-userlevel.h.in
+++ b/config-userlevel.h.in
@@ -29,6 +29,9 @@
 /* Define if you have the <byteswap.h> header file. */
 #undef HAVE_BYTESWAP_H
 
+/* Define if you have the CPU load cycles tracking function. */
+#undef HAVE_CLICK_LOAD
+
 /* Define if you have the clock_gettime function. */
 #undef HAVE_CLOCK_GETTIME
 

--- a/config.h.in
+++ b/config.h.in
@@ -77,6 +77,9 @@
 /* Define if Port::push/Port::pull should use bound function pointers. */
 #undef HAVE_BOUND_PORT_TRANSFER
 
+/* Define if compiled with heuristic for CPU load. */
+#undef HAVE_CLICK_LOAD
+
 /* Define if the C++ compiler understands constexpr. */
 #undef HAVE_CXX_CONSTEXPR
 

--- a/configure
+++ b/configure
@@ -868,6 +868,7 @@ enable_stats
 enable_stride
 enable_task_heap
 enable_task_stats
+enable_cpu_load
 enable_dmalloc
 enable_hash_iterator_epochs
 enable_force_expensive
@@ -1592,6 +1593,8 @@ Optional Features:
   --enable-task-heap      use heap for task list
   --enable-task-stats     Keep track of task statistics, used for automatic
                           balancing of tasks among threads
+  --enable-cpu-load       Keep track of CPU usage using an approximation.
+                          Useful when using polling keeping the CPU at 100%
   --enable-dmalloc        enable debugging malloc
   --enable-hash-iterator-epochs
                           hash iterator epochs
@@ -10924,6 +10927,18 @@ fi
 
 if test "x$enable_task_stats" = xyes; then
     $as_echo "#define HAVE_TASK_STATS 1" >>confdefs.h
+
+fi
+
+# Check whether --enable-cpu-load was given.
+if test "${enable_cpu_load+set}" = set; then :
+  enableval=$enable_cpu_load; :
+else
+  enable_cpu_load=no
+fi
+
+if test "x$enable_cpu_load" = xyes; then
+    $as_echo "#define HAVE_CLICK_LOAD 1" >>confdefs.h
 
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -1302,6 +1302,14 @@ if test "x$enable_task_stats" = xyes; then
     AC_DEFINE(HAVE_TASK_STATS)
 fi
 
+dnl click load
+AC_ARG_ENABLE([cpu-load],
+    [AS_HELP_STRING([--enable-cpu-load], [Keep track of CPU usage using an approximation. Useful when using polling keeping the CPU at 100%])],
+    [:], [enable_cpu_load=no])
+if test "x$enable_cpu_load" = xyes; then
+    AC_DEFINE(HAVE_CLICK_LOAD)
+fi
+
 dnl debugging malloc
 
 AC_ARG_ENABLE([dmalloc], [AS_HELP_STRING([--enable-dmalloc], [enable debugging malloc])], :, enable_dmalloc=no)

--- a/include/click/ewma.hh
+++ b/include/click/ewma.hh
@@ -4,6 +4,25 @@
 #include <click/confparse.hh>
 CLICK_DECLS
 
+template <unsigned alpha, unsigned shift>
+class EXPSMOOTH {
+    public:
+    unsigned val;
+
+    void update(unsigned obs) {
+        val = (obs * alpha + ((1 << shift) - alpha) * obs) >> shift;
+    }
+
+
+    unsigned unscaled_average() const {
+        return val;
+    }
+
+    unsigned average() const {
+        return val;
+    }
+};
+
 /** @file <click/ewma.hh>
  *  @brief  Click's classes for supporting exponentially weighted moving
  *  averages.

--- a/include/click/router.hh
+++ b/include/click/router.hh
@@ -84,6 +84,7 @@ class Router { public:
     static void add_write_handler(const Element *e, const String &hname, WriteHandlerCallback callback, void *user_data, uint32_t flags = 0);
     static void set_handler(const Element *e, const String &hname, uint32_t flags, HandlerCallback callback, void *read_user_data = 0, void *write_user_data = 0);
     static int set_handler_flags(const Element *e, const String &hname, uint32_t set_flags, uint32_t clear_flags = 0);
+    static int router_handler(int operation, String &data, Element *e, const Handler *handler, ErrorHandler *errh);
 
     enum { FIRST_GLOBAL_HANDLER = 0x40000000 };
     static int hindex(const Element *e, const String &hname);

--- a/lib/router.cc
+++ b/lib/router.cc
@@ -2432,7 +2432,7 @@ Router::configuration_string() const
     }
 }
 
-enum { GH_VERSION, GH_CONFIG, GH_FLATCONFIG, GH_LIST, GH_REQUIREMENTS,
+enum { GH_VERSION, GH_CONFIG, GH_FLATCONFIG, GH_LIST, GH_LOAD, GH_LOAD_CYCLES, GH_USEFUL_CYCLES, GH_REQUIREMENTS,
        GH_DRIVER, GH_ACTIVE_PORTS, GH_ACTIVE_PORT_STATS, GH_STRING_PROFILE,
        GH_STRING_PROFILE_LONG, GH_SCHEDULING_PROFILE, GH_STOP,
        GH_ELEMENT_CYCLES, GH_CLASS_CYCLES, GH_RESET_CYCLES };
@@ -2443,6 +2443,48 @@ struct stats_info {
     uint32_t task_calls, timer_calls, xfer_calls, nelements;
 };
 #endif
+
+
+int
+Router::router_handler(int operation, String &data, Element *e,
+			       const Handler *handler, ErrorHandler *errh) {
+    Router *r = (e ? e->router() : 0);
+    StringAccum sa;
+    int opt = reinterpret_cast<intptr_t>(handler->_read_user_data);
+    switch (opt) {
+ #if HAVE_CLICK_LOAD
+      case GH_LOAD:
+      case GH_LOAD_CYCLES:
+      case GH_USEFUL_CYCLES:
+          {
+        int index;
+        IntArg arg;
+        if (data && arg.parse(data, index, errh)) {
+            sa << r->master()->thread(index)->load();
+        } else {
+            int n = r->master()->nthreads();
+            for (int i = 0; i < n; i++) {
+                if (opt == GH_LOAD) {
+                    float l = r->master()->thread(i)->load();
+                    sa << (l == 0 ? "0" : String(r->master()->thread(i)->load()));
+                } else if (opt == GH_LOAD_CYCLES)
+                    sa << String(r->master()->thread(i)->load_cycles());
+                else
+                    sa << String(r->master()->thread(i)->useful_kcycles());
+                if (i < n - 1)
+                    sa << " ";
+            }
+        }
+        break;
+        }
+#endif
+        default:
+          data = "<error>";
+          return -1;
+    }
+    data = sa.take_string();
+    return 0;
+}
 
 String
 Router::router_read_handler(Element *e, void *thunk)
@@ -2666,6 +2708,11 @@ Router::static_initialize()
         add_read_handler(0, "requirements", router_read_handler, (void *)GH_REQUIREMENTS);
         add_read_handler(0, "handlers", Element::read_handlers_handler, 0);
         add_read_handler(0, "list", router_read_handler, (void *)GH_LIST);
+#if HAVE_CLICK_LOAD
+        set_handler(0, "load", Handler::h_read | Handler::f_read_param, router_handler, (void *)GH_LOAD, (void *)0);
+        set_handler(0, "load_cycles", Handler::h_read | Handler::f_read_param, router_handler, (void *)GH_LOAD_CYCLES, (void *)0);
+        set_handler(0, "useful_kcycles", Handler::h_read | Handler::f_read_param, router_handler, (void *)GH_USEFUL_CYCLES, (void *)0);
+#endif
         add_write_handler(0, "stop", router_write_handler, (void *)GH_STOP);
 #if CLICK_STATS >= 1
         add_read_handler(0, "active_ports", router_read_handler, (void *)GH_ACTIVE_PORTS);


### PR DESCRIPTION
By counting a proportion of useful cycles over all cycles spent in each
routerthreads. Then it is accessible through the load handler.

This allows to have a notion of load under polling with DPDK.

However it only works when context switching is very low/ each thread is assigned to a single core.