### PR TITLE
ARPQuerier: Add a per-core cache

### DIFF
--- a/elements/ethernet/arpquerier.hh
+++ b/elements/ethernet/arpquerier.hh
@@ -4,6 +4,7 @@
 #include <click/etheraddress.hh>
 #include <click/ipaddress.hh>
 #include <click/sync.hh>
+#include <click/hashtablemp.hh>
 #include <click/timer.hh>
 #include "arptable.hh"
 CLICK_DECLS
@@ -204,6 +205,7 @@ class ARPQuerier : public BatchElement { public:
     IPAddress _my_bcast_ip;
     uint32_t _poll_timeout_j;
     int _broadcast_poll;
+    bool _have_cache;
 
     // statistics
     atomic_uint32_t _arp_queries;
@@ -227,6 +229,7 @@ class ARPQuerier : public BatchElement { public:
     enum { h_table, h_table_xml, h_stats, h_insert, h_delete, h_clear,
 	   h_count, h_length };
 
+    per_thread<AgingTable<IPAddress,EtherAddress> > _cache;
 };
 
 CLICK_ENDDECLS

--- a/elements/test/hashtablemptest.cc
+++ b/elements/test/hashtablemptest.cc
@@ -1,0 +1,67 @@
+// -*- c-basic-offset: 4 -*-
+/*
+ * hashtabletest.{cc,hh} -- regression test element for HashTableMP<K, V>
+ * Tom Barbette
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
+#include <click/config.h>
+#include "hashtablemptest.hh"
+#include <click/hashtablemp.hh>
+#include <click/error.hh>
+#include <click/etheraddress.hh>
+#include <click/ipaddress.hh>
+#if CLICK_USERLEVEL
+# include <sys/time.h>
+# include <sys/resource.h>
+# include <unistd.h>
+#endif
+CLICK_DECLS
+
+HashTableMPTest::HashTableMPTest()
+{
+}
+
+#define CHECK(x) if (!(x)) return errh->error("%s:%d: test `%s' failed", __FILE__, __LINE__, #x);
+#define CHECK_DATA(x, y, l) CHECK(memcmp((x), (y), (l)) == 0)
+
+int
+HashTableMPTest::initialize(ErrorHandler *errh)
+{
+
+	AgingTable<IPAddress, EtherAddress, int> cache(10);
+	IPAddress ip = IPAddress("10.0.0.1");
+	EtherAddress eth;
+	EtherAddressArg().parse("aa:bb:cc:dd:ee:ff",eth);
+	cache.insert(ip, 1, eth);
+	CHECK(cache.size() == 1);
+
+	EtherAddress lookup;
+	CHECK(cache.find(ip,1,lookup,false));
+	CHECK(lookup == eth);
+	CHECK(cache.find(ip,10,lookup,false));
+	CHECK(cache.size() == 1);
+	CHECK(!cache.find(ip,12,lookup));
+	CHECK(cache.size() == 0);
+
+	cache.insert(ip, 21, eth);
+	CHECK(cache.size() == 1);
+	CHECK(cache.find(ip,30,lookup,true));
+	CHECK(cache.find(ip,32,lookup,true));
+	CHECK(cache.size() == 1);
+
+    errh->message("All tests pass!");
+    return 0;
+}
+
+EXPORT_ELEMENT(HashTableMPTest)
+CLICK_ENDDECLS

--- a/elements/test/hashtablemptest.hh
+++ b/elements/test/hashtablemptest.hh
@@ -1,0 +1,34 @@
+// -*- c-basic-offset: 4 -*-
+#ifndef CLICK_HASHTABLEMPTEST_HH
+#define CLICK_HASHTABLEMPTEST_HH
+#include <click/element.hh>
+CLICK_DECLS
+
+/*
+=c
+
+HashTableMPTest()
+
+=s test
+
+runs regression tests for HashTable<K, V>
+
+=d
+
+HashTableMPTest runs HashTable regression tests at initialization time. It
+does not route packets.
+
+*/
+
+class HashTableMPTest : public Element { public:
+
+    HashTableMPTest() CLICK_COLD;
+
+    const char *class_name() const		{ return "HashTableMPTest"; }
+
+    int initialize(ErrorHandler *) CLICK_COLD;
+
+};
+
+CLICK_ENDDECLS
+#endif

--- a/test/standard/hashtablemp-01.testie
+++ b/test/standard/hashtablemp-01.testie
@@ -1,0 +1,15 @@
+%info
+Tests hash table functionality with the HashTableMPTest element.
+
+%require
+click-buildtool provides HashTableMPTest
+
+%script
+click -qe 'HashTableMPTest'
+
+%expect stderr
+config:1:{{.*}}
+  All tests pass!
+
+%ignore stderr
+  Time: {{.*}}


### PR DESCRIPTION
A huge problem to solve in Click that stayed there way too long...
Concurrent access through ARPQuerier use synchronized access to a common table. (A
spinlock!!!). So we keep a per-core cache, which supports exhaustion
using the new AgeingTable. Makes things much much more faster ;)

Also this is the first use of the AgeingTable(MP is also available), that transparently implements lazy ageing.