### PR TITLE
FlowIPManager: Add LF mode

### DIFF
--- a/elements/flow/flowipmanager.cc
+++ b/elements/flow/flowipmanager.cc
@@ -1,5 +1,5 @@
 /*
- * FlowIPManager.{cc,hh} - Flow classification for the flow subsystem
+ * flowipmanager.{cc,hh} - Flow classification for the flow subsystem
  *
  * Copyright (c) 2019-2020 Tom Barbette, KTH Royal Institute of Technology
  *
@@ -41,11 +41,11 @@ FlowIPManager::configure(Vector<String> &conf, ErrorHandler *errh)
     bool lf = false;
 
     if (Args(conf, this, errh)
-            .read_or_set_p("CAPACITY", _table_size, 65536)
-            .read_or_set("RESERVE",_reserve, 0)
-            .read_or_set("TIMEOUT", _timeout, 60)
-            .read_or_set("LF", lf, false)
-            .complete() < 0)
+        .read_or_set_p("CAPACITY", _table_size, 65536)
+        .read_or_set("RESERVE",_reserve, 0)
+        .read_or_set("TIMEOUT", _timeout, 60)
+        .read_or_set("LF", lf, false)
+        .complete() < 0)
         return -1;
 
     find_children(_verbose);

--- a/elements/flow/flowipmanager.cc
+++ b/elements/flow/flowipmanager.cc
@@ -38,11 +38,14 @@ FlowIPManager::~FlowIPManager()
 int
 FlowIPManager::configure(Vector<String> &conf, ErrorHandler *errh)
 {
+    bool lf = false;
+
     if (Args(conf, this, errh)
-        .read_or_set_p("CAPACITY", _table_size, 65536)
-        .read_or_set("RESERVE",_reserve, 0)
-        .read_or_set("TIMEOUT", _timeout, 60)
-        .complete() < 0)
+            .read_or_set_p("CAPACITY", _table_size, 65536)
+            .read_or_set("RESERVE",_reserve, 0)
+            .read_or_set("TIMEOUT", _timeout, 60)
+            .read_or_set("LF", lf, false)
+            .complete() < 0)
         return -1;
 
     find_children(_verbose);
@@ -53,6 +56,11 @@ FlowIPManager::configure(Vector<String> &conf, ErrorHandler *errh)
     if (!is_pow2(_table_size)) {
         _table_size = next_pow2(_table_size);
         click_chatter("Real capacity will be %d",_table_size);
+    }
+
+    if (lf) {
+        _flags &= ~RTE_HASH_EXTRA_FLAGS_RW_CONCURRENCY;
+        _flags |= ~RTE_HASH_EXTRA_FLAGS_RW_CONCURRENCY_LF;
     }
     return 0;
 }
@@ -82,11 +90,13 @@ int FlowIPManager::initialize(ErrorHandler *errh)
 
     if (_timeout > 0) {
         _timer_wheel.initialize(_timeout);
+
+        _timer.initialize(this);
+        _timer.schedule_after(Timestamp::make_sec(1));
+        _task.initialize(this, false);
+
     }
 
-    _timer.initialize(this);
-    _timer.schedule_after(Timestamp::make_sec(1));
-    _task.initialize(this, false);
     return 0;
 }
 


### PR DESCRIPTION
Add LF mode to FlowIPManagerMP to add lock-free concurrency mode.

In practice it is done in FlowIPManager, as FlowIPMangerMP has no configuration.