### PR TITLE
Major Metron upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The [Metron controller][metron-ctrl] is released as an ONOS application.
 Metron Protocol
 ----
 Metron agents are managed by the Metron controller via a REST-based protocol.
-The management operations include resource advertisement, monitoring, service chain deployment, service chain reconfiguration (i.e., for load balancing), service chain removal, as well as NIC rule management operations (i.e., NIC rule installation, reporting, and deletion).
+The management operations include system resource advertisement & monitoring (i.e., CPUs, CPU caches, main memory, and NICs), service chain deployment, service chain reconfiguration (i.e., for load balancing), service chain removal, as well as NIC management operations (i.e., NIC rule installation/reporting/deletion, NIC port and queue management, etc).
 The protocol that prescribes this communication between the Metron controller and Metron agents is detailed in [this][metron-tutorial] tutorial.
 
 

--- a/conf/metron/metron-dispatcher-flow-legacy-af-pkt.click
+++ b/conf/metron/metron-dispatcher-flow-legacy-af-pkt.click
@@ -103,7 +103,7 @@ DriverManager(
 	print $(fd1.rules_aggr_stats),
 	print "",
 	print "Flushing rules...",
-	write metron.flush_nics,
+	write metron.rules_flush,
 	print "    Done!",
 	print "",
 	print "Minimum rule installation rate: "$(metron.rule_installation_rate_min fd0)" rules/sec",

--- a/conf/metron/metron-dispatcher-flow-legacy-af-xdp.click
+++ b/conf/metron/metron-dispatcher-flow-legacy-af-xdp.click
@@ -104,7 +104,7 @@ DriverManager(
 	print $(fd1.rules_aggr_stats),
 	print "",
 	print "Flushing rules...",
-	write metron.flush_nics,
+	write metron.rules_flush,
 	print "    Done!",
 	print "",
 	print "Minimum rule installation rate: "$(metron.rule_installation_rate_min fd0)" rules/sec",

--- a/conf/metron/metron-dispatcher-flow.click
+++ b/conf/metron/metron-dispatcher-flow.click
@@ -94,7 +94,7 @@ DriverManager(
 	print $(fd1.rules_aggr_stats),
 	print "",
 	print "Flushing rules...",
-	write metron.flush_nics,
+	write metron.rules_flush,
 	print "    Done!",
 	print "",
 	print "Minimum rule installation rate: "$(metron.rule_installation_rate_min fd0)" rules/sec",

--- a/elements/test/stringtest.cc
+++ b/elements/test/stringtest.cc
@@ -120,7 +120,7 @@ StringTest::initialize(ErrorHandler *errh)
     CHECK(String("HELLO;YOU").erase(9, 1) == "HELLO;YOU");
     CHECK(String("HELLO;YOU").erase(String::npos, 3) == "HELLO;YOU");
     CHECK(String("HELLO;YOU").erase() == empty);               // Defaults to the whole string
-    String s("HELLO;YOU");
+    s = "HELLO;YOU";
     String s1("I;AM;FINE;DUDE");
     s = s.erase();
     CHECK(s == empty);

--- a/elements/test/stringtest.cc
+++ b/elements/test/stringtest.cc
@@ -1,9 +1,9 @@
 // -*- c-basic-offset: 4 -*-
 /*
  * stringtest.{cc,hh} -- regression test element for String
- * Tom Barbette
+ * Tom Barbette and Georgios Katsikas
  *
- * Copyright (c) 2018 KTH Royal Institute of Technology
+ * Copyright (c) 2018-2019 KTH Royal Institute of Technology
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -19,10 +19,8 @@
 #include <click/config.h>
 #include "stringtest.hh"
 #include <click/glue.hh>
-#include <click/string.hh>
 #include <click/straccum.hh>
 #include <click/error.hh>
-#include <click/vector.hh>
 CLICK_DECLS
 
 
@@ -38,7 +36,7 @@ StringTest::initialize(ErrorHandler *errh)
     String empty = "";
     CHECK(empty == String::make_empty());
 
-    //Split test
+    // Split test
     CHECK(empty.split(';').size() == 0);
     CHECK(String("HELLO").split(';').size() == 1);
     CHECK(String("HELLO").split(';')[0] == "HELLO");
@@ -46,6 +44,13 @@ StringTest::initialize(ErrorHandler *errh)
     CHECK(String("HELLO;YOU").split(';')[0] == "HELLO");
     CHECK(String("HELLO;YOU").split(';')[1] == "YOU");
 
+    // Split with multiple delimiters
+    CHECK(String("").split(";").size() == 0);
+    CHECK(String("HELLO;YOU").split("").size() == 0);
+    CHECK(String("HI;HOW#ARE;YOU$DOING%BRO? I;AM#FINE,YOU?").split(";").size() == 4);
+    CHECK(String("HI;HOW#ARE;YOU$DOING%BRO? I;AM#FINE,YOU?").split(";#").size() == 6);
+
+    // Search tests
     String s;
     CHECK(s.length() == 0);
 
@@ -56,6 +61,7 @@ StringTest::initialize(ErrorHandler *errh)
     CHECK(s.search("!") == s.data() + s.length() - 1);
     CHECK(String("").search("!") == 0);
 
+    // Vector split test
     s = "a simple string";
     Vector<String> v = s.split(' ');
     CHECK(v.size() == 3);
@@ -63,15 +69,83 @@ StringTest::initialize(ErrorHandler *errh)
     CHECK(v[1] == "simple");
     CHECK(v[2] == "string");
 
+    // Find tests
+    CHECK(empty.find_left(';') == String::npos);
+    CHECK(String("HELLO").find_left(';') == String::npos);
+    CHECK(String("HELLO;YOU").find_left(';') == 5);
+    CHECK(String("HELLO;YOU").find_left('L') == 2);
+    CHECK(String("HELLO;YOU").find_left("L") == 2);
+    CHECK(String("HELLO;YOU").find_left("L", 3) == 3);
+    CHECK(String("HELLO;YOU").find_left("L", 4) == String::npos);
 
-    CHECK(s.replace("simple", "complex") == "a complex string");
-    CHECK(String("").replace("a", "b") == "");
+    CHECK(empty.find_right(';') == String::npos);
+    CHECK(String("HELLO;YOU").find_right('L') == 3);
+    CHECK(String("HELLO;YOU").find_right('L', 4) == 3);
+    CHECK(String("HELLO;YOU").find_right('L', 1) == String::npos);
+
+    CHECK(empty.find_first_of(";") == String::npos);
+    CHECK(String("HELLO;YOU").find_first_of("L") == 2);
+    CHECK(String("HELLO;YOU").find_first_of("LEH") == 0);
+    CHECK(String("HELLO;YOU").find_first_of("U") == 8);
+    CHECK(String("HELLO;YOU").find_first_of("L", 4) == String::npos);
+    CHECK(String("HELLO;YOU").find_first_of((const char *) "U;") == 5);
+    CHECK(String("HELLO;YOU").find_first_of((const String &) "U;") == 5);
+
+    CHECK(empty.find_first_not_of(";") == String::npos);
+    CHECK(String("HELLO;YOU").find_first_not_of("HELA") == 4);
+    CHECK(String("HELLO;YOU").find_first_not_of("HELLO") == 5);
+    CHECK(String("HELLO;YOU").find_first_not_of((const char *) "HELLO;YO") == 8);
+    CHECK(String("HELLO;YOU").find_first_not_of((const String &) "HELLO;YO") == 8);
+
+    CHECK(empty.find_last_of(';') == String::npos);
+    CHECK(String("HELLO;YOU").find_last_of('L') == 3);
+    CHECK(String("HELLO;YOU").find_last_of('O') == 7);
+    CHECK(String("HELLO;YOU").find_last_of('L', 1) == String::npos);
+    CHECK(String("HELLO;YOU").find_last_of('O', 3) == String::npos);
+    CHECK(String("HELLO;YOU").find_last_of('U', 7) == String::npos);
+    CHECK(String("HELLO;YOU").find_last_of('U', -2) == 8);
+
+    CHECK(empty.find_last_not_of(";") == String::npos);
+    CHECK(String("HELLO;YOU").find_last_not_of("HELLO") == 8);
+    CHECK(String("HELLO;YOU").find_last_not_of("HELLO", 7) == 6);
+    CHECK(String("HELLO;YOU").find_last_not_of("HELLO", 9) == 8);
+
+    // Erase tests
+    CHECK(empty.erase(0, 3) == String::make_empty());
+    CHECK(String("HELLO;YOU").erase(5, 4) == "HELLO");
+    CHECK(String("HELLO;YOU").erase(0, 6) == "YOU");
+    CHECK(String("HELLO;YOU").erase(0, 5).erase(1, 3) == ";");
+    CHECK(String("HELLO;YOU").erase(8, 2) == "HELLO;YO");      // 2 gets adjusted to 1
+    CHECK(String("HELLO;YOU").erase(8, 0) == "HELLO;YOU");
+    CHECK(String("HELLO;YOU").erase(9, 1) == "HELLO;YOU");
+    CHECK(String("HELLO;YOU").erase(String::npos, 3) == "HELLO;YOU");
+    CHECK(String("HELLO;YOU").erase() == empty);               // Defaults to the whole string
+    String s("HELLO;YOU");
+    String s1("I;AM;FINE;DUDE");
+    s = s.erase();
+    CHECK(s == empty);
+    s1 = s1.erase();
+    CHECK(s1 == empty);
+    CHECK(s == s1);
+
+    // Pop back (effectively uses erase)
+    empty.pop_back();
+    CHECK(empty == String::make_empty());
+    String s2("HELLO;YOU");
+    String s3("I;AM;FINE;DUDE");
+    s2.pop_back();
+    CHECK(s2 == "HELLO;YO");
+    s2.clear();
+    CHECK(s2 == empty);
+    s3.clear();
+    CHECK(s3 == empty);
+    CHECK(s2 == s3);
 
     if (!errh->nerrors()) {
-    	errh->message("All tests pass!");
-		return 0;
+        errh->message("All tests pass!");
+        return 0;
     } else
-    	return -1;
+        return -1;
 }
 
 EXPORT_ELEMENT(StringTest)

--- a/elements/userlevel/fromdpdkdevice.hh
+++ b/elements/userlevel/fromdpdkdevice.hh
@@ -91,18 +91,18 @@ Integer. The maximum transfer unit of the device.
 =item MODE
 
 String. The device's Rx mode. Can be none, rss, vmdq, vmdq_rss,
-vmdq_dcb, vmdq_dcb_rss. For DPDK version >= 17.05, flow_dir is also
+vmdq_dcb, vmdq_dcb_rss. For DPDK version >= 17.05, flow is also
 supported.
 
 =item FLOW_RULES_FILE
 
-String. For DPDK version >= 17.05, if MODE is set to flow_dir, a path to
-a file with Flow Director rules can be supplied to the device.
-These rules are installed in the NIC using DPDK's flow API.
+String. For DPDK version >= 17.05, if MODE is set to flow, a path to
+a file with flow rules can be supplied to the device.
+These rules are installed in the NIC using DPDK's Flow API.
 
 =item FLOW_ISOLATE
 
-Boolean. Requires MODE flow_disp. Isolated mode guarantees that all ingress
+Boolean. Requires MODE flow. Isolated mode guarantees that all ingress
 traffic comes from defined flow rules only (current and future).
 If ingress traffic does not match any of the defined rules, it will be
 discarded by the NIC. Defaults to false.

--- a/elements/userlevel/metron.cc
+++ b/elements/userlevel/metron.cc
@@ -4,9 +4,8 @@
  * (re)configures NFV service chains driven by a remote
  * controller
  *
- * Copyright (c) 2017 Tom Barbette, University of Liège
- * Copyright (c) 2017 Georgios Katsikas, RISE SICS and
- *                    KTH Royal Institute of Technology
+ * Copyright (c) 2017 Tom Barbette, University of Liège and KTH Royal Institute of Technology
+ * Copyright (c) 2017 Georgios Katsikas, KTH Royal Institute of Technology and RISE
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -30,7 +29,6 @@
 #include <signal.h>
 #include <limits>
 
-#include "fromdpdkdevice.hh"
 #include "todpdkdevice.hh"
 #include "metron.hh"
 
@@ -67,6 +65,184 @@ supported_types(const char **array)
 }
 
 /**
+ * Parses input string and returns information after key.
+ */
+static String
+parse_info(const String &hw_info, const String &key)
+{
+    String s;
+
+    s = hw_info.substring(hw_info.find_left(key) + key.length());
+    int pos = s.find_left(':') + 2;
+    s = s.substring(pos, s.find_left("\n") - pos);
+
+    return s;
+}
+
+
+/**
+ * Array of all CPU vendors.
+ */
+static const char *CPU_VENDORS_STR_ARRAY[] = { CPU_VENDORS };
+
+/**
+ * Converts an enum-based CPU vendor into string.
+ */
+const String
+cpu_vendor_enum_to_str(const CpuVendor &c)
+{
+    String vendor_str = String(CPU_VENDORS_STR_ARRAY[static_cast<uint8_t>(c)]);
+    vendor_str = vendor_str.lower().camel();
+    int pos = vendor_str.find_left('_');
+    return vendor_str.erase(pos, 1);
+}
+
+/**
+ * Converts a string-based CPU vendor into enum.
+ */
+CpuVendor
+cpu_vendor_str_to_enum(const String &c)
+{
+    const uint8_t n = sizeof(CPU_VENDORS_STR_ARRAY) /
+                      sizeof(CPU_VENDORS_STR_ARRAY[0]);
+    for (uint8_t i = 0; i < n; ++i) {
+        Vector<String> tok = String(CPU_VENDORS_STR_ARRAY[i]).split('_');
+        String cand = tok[0] + tok[1];
+
+        if (strcmp(cand.upper().c_str(), c.upper().c_str()) == 0) {
+            return (CpuVendor) i;
+        }
+    }
+    return UNKNOWN_VENDOR;
+}
+
+
+/**
+ * Array of all supported CPU cache types.
+ */
+static const char *CPU_CACHE_TYPES_STR_ARRAY[] = { CPU_CACHE_TYPES };
+
+/**
+ * Converts an enum-based CPU cache type into string.
+ */
+const String
+cpu_cache_type_enum_to_str(const CpuCacheType &c)
+{
+    return String(CPU_CACHE_TYPES_STR_ARRAY[static_cast<uint8_t>(c)]).lower().camel();
+}
+
+/**
+ * Converts a string-based CPU cache type into enum.
+ */
+CpuCacheType
+cpu_cache_type_str_to_enum(const String &c)
+{
+    const uint8_t n = sizeof(CPU_CACHE_TYPES_STR_ARRAY) /
+                      sizeof(CPU_CACHE_TYPES_STR_ARRAY[0]);
+    for (uint8_t i = 0; i < n; ++i) {
+        if (strcmp(CPU_CACHE_TYPES_STR_ARRAY[i], c.c_str()) == 0) {
+            return (CpuCacheType) i;
+        }
+    }
+    return UNKNOWN_CACHE_TYPE;
+}
+
+
+/**
+ * Array of all supported CPU cache levels.
+ */
+static const char *CPU_CACHE_LEVELS_STR_ARRAY[] = { CPU_CACHE_LEVELS };
+
+/**
+ * Converts an enum-based CPU cache level into string.
+ */
+const String
+cpu_cache_level_enum_to_str(const CpuCacheLevel &c)
+{
+    return String(CPU_CACHE_LEVELS_STR_ARRAY[static_cast<uint8_t>(c)]).upper();
+}
+
+/**
+ * Converts a string-based CPU cache level into enum.
+ */
+CpuCacheLevel
+cpu_cache_level_str_to_enum(const String &c)
+{
+    const uint8_t n = sizeof(CPU_CACHE_LEVELS_STR_ARRAY) /
+                      sizeof(CPU_CACHE_LEVELS_STR_ARRAY[0]);
+    for (uint8_t i = 0; i < n; ++i) {
+        if (strcmp(CPU_CACHE_LEVELS_STR_ARRAY[i], c.c_str()) == 0) {
+            return (CpuCacheLevel) i;
+        }
+    }
+    return UNKNOWN_LEVEL;
+}
+
+
+/**
+ * Array of all supported CPU cache policies.
+ */
+static const char *CPU_CACHE_POLICIES_STR_ARRAY[] = { CPU_CACHE_POLICIES };
+
+/**
+ * Converts an enum-based CPU cache policy into string.
+ */
+const String
+cpu_cache_policy_enum_to_str(const CpuCachePolicy &c)
+{
+    String policy_str = String(CPU_CACHE_POLICIES_STR_ARRAY[static_cast<uint8_t>(c)]);
+    return policy_str.lower().camel().replace('_', '-');
+}
+
+/**
+ * Converts a string-based CPU cache policy into enum.
+ */
+CpuCachePolicy
+cpu_cache_policy_str_to_enum(const String &c)
+{
+    const uint8_t n = sizeof(CPU_CACHE_POLICIES_STR_ARRAY) /
+                      sizeof(CPU_CACHE_POLICIES_STR_ARRAY[0]);
+    for (uint8_t i = 0; i < n; ++i) {
+        if (strcmp(CPU_CACHE_POLICIES_STR_ARRAY[i], c.c_str()) == 0) {
+            return (CpuCachePolicy) i;
+        }
+    }
+    return UNKNOWN_POLICY;
+}
+
+
+/**
+ * Array of all supported memory types.
+ */
+static const char *MEMORY_TYPES_STR_ARRAY[] = { MEMORY_TYPES };
+
+/**
+ * Converts an enum-based memory type into string.
+ */
+const String
+memory_type_enum_to_str(const MemoryType &m)
+{
+    return String(MEMORY_TYPES_STR_ARRAY[static_cast<uint8_t>(m)]).upper();
+}
+
+/**
+ * Converts a string-based memory type into enum.
+ */
+MemoryType
+memory_type_str_to_enum(const String &m)
+{
+    const uint8_t n = sizeof(MEMORY_TYPES_STR_ARRAY) /
+                      sizeof(MEMORY_TYPES_STR_ARRAY[0]);
+    for (uint8_t i = 0; i < n; ++i) {
+        if (strcmp(MEMORY_TYPES_STR_ARRAY[i], m.c_str()) == 0) {
+            return (MemoryType) i;
+        }
+    }
+    return UNKNOWN_MEMORY_TYPE;
+}
+
+
+/**
  * Array of all supported service chain types.
  */
 static const char *SC_TYPES_STR_ARRAY[] = { SC_CONF_TYPES };
@@ -95,6 +271,7 @@ sc_type_str_to_enum(const String &sc_type)
     }
     return UNKNOWN;
 }
+
 
 /**
  * Array of all supported Rx filter types.
@@ -126,38 +303,1396 @@ rx_filter_type_str_to_enum(const String &rf_str)
     return NONE;
 }
 
+
+/******************************
+ * PlatformInfo
+ ******************************/
 /**
- * Parses input string and returns information after key.
+ * PlatformInfo constructors.
  */
-static String
-parse_vendor_info(const String &hw_info, const String &key)
+PlatformInfo::PlatformInfo() : _hw_info(), _sw_info(), _serial_nb(),_chassis_id()
+{}
+
+PlatformInfo::PlatformInfo(String hw, String sw, String serial, String chassis) :
+    _hw_info(hw), _sw_info(sw), _serial_nb(serial), _chassis_id(chassis)
+{}
+
+/**
+ * PlatformInfo destructor.
+ */
+PlatformInfo::~PlatformInfo()
+{}
+
+/**
+ * Prints platform information.
+ */
+void
+PlatformInfo::print()
 {
-    String s;
+    click_chatter("     H/W info: %s", get_hw_info().c_str());
+    click_chatter("     S/W info: %s", get_sw_info().c_str());
+    click_chatter("Serial number: %s", get_serial_number().c_str());
+    click_chatter("   Chassis ID: %s", get_chassis_id().c_str());
+}
 
-    s = hw_info.substring(hw_info.find_left(key) + key.length());
-    int pos = s.find_left(':') + 2;
-    s = s.substring(pos, s.find_left("\n") - pos);
+/******************************
+ * LatencyStats
+ ******************************/
+/**
+ * LatencyStats constructor.
+ */
+LatencyStats::LatencyStats() : _avg_throughput(0), _min_latency(0),
+                               _avg_latency(0), _max_latency(0)
+{}
 
-    return s;
+/**
+ * LatencyStats destructor.
+ */
+LatencyStats::~LatencyStats()
+{}
+
+void
+LatencyStats::print()
+{
+    click_chatter("\n");
+    click_chatter("Average Throughput: %" PRIu64 " Mbps", _avg_throughput);
+    click_chatter("Minimum    Latency: %" PRIu64 " nsec", _min_latency);
+    click_chatter("Average    Latency: %" PRIu64 " nsec", _avg_latency);
+    click_chatter("Maximum    Latency: %" PRIu64 " nsec", _max_latency);
+}
+
+/******************************
+ * CPUStats
+ ******************************/
+/**
+ * CPUStats constructor.
+ */
+CPUStats::CPUStats() : _physical_id(-1), _load(0.0f), _max_nic_queue(0),
+                                   _latency(), _active(false), _active_time()
+{}
+
+/**
+ * CPUStats operator =.
+ */
+CPUStats &
+CPUStats::operator=(CPUStats &r)
+{
+    _physical_id = r.get_physical_id();
+    _load = r.get_load();
+    _max_nic_queue = r.get_max_nic_queue();
+    _latency = r.get_latency();
+    _active = r.is_active();
+    _active_time = r.get_active_time();
+
+    return *this;
+}
+
+/**
+ * CPUStats destructor.
+ */
+CPUStats::~CPUStats()
+{}
+
+/**
+ * Retunrs the activity time of a CPU.
+ */
+int
+CPUStats::active_since()
+{
+    int cpu_time;
+    if (_active) {
+        cpu_time = (Timestamp::now_steady() - _active_time).msecval();
+    } else {
+        cpu_time = -(Timestamp::now_steady() - _active_time).msecval();
+    }
+    return cpu_time;
+}
+
+/**
+ * Prints CPU statistics.
+ */
+void
+CPUStats::print()
+{
+    if (!is_assigned()) {
+        return;
+    }
+
+    click_chatter("         CPU  Status: %s", _active ? "active" : "inactive");
+    click_chatter("         CPU    Load: %f%%", _load);
+    click_chatter("   Maximum NIC Queue: %d", _max_nic_queue);
+
+    _latency.print();
+}
+
+/******************************
+ * CPU
+ ******************************/
+/**
+ * CPU constructor.
+ */
+CPU::CPU(int phy_id, int log_id, int socket,
+        String vendor, long frequency) : _stats()
+{
+    assert(phy_id >= 0);
+    assert(log_id >= 0);
+    assert(socket >= 0);
+    assert((vendor) && (!vendor.empty()));
+    assert(frequency > 0);
+    _physical_id = phy_id;
+    _logical_id = log_id;
+    _socket = socket;
+    _vendor = vendor;
+    _frequency = frequency;
+}
+
+/**
+ * CPU destructor.
+ */
+CPU::~CPU()
+{}
+
+/**
+ * Print CPU information.
+ */
+void
+CPU::print()
+{
+    click_chatter("\n");
+    click_chatter("Physical CPU core ID: %d", _physical_id);
+    click_chatter(" Logical CPU core ID: %d", _logical_id);
+    click_chatter("       CPU Socket ID: %d", _socket);
+    click_chatter("       CPU    Vendor: %s", _vendor.c_str());
+    click_chatter("       CPU Frequency: %ld MHz", _frequency);
+
+    _stats.print();
+}
+
+/**
+ * Encodes CPU information to JSON.
+ */
+Json
+CPU::to_json()
+{
+    Json cpu = Json::make_object();
+
+    cpu.set("physicalId", get_physical_id());
+    cpu.set("logicalId", get_logical_id());
+    cpu.set("socket", get_socket());
+    cpu.set("vendor", get_vendor());
+    cpu.set("frequency", get_frequency());
+
+    return cpu;
+}
+
+/******************************
+ * CPU Cache ID
+ ******************************/
+/**
+ * CpuCacheId constructors.
+ */
+CpuCacheId::CpuCacheId(CpuCacheLevel level, CpuCacheType type)
+{
+    assert(level != UNKNOWN_LEVEL);
+    assert(type != UNKNOWN_CACHE_TYPE);
+    _level = level;
+    _type = type;
+}
+
+CpuCacheId::CpuCacheId(String level_str, String type_str) :
+    CpuCacheId(
+        cpu_cache_level_str_to_enum(level_str.upper()),
+        cpu_cache_type_str_to_enum(type_str.upper())
+    )
+{}
+
+/**
+ * CpuCacheId destructor.
+ */
+CpuCacheId::~CpuCacheId()
+{}
+
+
+/******************************
+ * CPU Cache
+ ******************************/
+/**
+ * CpuCache constructors.
+ */
+CpuCache::CpuCache(CpuCacheLevel level, CpuCacheType type,
+                   CpuCachePolicy policy, CpuVendor vendor,
+                   long capacity, int sets, int ways, int line_length, bool shared)
+{
+    assert(policy != UNKNOWN_POLICY);
+    assert(vendor != UNKNOWN_VENDOR);
+    assert(capacity > 0);
+    assert(sets > 0);
+    assert(line_length > 0);
+    assert(ways > 0);
+    _cache_id = new CpuCacheId(level, type);
+    _policy = policy;
+    _vendor = vendor;
+    _capacity = capacity;
+    _sets = sets;
+    _ways = ways;
+    _line_length = line_length;
+    _shared = shared;
+}
+
+CpuCache::CpuCache(
+    String level_str, String type_str, String policy_str, String vendor_str,
+    long capacity, int sets, int ways, int line_length, bool shared) :
+    CpuCache(
+        cpu_cache_level_str_to_enum(level_str.upper()),
+        cpu_cache_type_str_to_enum(type_str.upper()),
+        cpu_cache_policy_str_to_enum(policy_str.upper()),
+        cpu_vendor_str_to_enum(vendor_str.upper()),
+        capacity, sets, ways, line_length, shared
+    )
+{
+}
+
+/**
+ * CpuCache destructor.
+ */
+CpuCache::~CpuCache()
+{
+    if (_cache_id)
+        delete _cache_id;
+}
+
+/**
+ * Turns an integer-based CPU cache level into CpuCacheLevel.
+ */
+CpuCacheLevel
+CpuCache::level_from_integer(const int &level)
+{
+    switch(level) {
+        case 0:
+            return REGISTER;
+        case 1:
+            return L1;
+        case 2:
+            return L2;
+        case 3:
+            return L3;
+        case 4:
+            return L4;
+        default:
+            assert(true);
+    }
+}
+
+/**
+ * Turns a CpuCacheLevel into an integer-based CPU cache level.
+ */
+int
+CpuCache::level_to_integer(const CpuCacheLevel &level)
+{
+    String level_str = cpu_cache_level_enum_to_str(level);
+    return atoi(level_str.upper().split('L')[1].c_str());
+}
+
+/**
+ * Turns a CpuCacheType into an string-based CPU cache type.
+ */
+CpuCacheType
+CpuCache::type_from_string(const String &type)
+{
+    if (type.lower().equals("data")) {
+        return DATA;
+    } else if (type.lower().equals("instruction")) {
+        return INSTRUCTION;
+    }
+    return UNIFIED;
+}
+
+/**
+ * Turns an integer-based CPU cache policy into CpuCachePolicy.
+ */
+CpuCachePolicy
+CpuCache::policy_from_ways(const int &ways, const int &sets)
+{
+    if (ways == 1) {
+        return DIRECT_MAPPED;
+    }
+
+    if (sets == 1) {
+        return FULLY_ASSOCIATIVE;
+    }
+
+    return SET_ASSOCIATIVE;
+}
+
+/**
+ * Print the CPU cache layout.
+ */
+void
+CpuCache::print()
+{
+    click_chatter("CPU Cache");
+    click_chatter("\t     Vendor: %s", cpu_vendor_enum_to_str(get_vendor()).c_str());
+    click_chatter("\t      Level: %s", cpu_cache_level_enum_to_str(get_cache_id()->get_level()).c_str());
+    click_chatter("\t       Type: %s", cpu_cache_type_enum_to_str(get_cache_id()->get_type()).c_str());
+    click_chatter("\t     Policy: %s", cpu_cache_policy_enum_to_str(get_policy()).c_str());
+    click_chatter("\t  # of Sets: %d", get_sets());
+    click_chatter("\t  # of Ways: %d", get_ways());
+    click_chatter("\tLine length: %d Bytes", get_line_length());
+    click_chatter("\t   Capacity: %ld kBytes", get_capacity());
+    click_chatter("\t  Is shared: %s", is_shared() ? "Shared" : "Non-shared");
+    click_chatter("\n");
+}
+
+/**
+ * Encodes this CPU cache into JSON.
+ */
+Json
+CpuCache::to_json()
+{
+    Json jcache = Json::make_object();
+
+    jcache.set("vendor", cpu_vendor_enum_to_str(get_vendor()));
+    jcache.set("level", cpu_cache_level_enum_to_str(get_cache_id()->get_level()));
+    jcache.set("type", cpu_cache_type_enum_to_str(get_cache_id()->get_type()));
+    jcache.set("policy", cpu_cache_policy_enum_to_str(get_policy()));
+    jcache.set("sets", get_sets());
+    jcache.set("ways", get_ways());
+    jcache.set("lineLength", get_line_length());
+    jcache.set("capacity", get_capacity());
+    jcache.set("shared", is_shared() ? 1 : 0);
+
+    return jcache;
+}
+
+/******************************
+ * CPU Cache Hierarchy
+ ******************************/
+/**
+ * CpuCacheHierarchy constructors.
+ */
+CpuCacheHierarchy::CpuCacheHierarchy(CpuVendor vendor, int sockets_nb, int cores_nb) :
+    _levels(0), _per_core_capacity(0), _llc_capacity(0), _total_capacity(0)
+{
+    assert(vendor != UNKNOWN_VENDOR);
+    assert(sockets_nb > 0);
+    assert(cores_nb > 0);
+    _vendor = vendor;
+    _sockets_nb = sockets_nb;
+    _cores_nb = cores_nb;
+
+    query();
+}
+
+CpuCacheHierarchy::CpuCacheHierarchy(String vendor_str, int sockets_nb, int cores_nb) :
+    CpuCacheHierarchy(cpu_vendor_str_to_enum(vendor_str), sockets_nb, cores_nb)
+{}
+
+/**
+ * CpuCacheHierarchy destructor.
+ */
+CpuCacheHierarchy::~CpuCacheHierarchy()
+{
+    auto it = _cache_hierarchy.begin();
+    while (it != _cache_hierarchy.end()) {
+        if (it.value()) {
+            delete it.value();
+        }
+        it++;
+    }
+    _cache_hierarchy.clear();
+}
+
+/**
+ * Add a CPU cache into this hierarchy.
+ *
+ * @args cache: CPU cache to add into the hierarchy
+ */
+void
+CpuCacheHierarchy::add_cache(CpuCache *cache)
+{
+    int currentSize = _cache_hierarchy.size();
+    _cache_hierarchy.insert(cache->get_cache_id(), cache);
+    assert(_cache_hierarchy.size() == currentSize + 1);
+
+    int level = CpuCache::level_to_integer(cache->get_cache_id()->get_level());
+    if (_levels < level) {
+        _levels = level;
+    }
+    assert(_levels <= CpuCacheHierarchy::MAX_CPU_CACHE_LEVELS);
+
+    long capacity = cache->get_capacity();
+    assert(capacity > 0);
+    if (cache->is_shared()) {
+        _llc_capacity += capacity;
+    } else {
+        _per_core_capacity += capacity;
+    }
+}
+
+/**
+ * Initiate a query to retrieve the CPU cache layout.
+ */
+void
+CpuCacheHierarchy::query()
+{
+    int max_level = 0;
+    String cache_folders = shell_command_output_string(
+        "find /sys/devices/system/cpu/cpu0/cache/ -maxdepth 1 -type d | grep index | sort -u", "", 0);
+    Vector<String> cache_tokens = cache_folders.split('\n');
+    for (unsigned i = 0; i < cache_tokens.size(); i++) {
+        String cache_file = cache_tokens[i];
+        if (cache_file.empty()) {
+            continue;
+        }
+
+        int level_int;
+        bool is_shared = false;
+        String cpu_list = file_string(cache_file + "/shared_cpu_list").c_str();
+        Vector<String> cpu_tokens = cpu_list.split(',');
+        if (cpu_tokens.size() > 1) {
+            level_int = max_level + 1;
+            is_shared = true;
+        } else {
+            level_int = atoi(file_string(cache_file + "/level").c_str());
+            max_level = level_int;
+        }
+        String type_str = file_string(cache_file + "/type").trim_space().c_str();
+        int sets = atoi(file_string(cache_file + "/number_of_sets").trim_space().c_str());
+        int ways = atoi(file_string(cache_file + "/ways_of_associativity").trim_space().c_str());
+        long capacity = atol(file_string(cache_file + "/size").trim_space().c_str()) * CpuCacheHierarchy::BYTES_IN_KILO_BYTE;
+        int line_len = atoi(file_string(cache_file + "/coherency_line_size").trim_space().c_str());
+
+        CpuCacheLevel level = CpuCache::level_from_integer(level_int);
+        CpuCacheType type = CpuCache::type_from_string(type_str);
+        CpuCachePolicy policy = CpuCache::policy_from_ways(ways, sets);
+
+        add_cache(
+            new CpuCache(
+                level, type, policy, _vendor, capacity,
+                sets, ways, line_len, is_shared
+            )
+        );
+    }
+
+    compute_total_capacity();
+}
+
+/**
+ * Compute the total CPU cache capacity.
+ * The total capacity is the sum of the (shared) socket-level
+ * and the per-core capacities.
+ */
+void
+CpuCacheHierarchy::compute_total_capacity()
+{
+    assert(_sockets_nb > 0);
+    assert(_cores_nb > 0);
+    assert(_per_core_capacity > 0);
+    assert(_llc_capacity > 0);
+    _total_capacity = (_sockets_nb * _llc_capacity) + (_cores_nb * _per_core_capacity);
+    assert(
+        (_total_capacity > 0) &&
+        (_total_capacity > _per_core_capacity) &&
+        (_total_capacity > _llc_capacity)
+    );
+}
+
+/**
+ * Print the CPU cache layout.
+ */
+void
+CpuCacheHierarchy::print()
+{
+    if (_cache_hierarchy.size() == 0) {
+        click_chatter("No CPU Cache hierarchy detected");
+        return;
+    }
+
+    click_chatter("\n");
+    click_chatter("=======================================================================");
+    auto it = _cache_hierarchy.begin();
+    while (it != _cache_hierarchy.end()) {
+        CpuCache *cache = it.value();
+        cache->print();
+        it++;
+    }
+
+    click_chatter("CPU Cache Hierarchy - Summary");
+    click_chatter("\tLevels: %d", _levels);
+    click_chatter("\tVendor: %s", cpu_vendor_enum_to_str(_vendor).c_str());
+    click_chatter("\t%3d CPU cores with (local) per-core capacity %10ld kB", _cores_nb, _per_core_capacity);
+    click_chatter("\t%3d CPU sockets with per-socket LLC capacity %10ld kB", _sockets_nb, _llc_capacity);
+    click_chatter("\tTotal capacity: %10ld kB", _total_capacity);
+    click_chatter("=======================================================================");
+}
+
+/**
+ * Encodes the CPU cache hierarchy into JSON.
+ */
+Json
+CpuCacheHierarchy::to_json()
+{
+    Json jroot = Json::make_object();
+
+    if (_cache_hierarchy.size() == 0) {
+        click_chatter("No CPU Cache hierarchy to convert to JSON");
+        return jroot;
+    }
+
+    jroot.set("sockets", get_sockets_nb());
+    jroot.set("cores", get_cores_nb());
+    jroot.set("levels", get_levels());
+
+    // CPU cache resources
+    Json jcaches = Json::make_array();
+
+    auto it = _cache_hierarchy.begin();
+    while (it != _cache_hierarchy.end()) {
+        CpuCache *cache = it.value();
+        jcaches.push_back(cache->to_json());
+
+        it++;
+    }
+
+    jroot.set("cpuCaches", jcaches);
+
+    return jroot;
+}
+
+/******************************
+ * Memory Statistics
+ ******************************/
+/**
+ * Main memory statistics constructor.
+ */
+MemoryStats::MemoryStats() : _used(0), _free(0), _total(0)
+{
+    capacity_query();
+}
+
+/**
+ * Main memory statistics destructor.
+ */
+MemoryStats::~MemoryStats()
+{}
+
+/**
+ * Initiate a query to retrieve the total memory capacity.
+ */
+void
+MemoryStats::capacity_query()
+{
+    String mem_info = file_string("/proc/meminfo");
+    long mem_total = atol(parse_info(mem_info, "MemTotal").c_str());
+    assert(mem_total > 0);
+
+    _total = mem_total;
+}
+
+/**
+ * Initiate a query to retrieve the current memory utilization.
+ */
+void
+MemoryStats::utilization_query()
+{
+    assert(_total > 0);
+
+    String mem_info = file_string("/proc/meminfo");
+    long mem_free = atol(parse_info(mem_info, "MemFree").c_str());
+    long mem_used = _total - mem_free;
+    assert(mem_used > 0);
+    assert(mem_free > 0);
+    assert(mem_used + mem_free == _total);
+
+    _used = mem_used;
+    _free = mem_free;
+}
+
+/**
+ * Print main memory statistics.
+ */
+void
+MemoryStats::print()
+{
+    click_chatter("\n");
+    click_chatter("=======================================================================");
+    click_chatter("Main Memory Utilization", get_memory_used_gb());
+    click_chatter("Main Memory  Used: %ld GB", get_memory_used_gb());
+    click_chatter("Main Memory  Free: %ld GB", get_memory_free_gb());
+    click_chatter("Main Memory Total: %ld GB", get_memory_total_gb());
+    click_chatter("=======================================================================");
+}
+
+/**
+ * Encodes main memory statistics into JSON.
+ */
+Json
+MemoryStats::to_json()
+{
+    // Give fresh stats to the controller
+    utilization_query();
+
+    Json jroot = Json::make_object();
+
+    jroot.set("unit", "kBytes");
+    jroot.set("used", get_memory_used());
+    jroot.set("free", get_memory_free());
+    jroot.set("total", get_memory_total());
+
+    return jroot;
+}
+
+/******************************
+ * Memory module
+ ******************************/
+/**
+ * Main memory module constructor.
+ */
+MemoryModule::MemoryModule()
+{
+    _id = -1;
+    _type = UNKNOWN_MEMORY_TYPE;
+    _manufacturer = "";
+    _serial_nb = "";
+    _data_width = -1;
+    _total_width = -1;
+    _capacity = -1;
+    _speed = -1;
+    _configured_speed = -1;
+}
+
+MemoryModule::MemoryModule(int id, MemoryType type, String manufacturer, String serial_nb,
+    int data_width, int total_width, long capacity, long speed, long configured_speed)
+{
+    assert(id >= 0);
+    assert(type != UNKNOWN_MEMORY_TYPE);
+    assert(!manufacturer.empty());
+    assert(!serial_nb.empty());
+    assert(data_width > 0);
+    assert(total_width > 0);
+    assert(capacity > 0);
+    assert(speed > 0);
+    assert(configured_speed > 0);
+
+    _id = id;
+    _type = type;
+    _manufacturer = manufacturer;
+    _serial_nb = serial_nb;
+    _data_width = data_width;
+    _total_width = total_width;
+    _capacity = capacity;
+    _speed = speed;
+    _configured_speed = configured_speed;
+}
+
+MemoryModule::~MemoryModule()
+{
+}
+
+/**
+ * Prints main memory module.
+ */
+void
+MemoryModule::print()
+{
+    click_chatter("\n");
+    click_chatter("Memory               ID: %d", get_id());
+    click_chatter("Memory             type: %s", memory_type_enum_to_str(get_type()).c_str());
+    click_chatter("Memory     manufacturer: %s", get_manufacturer().c_str());
+    click_chatter("Memory        serial no: %s", get_serial_number().c_str());
+    click_chatter("Memory       data width: %d bits", get_data_width());
+    click_chatter("Memory      total width: %d bits", get_total_width());
+    click_chatter("Memory         capacity: %ld MBytes", get_capacity());
+    click_chatter("Memory            speed: %ld MT/s", get_speed());
+    click_chatter("Memory configured speed: %ld MT/s", get_configured_speed());
+}
+
+/**
+ * Encodes main memory module information into JSON.
+ */
+Json
+MemoryModule::to_json()
+{
+    Json jroot = Json::make_object();
+
+    jroot.set("type", memory_type_enum_to_str(get_type()));
+    jroot.set("manufacturer", get_manufacturer());
+    jroot.set("serial", get_serial_number());
+    jroot.set("dataWidth", get_data_width());
+    jroot.set("totalWidth", get_total_width());
+    jroot.set("capacity", get_capacity());
+    jroot.set("speed", get_speed());
+    jroot.set("speedConfigured", get_configured_speed());
+
+    return jroot;
+}
+
+/******************************
+ * Memory
+ ******************************/
+/**
+ * Main memory constructor.
+ */
+MemoryHierarchy::MemoryHierarchy() : _stats()
+{
+    capacity_query();
+
+    _memory_modules.resize(_modules_nb, 0);
+    for (unsigned i = 0; i < (unsigned) _modules_nb; i++) {
+        _memory_modules[i] = new MemoryModule();
+    }
+    _total_capacity = 0;
+
+    query();
+}
+
+/**
+ * Main memory destructor.
+ */
+MemoryHierarchy::~MemoryHierarchy()
+{
+    for (unsigned i = 0; i < (unsigned) _memory_modules.size(); i++) {
+        if (_memory_modules[i]) {
+            delete _memory_modules[i];
+        }
+    }
+
+    _memory_modules.clear();
+}
+
+/**
+ * Queries the system to acquire the number of main memory modules.
+ */
+void
+MemoryHierarchy::capacity_query()
+{
+    // TODO: What if not DDR-based?
+    int mem_modules = atoi(shell_command_output_string("lshw -short -C memory | grep DDR | wc -l", "", 0).c_str());
+    assert(mem_modules > 0);
+    _modules_nb = mem_modules;
+}
+
+/**
+ * Queries the system to acquire main memory information.
+ */
+void
+MemoryHierarchy::query()
+{
+    String mem_summary = shell_command_output_string("dmidecode -t memory", "", 0);
+    Vector<String> line_vec = mem_summary.split('\n');
+    unsigned active_devices = 0;
+
+    for (unsigned j = 0; j < line_vec.size(); j++) {
+        if (active_devices == get_modules_number()) {
+            break;
+        }
+
+        String line = line_vec[j];
+        if (line.empty()) {
+            continue;
+        }
+
+        if (line.find_left(':') < 0) {
+            continue;
+        }
+
+        Vector<String> line_tokens = line.split(':');
+        if (line_tokens.size() != 2) {
+            continue;
+        }
+
+        line_tokens[0] = line_tokens[0].trim_space().trim_space_left();
+        line_tokens[1] = line_tokens[1].trim_space().trim_space_left();
+
+        if (line_tokens[0].equals("Total Width") && !line_tokens[1].equals("Unknown")) {
+            _memory_modules[active_devices]->set_total_width(
+                atoi(line_tokens[1].split(' ')[0].c_str())
+            );
+            continue;
+        }
+
+        if (line_tokens[0].equals("Data Width") && !line_tokens[1].equals("Unknown")) {
+            _memory_modules[active_devices]->set_data_width(
+                atoi(line_tokens[1].split(' ')[0].c_str())
+            );
+            continue;
+        }
+
+        if (line_tokens[0].equals("Size") && !line_tokens[1].equals("No Module Installed")) {
+            _memory_modules[active_devices]->set_capacity(
+                atol(line_tokens[1].split(' ')[0].c_str())
+            );
+            _total_capacity += _memory_modules[active_devices]->get_capacity();
+            continue;
+        }
+
+        if (line_tokens[0].equals("Type") && !line_tokens[1].equals("Unknown")) {
+            _memory_modules[active_devices]->set_type(memory_type_str_to_enum(line_tokens[1]));
+            continue;
+        }
+
+        if (line_tokens[0].equals("Speed") && !line_tokens[1].equals("Unknown")) {
+            _memory_modules[active_devices]->set_speed(
+                atol(line_tokens[1].split(' ')[0].c_str())
+            );
+            continue;
+        }
+
+        if (line_tokens[0].equals("Manufacturer") && !line_tokens[1].equals("Not Specified")) {
+            _memory_modules[active_devices]->set_manufacturer(line_tokens[1]);
+            continue;
+        }
+
+        if (line_tokens[0].equals("Serial Number") && !line_tokens[1].equals("Not Specified")) {
+            _memory_modules[active_devices]->set_serial_nb(line_tokens[1]);
+            continue;
+        }
+
+        if (line_tokens[0].equals("Configured Clock Speed") && !line_tokens[1].equals("Unknown")) {
+            _memory_modules[active_devices]->set_configured_speed(
+                atol(line_tokens[1].split(' ')[0].c_str())
+            );
+            _memory_modules[active_devices]->set_id((int) active_devices);
+            active_devices++;
+            continue;
+        }
+    }
+
+    fill_missing();
+}
+
+/**
+ * Returns the first valid capacity of a memory module.
+ */
+long
+MemoryHierarchy::get_module_capacity()
+{
+    long capacity = -1;
+
+    for (unsigned i = 0; i < (unsigned) _memory_modules.size(); i++) {
+        capacity = _memory_modules[i]->get_capacity();
+        if (capacity > 0) {
+            return capacity;
+        }
+    }
+
+    return capacity;
+}
+
+/**
+ * Returns the first valid speed of a memory module.
+ */
+long
+MemoryHierarchy::get_module_speed()
+{
+    long speed = -1;
+
+    for (unsigned i = 0; i < (unsigned) _memory_modules.size(); i++) {
+        speed = _memory_modules[i]->get_speed();
+        if (speed > 0) {
+            return speed;
+        }
+    }
+
+    return speed;
+}
+
+/**
+ * Prints main memory hierarchy.
+ */
+void
+MemoryHierarchy::fill_missing()
+{
+    for (unsigned i = 0; i < (unsigned) _memory_modules.size(); i++) {
+        MemoryModule *module = _memory_modules[i];
+        if (module->get_capacity() < 0) {
+            module->set_capacity(get_module_capacity());
+        }
+        if (module->get_speed() < 0) {
+            module->set_speed(get_module_speed());
+        }
+    }
+}
+
+/**
+ * Prints main memory hierarchy.
+ */
+void
+MemoryHierarchy::print()
+{
+    click_chatter("=======================================================================");
+    click_chatter("    # of memory modules: %d", get_modules_number());
+    click_chatter("  Total memory capacity: %ld MBytes", get_total_capacity());
+    for (unsigned i = 0; i < (unsigned) _memory_modules.size(); i++) {
+        _memory_modules[i]->print();
+    }
+    click_chatter("=======================================================================");
+}
+
+/**
+ * Encodes main memory information into JSON.
+ */
+Json
+MemoryHierarchy::to_json()
+{
+    Json jroot = Json::make_object();
+
+    Json jmodules = Json::make_array();
+    for (unsigned i = 0; i < (unsigned) _memory_modules.size(); i++) {
+        jmodules.push_back(_memory_modules[i]->to_json());
+    }
+
+    jroot.set("modules", jmodules);
+
+    return jroot;
+}
+
+/******************************
+ * NIC
+ ******************************/
+/**
+ * NIC constructor.
+ */
+NIC::NIC(bool verbose) :
+    _element(0), _index(-1), _verbose(verbose), mirror(0)
+{}
+
+/**
+ * NIC copy constructor.
+ */
+NIC::NIC(const NIC &n)
+{
+    _index = n._index;
+    _verbose = n._verbose;
+    _element = n._element;
+}
+
+/**
+ * NIC destructor.
+ */
+NIC::~NIC()
+{}
+
+/**
+ * Sets the Click element that represents this NIC.
+ */
+void
+NIC::set_element(Element *el)
+{
+    assert(el);
+    _element = el;
+}
+
+/**
+ * Sets the device's Click port index.
+ */
+void
+NIC::set_index(const int &index)
+{
+    assert(index >= 0);
+    _index = index;
+}
+
+/**
+ * Sets the NIC's status through the respective element.
+ */
+void
+NIC::set_active(const bool &active)
+{
+    assert(_element);
+    cast()->set_active(active);
+}
+
+/**
+ * Casts a NIC object to its Click counterpart.
+ */
+FromDPDKDevice *
+NIC::cast()
+{
+    if (!get_element()) {
+        return NULL;
+    }
+    return dynamic_cast<FromDPDKDevice *>(get_element());
+}
+
+#if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
+/**
+ * Returns a FlowDispatcher object associated with this NIC.
+ */
+FlowDispatcher *
+NIC::get_flow_dispatcher(int sriov)
+{
+    return FlowDispatcher::get_flow_dispatcher(get_port_id() + sriov);
+}
+
+/**
+ * Returns a FlowCache object associated with this NIC.
+ */
+FlowCache *
+NIC::get_flow_cache(int sriov)
+{
+    return get_flow_dispatcher(sriov)->get_flow_cache();
+}
+#endif
+
+/**
+ * Returns the number of queues per VF pool.
+ */
+int
+NIC::queue_per_pool()
+{
+    int nb_vf_pools = atoi(call_rx_read("nb_vf_pools").c_str());
+    if (nb_vf_pools == 0) {
+        return 1;
+    }
+
+    return atoi(call_rx_read("nb_rx_queues").c_str()) / nb_vf_pools;
+}
+
+/**
+ * Maps a physical CPU core ID to a hardware queue ID.
+ */
+int
+NIC::phys_cpu_to_queue(int phys_cpu_id)
+{
+    assert(phys_cpu_id >= 0);
+    return phys_cpu_id * (queue_per_pool());
+}
+
+/**
+ * Encodes NIC information to JSON.
+ * Depending on the value of the second argument,
+ * this piece of information can either be generic
+ * NIC information of NIC statistics.
+ */
+Json
+NIC::to_json(const RxFilterType &rx_mode, const bool &stats)
+{
+    Json nic = Json::make_object();
+
+    nic.set("name", get_name());
+    nic.set("id", get_index());
+    if (!stats) {
+        nic.set("vendor", call_rx_read("vendor"));
+        nic.set("driver", call_rx_read("driver"));
+        nic.set("speed", call_rx_read("speed"));
+        nic.set("status", call_rx_read("carrier"));
+        nic.set("portType", call_rx_read("type"));
+        nic.set("hwAddr", call_rx_read("mac").replace('-',':'));
+        Json jtagging = Json::make_array();
+        jtagging.push_back(rx_filter_type_enum_to_str(rx_mode));
+        nic.set("rxFilter", jtagging);
+    } else {
+        nic.set("rxCount", call_rx_read("hw_count"));
+        nic.set("rxBytes", call_rx_read("hw_bytes"));
+        nic.set("rxDropped", call_rx_read("hw_dropped"));
+        nic.set("rxErrors", call_rx_read("hw_errors"));
+        nic.set("txCount", call_tx_read("hw_count"));
+        nic.set("txBytes", call_tx_read("hw_bytes"));
+        nic.set("txErrors", call_tx_read("hw_errors"));
+    }
+
+    return nic;
+}
+
+/**
+ * Implements read handlers for a NIC.
+ */
+String
+NIC::call_rx_read(String h)
+{
+    const Handler *hc = Router::handler(_element, h);
+
+    if (hc && hc->visible()) {
+        return hc->call_read(_element, ErrorHandler::default_handler());
+    }
+
+    return "undefined";
+}
+
+/**
+ * Relays handler calls to a NIC's underlying TX element.
+ */
+String
+NIC::call_tx_read(String h)
+{
+    // TODO: Ensure element type
+    ToDPDKDevice *td = dynamic_cast<FromDPDKDevice *>(_element)->find_output_element();
+    if (!td) {
+        return "[NIC " + String(get_device_address()) + "] Could not find matching ToDPDKDevice";
+    }
+
+    const Handler *hc = Router::handler(td, h);
+    if (hc && hc->visible()) {
+        return hc->call_read(td, ErrorHandler::default_handler());
+    }
+
+    return "undefined";
+}
+
+/**
+ * Relays handler calls to a NIC's underlying Rx element.
+ */
+int
+NIC::call_rx_write(String h, const String input)
+{
+    FromDPDKDevice *fd = dynamic_cast<FromDPDKDevice *>(_element);
+    if (!fd) {
+        click_chatter("[NIC %s] Could not find matching FromDPDKDevice", get_device_address().c_str());
+        return ERROR;
+    }
+
+    const Handler *hc = Router::handler(fd, h);
+    if (hc && hc->visible()) {
+        return hc->call_write(input, fd, ErrorHandler::default_handler());
+    }
+
+    click_chatter("[NIC %s] Could not find matching handler %s", get_device_address().c_str(), h.c_str());
+
+    return ERROR;
+}
+
+/***************************************
+ * CPULayout
+ **************************************/
+/**
+ * CPULayout constructor.
+ */
+CPULayout::CPULayout(int sockets_nb, int cores_nb, int active_cores_nb,
+                    String vendor, long frequency, String numa_nodes) :
+    _lcore_to_phy_core(), _lcore_to_socket()
+{
+    assert(sockets_nb >= 0);
+    assert(cores_nb >= 0);
+    assert(cores_nb % sockets_nb == 0);
+    assert((active_cores_nb >= 0) && (active_cores_nb <= cores_nb));
+    assert((vendor) && (!vendor.empty()));
+    assert(frequency > 0);
+    assert((numa_nodes) && (!numa_nodes.empty()));
+    _sockets_nb = sockets_nb;
+    _cores_nb = cores_nb;
+    _cores_per_socket = _cores_nb / _sockets_nb;
+    _active_cores_nb = active_cores_nb;
+    _vendor = vendor;
+    _frequency = frequency;
+    _numa_nodes = numa_nodes;
+    _cpus.resize(cores_nb, 0);
+
+    compose();
+}
+
+/**
+ * CPULayout destructor.
+ */
+CPULayout::~CPULayout()
+{
+    for (unsigned i = 0; i < (unsigned)_cpus.size() ; i++) {
+        if (_cpus[i]) {
+            delete _cpus[i];
+        }
+    }
+    _cpus.clear();
+
+    _lcore_to_phy_core.clear();
+    _lcore_to_socket.clear();
+}
+
+/**
+ * Compose the CPU layout by processing the input information.
+ */
+void
+CPULayout::compose()
+{
+    assert(!_numa_nodes.empty());
+
+    unsigned lcore = 0;
+    Vector<String> tokens = _numa_nodes.split('\n');
+    for (unsigned i = 0; i < (unsigned) tokens.size(); i++) {
+        String token = tokens[i];
+        if (token.empty()) {
+            continue;
+        }
+
+        Vector<String> core_tokens = token.split(':');
+        assert(core_tokens.size() == 3);
+
+        int socket = atoi(core_tokens[1].trim_space_left().split(' ')[0].c_str());
+        // This core ID shows the numbering within a single socket
+        // If we have more than one sockets, the numbering resets to 0.
+        // int core = atoi(core_tokens[2].trim_space_left().c_str());
+
+        _lcore_to_phy_core.insert(lcore, lcore);
+        _lcore_to_socket.insert(lcore, socket);
+        lcore++;
+    }
+
+    for (int i = 0; i < _cores_nb; i++) {
+        _cpus[i] = new CPU(
+            get_phy_core_by_lcore(i), i, get_socket_by_lcore(i), _vendor, _frequency
+        );
+    }
+}
+
+/**
+ * Print the CPU layout.
+ */
+void
+CPULayout::print()
+{
+    click_chatter("\n");
+    click_chatter("=======================================================================");
+    click_chatter("CPU layout information:");
+    auto it = _lcore_to_phy_core.begin();
+    while (it != _lcore_to_phy_core.end()) {
+        int lcore = it.key();
+        int pcore = it.value();
+        int socket = _lcore_to_socket[lcore];
+        click_chatter("\t[Socket %d] Logical core %3d --> Physical core %3d", socket, lcore, pcore);
+        it++;
+    }
+
+    click_chatter("\nCPU cores' information:");
+    for (unsigned i = 0; i < (unsigned)_cpus.size() ; i++) {
+        _cpus[i]->print();
+    }
+    click_chatter("=======================================================================");
+}
+
+/***************************************
+ * SystemResources
+ **************************************/
+/**
+ * SystemResources constructor.
+ */
+SystemResources::SystemResources(
+    int sockets_nb, int cores_nb, int active_cores_nb, String vendor, long frequency,
+    String numa_nodes, String hw, String sw, String serial, String chassis) :
+    _plat_info(hw, sw, serial, chassis),
+    _cpu_layout(sockets_nb, cores_nb, active_cores_nb, vendor, frequency, numa_nodes),
+    _cpu_cache_hierarchy(vendor, sockets_nb, cores_nb), _memory_hierarchy()
+{}
+
+/**
+ * SystemResources destructor.
+ */
+SystemResources::~SystemResources()
+{}
+
+/**
+ * Print the system's resources.
+ */
+void
+SystemResources::print()
+{
+    click_chatter("=================================================================================");
+    click_chatter("=== System Information");
+    click_chatter("=================================================================================");
+    click_chatter("# CPU sockets: %d", get_cpu_sockets());
+    click_chatter("   CPU vendor: %s", get_cpu_vendor().c_str());
+
+    _plat_info.print();
+    _cpu_layout.print();
+    _cpu_cache_hierarchy.print();
+    _memory_hierarchy.print();
+    click_chatter("=================================================================================");
+    click_chatter("\n");
 }
 
 /***************************************
  * Metron
  **************************************/
+/**
+ * Metron constructor.
+ */
 Metron::Metron() :
-    _timer(this), _rx_mode(FLOW), _discover_timer(&discover_timer, this),
-    _discover_ip(), _discovered(false), _monitoring_mode(false),
-    _fail(false), _load_timer(1000), _verbose(false)
+    _timer(this), _sys_res(0), _rx_mode(FLOW),
+    _discover_timer(&discover_timer, this),
+    _discover_ip(), _discovered(false),
+    _monitoring_mode(false), _fail(false),
+    _load_timer(1000), _verbose(false)
 {
     _core_id = click_max_cpu_ids() - 1;
     _cpu_click_to_phys.resize(click_max_cpu_ids(), 0);
+
+    // Build up system resources
+    collect_system_resources();
+}
+
+/**
+ * Metron destructor.
+ */
+Metron::~Metron()
+{
+    if (_sys_res) {
+        delete _sys_res;
+    }
+
+    _nics.clear();
+
+    auto sci = _scs.begin();
+    while (sci != _scs.end()) {
+        if (sci.value()) {
+            delete sci.value();
+        }
+        sci++;
+    }
+    _scs.clear();
+
+    for (unsigned i = 0; i < _sc_to_core_map.size() ; i++) {
+        if (_sc_to_core_map[i]) {
+            delete _sc_to_core_map[i];
+        }
+    }
+    _sc_to_core_map.clear();
+
+    _args.clear();
+    _dpdk_args.clear();
+    _cpu_click_to_phys.clear();
+}
+
+/**
+ * Collect important system resources.
+ */
+void
+Metron::collect_system_resources()
+{
+    int sockets_nb = atoi(
+        shell_command_output_string(
+            "cat /proc/cpuinfo | grep 'physical id' | sort -u | wc -l", "", 0
+        ).c_str()
+    );
+    int total_cores_nb = atoi(
+        shell_command_output_string(
+            "cat /proc/cpuinfo | grep 'processor' | sort -u | wc -l", "", 0
+        ).c_str()
+    );
+    int active_cores_nb = click_max_cpu_ids();
+    String cpu_info = file_string("/proc/cpuinfo");
+    String cpu_vendor = parse_info(cpu_info, "vendor_id");
+    String hw_info = parse_info(cpu_info, "model name");
+    String sw_info = String("Click ") + String(CLICK_VERSION);
+    String numa_nodes = shell_command_output_string(
+        "egrep -e \"core id\" -e ^physical /proc/cpuinfo | xargs -l2 echo", "", 0);
+    String sys_info = shell_command_output_string("dmidecode -t 1", "", 0);
+    String serial = parse_info(sys_info, "Serial Number");
+    String chassis_id = String(0); // Find a chassis ID :p
+    long frequency = (long) cycles_hz() / CPU::MEGA_HZ;
+    assert(frequency > 0);
+
+    _sys_res = new SystemResources(
+        sockets_nb, total_cores_nb, active_cores_nb,
+        cpu_vendor, frequency, numa_nodes, hw_info,
+        sw_info, serial, chassis_id
+    );
+
+    click_chatter("\n");
 #if HAVE_DPDK
     if (dpdk_enabled) {
         unsigned id = 0;
         for (unsigned i = 0; i < RTE_MAX_LCORE; i++) {
             if (rte_lcore_is_enabled(i)) {
                 click_chatter("Logical CPU core %d to %d", id, i);
-                _cpu_click_to_phys[id++]=i;
+                _cpu_click_to_phys[id++] = i;
             } else {
                 click_chatter("Logical CPU core %d deactivated", i);
             }
@@ -170,15 +1705,10 @@ Metron::Metron() :
             _cpu_click_to_phys[i] = i;
         }
     }
-}
 
-Metron::~Metron()
-{
-    _nics.clear();
-    _scs.clear();
-    _cpu_map.clear();
-    _args.clear();
-    _dpdk_args.clear();
+    // if (_verbose) {
+        _sys_res->print();
+    // }
 }
 
 /**
@@ -200,7 +1730,7 @@ Metron::configure(Vector<String> &conf, ErrorHandler *errh)
     bool no_discovery = false;
 
     if (Args(conf, this, errh)
-        .read    ("ID",                _id)
+        .read    ("ID",                _agent_id)
         .read_all("NIC",               nics)
         .read    ("RX_MODE",           rx_mode)
         .read    ("AGENT_IP",          _agent_ip)
@@ -215,13 +1745,13 @@ Metron::configure(Vector<String> &conf, ErrorHandler *errh)
         .read    ("FAIL",              _fail)
         .read    ("LOAD_TIMER",        _load_timer)
         .read    ("ON_SCALE", HandlerCallArg(HandlerCall::writable), _on_scale)
+        .read    ("NODISCOVERY",       no_discovery)
+        .read    ("MIRROR",            _mirror)
+        .read    ("VERBOSE",           _verbose)
         .read_all("SLAVE_DPDK_ARGS",   _dpdk_args)
         .read_all("SLAVE_ARGS",        _args)
         .read    ("SLAVE_EXTRA",       _slave_extra)
         .read    ("SLAVE_TD_EXTRA",    _slave_td_args)
-        .read    ("NODISCOVERY",       no_discovery)
-        .read    ("MIRROR",            _mirror)
-        .read    ("VERBOSE",           _verbose)
         .complete() < 0)
         return ERROR;
 
@@ -302,7 +1832,7 @@ Metron::configure(Vector<String> &conf, ErrorHandler *errh)
     for (Element *e : nics) {
         NIC nic(_verbose);
         nic.set_index(index++);
-        nic.element = e;
+        nic.set_element(e);
         _nics.insert(nic.get_name(), nic);
     }
 
@@ -329,7 +1859,7 @@ Metron::confirm_nic_mode(ErrorHandler *errh)
     auto nic = _nics.begin();
     while (nic != _nics.end()) {
         // Cast input element
-        FromDPDKDevice *fd = dynamic_cast<FromDPDKDevice *>(nic.value().element);
+        FromDPDKDevice *fd = nic.value().cast();
         if (!fd || !fd->get_device()) {
             nic++;
             continue;
@@ -409,26 +1939,18 @@ int
 Metron::initialize(ErrorHandler *errh)
 {
     // Generate a unique ID for this agent, if not already given
-    if (_id.empty()) {
-        _id = "metron:nfv:dataplane:";
+    if (_agent_id.empty()) {
+        _agent_id = "metron:nfv:dataplane:";
         String uuid = shell_command_output_string("cat /proc/sys/kernel/random/uuid", "", errh);
         uuid = uuid.substring(0, uuid.find_left("\n"));
-        _id = (!uuid || uuid.empty())? _id + "00000000-0000-0000-0000-000000000001" : _id + uuid;
+        _agent_id = (!uuid || uuid.empty())? _agent_id + "00000000-0000-0000-0000-000000000001" : _agent_id + uuid;
     }
 
     if (_on_scale)
         if (_on_scale.initialize_write(this, errh) < 0)
             return -1;
 
-    _cpu_map.resize(get_cpus_nb(), 0);
-
-    String hw_info = file_string("/proc/cpuinfo");
-    _cpu_vendor = parse_vendor_info(hw_info, "vendor_id");
-    _hw = parse_vendor_info(hw_info, "model name");
-    _sw = CLICK_VERSION;
-
-    String sw_info = shell_command_output_string("dmidecode -t 1", "", errh);
-    _serial = parse_vendor_info(sw_info, "Serial Number");
+    _sc_to_core_map.resize(get_cpus_nb(), 0);
 
 #if HAVE_CURL
     // Only if user has requested discovery
@@ -502,7 +2024,7 @@ Metron::try_slaves(ErrorHandler *errh)
     assign_cpus(&sc, cpu_phys_map);
     assert(cpu_phys_map[0] >= 0);
     for (unsigned i = 0; i < click_max_cpu_ids(); i++) {
-        sc.get_cpu_info(i).cpu_phys_id = cpu_phys_map[i];
+        sc.get_cpu_info(i).set_physical_id(cpu_phys_map[i]);
         sc.get_cpu_info(i).set_active(true);
     }
     sc._manager = new ClickSCManager(&sc, false);
@@ -552,7 +2074,7 @@ Metron::discover()
         Json device;
         {
             Json rest = Json::make_object();
-            rest.set("username", _id);
+            rest.set("username", _agent_id);
             rest.set("password", "");
             rest.set("ip", _agent_ip);
             rest.set("port", _agent_port);
@@ -560,7 +2082,7 @@ Metron::discover()
             rest.set("url", "");
             rest.set("testUrl", "");
             rest.set("isProxy", false);
-            hw_info_to_json(rest);
+            sys_info_to_json(rest);
             device.set("rest", rest);
 
             Json basic = Json::make_object();
@@ -652,7 +2174,7 @@ Metron::get_assigned_cpus_nb()
 {
     int tot = 0;
     for (unsigned i = 0; i < get_cpus_nb(); i++) {
-        if (_cpu_map[i] != 0) {
+        if (_sc_to_core_map[i] != 0) {
             tot++;
         }
     }
@@ -684,9 +2206,9 @@ Metron::assign_cpus(ServiceChain *sc, Vector<int> &map)
 
     int j = 0;
 
-    for (unsigned i = 0; i < _cpu_map.size(); i++) {
-        if (_cpu_map[i] == 0) {
-            _cpu_map[i] = sc;
+    for (unsigned i = 0; i < _sc_to_core_map.size(); i++) {
+        if (_sc_to_core_map[i] == 0) {
+            _sc_to_core_map[i] = sc;
             map[j++] = i;
             if (j == map.size()) {
                 return true;
@@ -704,8 +2226,8 @@ void
 Metron::unassign_cpus(ServiceChain *sc)
 {
     for (unsigned i = 0; i < get_cpus_nb(); i++) {
-        if (_cpu_map[i] == sc) {
-            _cpu_map[i] = 0;
+        if (_sc_to_core_map[i] == sc) {
+            _sc_to_core_map[i] = 0;
         }
     }
 }
@@ -759,11 +2281,12 @@ Metron::instantiate_service_chain(ServiceChain *sc, ErrorHandler *errh)
         return ERROR;
     }
 
-    for (unsigned i = 0; i < cpu_phys_map.size(); i++) {
+    for (unsigned i = 0; i < (unsigned) cpu_phys_map.size(); i++) {
         assert(cpu_phys_map[i] >= 0);
-        sc->get_cpu_info(i).cpu_phys_id = cpu_phys_map[i];
+        sc->get_cpu_info(i).set_physical_id(cpu_phys_map[i]);
     }
-    for (unsigned i = 0; i < sc->_initial_cpus_nb; i++) {
+
+    for (unsigned i = 0; i < (unsigned) sc->_initial_cpus_nb; i++) {
         sc->get_cpu_info(i).set_active(true);
     }
 
@@ -782,7 +2305,7 @@ Metron::instantiate_service_chain(ServiceChain *sc, ErrorHandler *errh)
         click_chatter("Could not launch service chain...");
         unassign_cpus(sc);
         if (_fail) {
-            click_chatter("Metron is in fail mode... It is going to abort due to a major error !");
+            click_chatter("Metron failed to instantiate a service chain... It is going to abort due to a major error!");
             abort();
         }
         return ERROR;
@@ -832,32 +2355,591 @@ Metron::delete_service_chain(ServiceChain *sc, ErrorHandler *errh)
 }
 
 /**
+ * Schedule Metron agent's timer to connect to the controller.
+ */
+int
+Metron::connect(const Json &j)
+{
+    if (!_discover_timer.scheduled())
+        _discover_timer.schedule_now();
+    _discovered = true;
+
+    return SUCCESS;
+}
+
+/**
+ * Un-schedule Metron agent's timer to disconnect from the controller.
+ */
+int
+Metron::disconnect(const Json &j)
+{
+    // No controller
+    if (!_discovered) {
+        click_chatter(
+            "Cannot disconnect from the controller: Metron agent is not associated with a controller"
+        );
+        return ERROR;
+    }
+
+    if (_discover_timer.scheduled())
+        _discover_timer.unschedule();
+    _discovered = false;
+
+    return SUCCESS;
+}
+
+/**
+ * Manage Metron agent's NIC ports through JSON.
+ */
+int
+Metron::nic_port_administrator(const Json &j)
+{
+    // No controller
+    if (!_discovered) {
+        click_chatter(
+            "Cannot manage NIC ports: Metron agent is not associated with a controller"
+        );
+        return ERROR;
+    }
+
+    // Get port command
+    int port_number = j.get_i("port");
+    String port_status = j.get_s("portStatus");
+
+    click_chatter("Metron controller requested to %s NIC port %d", port_status.c_str(), port_number);
+
+    NIC *nic = get_nic_by_index(port_number);
+    if (!nic) {
+        click_chatter("Cannot manage the status of unknown NIC port %d", port_number);
+        return ERROR;
+    }
+
+    // Set the status of the port
+    nic->set_active(port_status == "enable" ? true : false);
+
+    return SUCCESS;
+}
+
+/**
+ * Report Metron agent's NIC queues using JSON.
+ */
+Json
+Metron::nic_queues_report()
+{
+    Json jroot = Json::make_object();
+
+    // No controller
+    if (!_discovered) {
+        click_chatter(
+            "Cannot report NIC queues: Metron agent is not associated with a controller"
+        );
+        return jroot;
+    }
+
+    click_chatter("Metron controller requested to report NIC queues");
+
+    // An array of NICs
+    Json jnics = Json::make_array();
+
+    auto begin = _nics.begin();
+    while (begin != _nics.end()) {
+        NIC *nic = &begin.value();
+        FromDPDKDevice *fd = nic->cast();
+        DPDKDevice::DevInfo fd_info = fd->get_device()->get_info();
+
+        Json jnic = Json::make_object();
+        jnic.set("id", nic->get_index());
+
+        // Each NIC requires an array of queues
+        Json jqueues = Json::make_array();
+
+        for (unsigned i = 0; i < (unsigned)fd_info.rx_queues.size(); i++) {
+            // Active queue
+            if (fd_info.rx_queues[i]) {
+               Json jqueue = Json::make_object();
+               jqueue.set("id", i);
+               jqueue.set("type", "MAX");  // ONOS supports MIN, MAX, PRIORITY, BURST
+               jqueue.set("maxRate", nic->call_rx_read("speed"));
+               jqueues.push_back(jqueue);
+            }
+        }
+
+        jnic.set("queues", jqueues);
+        jnics.push_back(jnic);
+
+        begin++;
+    }
+
+    jroot.set("nics", jnics);
+
+    return jroot;
+}
+
+/**
+ * Encodes hardware information to JSON.
+ */
+void
+Metron::sys_info_to_json(Json &j)
+{
+    j.set("manufacturer", Json(_sys_res->get_cpu_vendor()));
+    j.set("hwVersion", Json(_sys_res->get_hw_info()));
+    j.set("swVersion", Json(_sys_res->get_sw_info()));
+}
+
+/**
+ * Encodes Metron resources to JSON.
+ */
+Json
+Metron::to_json()
+{
+    Json jroot = Json::make_object();
+
+    click_chatter("Metron controller requested server's resources");
+
+    jroot.set("id", Json(_agent_id));
+    jroot.set("serial", Json(_sys_res->get_serial_number()));
+    jroot.set("chassisId", Json(atol(_sys_res->get_chassis_id().c_str())));
+
+    // System Info
+    sys_info_to_json(jroot);
+
+    // CPU resources
+    Json jcpus = Json::make_array();
+    for (unsigned i = 0; i < (unsigned) get_cpus_nb(); i++) {
+        jcpus.push_back(
+            _sys_res->get_cpu_layout().get_cpu_core(i)->to_json()
+        );
+    }
+    jroot.set("cpus", jcpus);
+
+    // CPU cache resources
+    Json jcaches = _sys_res->get_cpu_cache_hiearchy().to_json();
+    jroot.set("cpuCacheHierarchy", jcaches);
+
+    // Main memory resources
+    Json jmem = _sys_res->get_memory().to_json();
+    jroot.set("memoryHierarchy", jmem);
+
+    // NIC resources
+    Json jnics = Json::make_array();
+    auto begin = _nics.begin();
+    while (begin != _nics.end()) {
+        jnics.push_back(begin.value().to_json(this->_rx_mode, false));
+        begin++;
+    }
+    jroot.set("nics", jnics);
+
+    return jroot;
+}
+
+#if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
+/**
+ * Flushes all rules from all Metron NICs.
+ */
+int
+Metron::flush_nics()
+{
+    auto it = _nics.begin();
+    while (it != _nics.end()) {
+        NIC *nic = &it.value();
+
+        FlowDispatcher::get_flow_dispatcher(nic->get_port_id())->flow_rules_flush();
+
+        it++;
+    }
+
+    return SUCCESS;
+}
+#endif
+
+/**
+ * Encodes time to JSON.
+ */
+Json
+Metron::time_to_json()
+{
+    Json jroot = Json::make_object();
+
+    // No controller
+    if (!_discovered) {
+        click_chatter(
+            "Cannot report time: Metron agent is not associated with a controller"
+        );
+        return jroot;
+    }
+
+    click_chatter("Metron controller requested the time of this server");
+
+    // Enclose the timestamp into JSON
+    jroot.set("time", Json(static_cast<long>(Timestamp::now().longval())));
+
+    return jroot;
+}
+
+/**
+ * Encodes system (e.g., CPU, NIC) statistics to JSON.
+ */
+Json
+Metron::system_stats_to_json()
+{
+    Json jroot = Json::make_object();
+
+    // No controller
+    if (!_discovered) {
+        click_chatter(
+            "Cannot report global statistics: Metron agent is not associated with a controller"
+        );
+        return jroot;
+    }
+
+    click_chatter("Metron controller requested system statistics");
+
+    // High-level CPU resources
+    jroot.set("busyCpus", Json(get_assigned_cpus_nb()));
+    jroot.set("freeCpus", Json(get_cpus_nb() - get_assigned_cpus_nb()));
+
+    // Per core load
+    Json jcpus = Json::make_array();
+
+    /**
+     * First, go through the active chains and search for
+     * CPUs with some real load.
+     * Mark them so that we can find the idle ones next.
+     */
+    int assigned_cpus = 0;
+    Vector<int> busy_cpus;
+    auto sci = _scs.begin();
+    while (sci != _scs.end()) {
+        ServiceChain *sc = sci.value();
+
+        for (unsigned j = 0; j < sc->get_max_cpu_nb(); j++) {
+            jcpus.push_back(sc->get_cpu_stats(j));
+            busy_cpus.push_back(sc->get_cpu_phys_id(j));
+            assigned_cpus++;
+        }
+
+        sci++;
+    }
+
+    // Now, inititialize the load of each idle core to 0
+    for (unsigned j = 0; j < get_cpus_nb(); j++) {
+        int *found = find(busy_cpus.begin(), busy_cpus.end(), (int) j);
+        // This is a busy one
+        if (found != busy_cpus.end()) {
+            continue;
+        }
+
+        Json jcpu = Json::make_object();
+        jcpu.set("id", j);
+        jcpu.set("load", 0);      // No load
+        jcpu.set("queue", -1);
+        jcpu.set("busy", -1);  // This CPU core is free
+
+        if (_monitoring_mode) {
+            LatencyStats lat = LatencyStats();
+            add_per_core_monitoring_data(&jcpu, lat);
+        }
+
+        jcpus.push_back(jcpu);
+    }
+
+    /*
+     * At this point the JSON array should have load
+     * information for each core of this server.
+     */
+    assert(jcpus.size() == get_cpus_nb());
+    assert(assigned_cpus == get_assigned_cpus_nb());
+
+    jroot.set("cpus", jcpus);
+
+    // Main memory statistics
+    jroot.set("memory", _sys_res->get_memory().get_memory_stats().to_json());
+
+    // NIC resources
+    Json jnics = Json::make_array();
+    auto begin = _nics.begin();
+    while (begin != _nics.end()) {
+        jnics.push_back(begin.value().to_json(this->_rx_mode, true));
+        begin++;
+    }
+    jroot.set("nics", jnics);
+
+    return jroot;
+}
+
+Json
+Metron::setup_link_discovery()
+{
+    Json jroot = Json::make_object();
+
+    // No controller
+    if (!_discovered) {
+        click_chatter(
+            "Cannot perform link discovery: Metron agent is not associated with a controller"
+        );
+        return jroot;
+    }
+
+    click_chatter("Metron controller requested link discovery");
+
+    click_chatter("Link discovery not supported yet");
+
+    return jroot;
+}
+
+#if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
+Json
+Metron::nics_table_stats_to_json()
+{
+    Json jroot = Json::make_object();
+
+    // No controller
+    if (!_discovered) {
+        click_chatter(
+            "Cannot report NIC(s) table statistics: Metron agent is not associated with a controller"
+        );
+        return jroot;
+    }
+
+    click_chatter("Metron controller requested NIC(s) table statistics");
+
+    // NIC resources
+    Json jnics = Json::make_array();
+    auto begin = _nics.begin();
+    while (begin != _nics.end()) {
+        NIC *nic = &begin.value();
+
+        Json jnic = Json::make_object();
+        jnic.set("id", nic->get_index());
+
+        FlowDispatcher *fd = FlowDispatcher::get_flow_dispatcher(nic->get_port_id());
+        NicTableStats rule_stats(nic->get_port_id());
+        fd->flow_rule_table_stats(rule_stats);
+
+        // Arrays of NIC tables
+        Json jtables = Json::make_array();
+
+        Json jtable = Json::make_object();
+        jtable.set("id", 0); // Currently all rules reside in the same table
+        jtable.set("activeEntries", rule_stats.rules_nb());
+        jtable.set("pktsLookedUp", rule_stats.pkts_looked_up());
+        jtable.set("pktsMatched", rule_stats.pkts_matched());
+        int32_t table_capacity = rule_stats.capacity();
+        if (table_capacity > 0) {
+            jtable.set("maxSize", table_capacity);
+        }
+        jtables.push_back(jtable);
+
+        jnic.set("table", jtables);
+        jnics.push_back(jnic);
+
+        begin++;
+    }
+    jroot.set("nics", jnics);
+
+    return jroot;
+}
+#endif
+
+/**
+ * Extends the input JSON object with additional fields.
+ * These fields contain per-core measurements, such as
+ * average throughput and several latency percentiles.
+ */
+void
+Metron::add_per_core_monitoring_data(Json *jobj, LatencyStats &lat)
+{
+    if (!jobj) {
+        click_chatter("Input JSON object is NULL. Cannot add per-core monitoring data");
+        return;
+    }
+
+    if ((lat.get_avg_throughput() < 0) || (lat.get_min_latency() < 0) ||
+        (lat.get_avg_latency() < 0) || (lat.get_max_latency() < 0)) {
+        click_chatter("Invalid per-core monitoring data");
+        return;
+    }
+
+    Json jtput = Json::make_object();
+    jtput.set("average", lat.get_avg_throughput());
+    jtput.set("unit", "bps");
+    jobj->set("throughput", jtput);
+
+    Json jlat = Json::make_object();
+    jlat.set("min", lat.get_min_latency());
+    jlat.set("average", lat.get_avg_latency());
+    jlat.set("max", lat.get_max_latency());
+    jlat.set("unit", "ns");
+    jobj->set("latency", jlat);
+}
+
+/**
+ * Encodes controller information to JSON.
+ */
+Json
+Metron::controllers_to_json()
+{
+    Json jroot = Json::make_object();
+
+    // No controller
+    if (!_discovered) {
+        return jroot;
+    }
+
+    click_chatter("Metron controller requested the controllers of this server");
+
+    // A list with a single controller (always)
+    Json jctrls_list = Json::make_array();
+    Json jctrl = Json::make_object();
+    jctrl.set("ip", _discover_ip);
+    jctrl.set("port", _discover_port);
+    jctrl.set("type", "tcp");
+    jctrls_list.push_back(jctrl);
+
+    jroot.set("controllers", jctrls_list);
+
+    return jroot;
+}
+
+/**
+ * Decodes controller information from JSON.
+ */
+int
+Metron::controllers_from_json(const Json &j)
+{
+    click_chatter("Metron controller requested to update the controllers of this server");
+
+    // A list of controllers is expected
+    Json jlist = j.get("controllers");
+
+    for (unsigned short i = 0; i < jlist.size(); i++) {
+        String ctrl_ip;
+        int    ctrl_port = -1;
+        String ctrl_type;
+
+        // Get this controller's information
+        Json jctrl = jlist[i];
+
+        // Store the new parameters
+        ctrl_ip   = jctrl.get_s("ip");
+        ctrl_port = jctrl.get_i("port");
+        ctrl_type = jctrl.get_s("type");
+
+        // Incorrect information received
+        if (ctrl_ip.empty() || (ctrl_port < 0)) {
+            click_chatter(
+                "Invalid controller information: IP (%s), Port (%d)",
+                ctrl_ip.c_str(), ctrl_port
+            );
+            return ERROR;
+        }
+
+        // Need to re-discover, we got a new controller instance
+        if ((ctrl_ip != _discover_ip) || (!_discovered)) {
+            _discover_ip   = ctrl_ip;
+            _discover_port = ctrl_port;
+
+            click_chatter(
+                "Controller instance updated: IP (%s), Port (%d)",
+                ctrl_ip.c_str(), ctrl_port
+            );
+
+            // Initiate discovery
+            _discovered = discover();
+            return _discovered;
+        } else {
+            click_chatter(
+                "Controller instance persists: IP (%s), Port (%d)",
+                ctrl_ip.c_str(), ctrl_port
+            );
+        }
+
+        // No support for multiple controller instances
+        break;
+    }
+
+    return SUCCESS;
+}
+
+/**
+ * Disassociates a Metron agent from a Metron controller.
+ */
+int
+Metron::controller_delete_from_json(const String &ip)
+{
+    click_chatter("Metron controller requested to delete the controller of this server");
+
+    // This agent is not associated with a Metron controller at the moment
+    if (_discover_ip.empty()) {
+        click_chatter("No controller associated with this Metron agent");
+        return ERROR;
+    }
+
+    // Request to delete a controller must have correct IP
+    if ((!ip.empty()) && (ip != _discover_ip)) {
+        click_chatter("Metron agent is not associated with a Metron controller on %s", ip.c_str());
+        return ERROR;
+    }
+
+    click_chatter(
+        "Metron controller instance on %s:%d has been deleted",
+        _discover_ip.c_str(), _discover_port
+    );
+
+    // Reset controller information
+    _discovered    = false;
+    _discover_ip   = "";
+    _discover_port = -1;
+
+    return SUCCESS;
+}
+
+/**
  * Metron agent's read handlers.
  */
 String
 Metron::read_handler(Element *e, void *user_data)
 {
     Metron *m = static_cast<Metron *>(e);
+    assert(m);
     intptr_t what = reinterpret_cast<intptr_t>(user_data);
 
     Json jroot = Json::make_object();
 
     switch (what) {
-        case h_discovered: {
+        case h_server_discovered: {
             return m->_discovered? "true" : "false";
         }
-        case h_resources: {
+        case h_server_resources: {
             jroot = m->to_json();
+            break;
+        }
+        case h_server_time: {
+            jroot = m->time_to_json();
+            break;
+        }
+        case h_server_stats: {
+            jroot = m->system_stats_to_json();
+            break;
+        }
+        case h_nic_queues: {
+            jroot = m->nic_queues_report();
+            break;
+        }
+        case h_nic_link_discovery: {
+            jroot = m->setup_link_discovery();
             break;
         }
         case h_controllers: {
             jroot = m->controllers_to_json();
             break;
         }
-        case h_stats: {
-            jroot = m->stats_to_json();
+    #if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
+        case h_rules_table_stats: {
+            jroot = m->nics_table_stats_to_json();
             break;
         }
+    #endif
         default: {
             click_chatter("Unknown read handler: %d", what);
             return "";
@@ -877,10 +2959,19 @@ Metron::write_handler(
     Metron *m = static_cast<Metron *>(e);
     intptr_t what = reinterpret_cast<intptr_t>(user_data);
     switch (what) {
-        case h_controllers: {
+        case h_server_connect: {
+            return m->connect(Json::parse(data));
+        }
+        case h_server_disconnect: {
+            return m->disconnect(Json::parse(data));
+        }
+        case h_nic_ports: {
+            return m->nic_port_administrator(Json::parse(data));
+        }
+        case h_controllers_set: {
             return m->controllers_from_json(Json::parse(data));
         }
-        case h_delete_chains: {
+        case h_service_chains_delete: {
             ServiceChain *sc = m->find_service_chain_by_id(data);
             if (!sc) {
                 return errh->error(
@@ -889,19 +2980,23 @@ Metron::write_handler(
                 );
             }
 
+            click_chatter("Metron controller requested service chain deletion");
+
             int ret = m->delete_service_chain(sc, errh);
             if (ret == SUCCESS) {
                 errh->message("Deleted service chain with ID: %s", sc->get_id().c_str());
                 delete(sc);
+            } else {
+                errh->error("Failed to delete service chain with ID: %s", sc->get_id().c_str());
             }
 
             return ret;
         }
-        case h_delete_controllers: {
-            return m->delete_controller_from_json((const String &) data);
+        case h_controllers_delete: {
+            return m->controller_delete_from_json((const String &) data);
         }
     #if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
-        case h_add_rules_from_file: {
+        case h_rules_add_from_file: {
             int delim = data.find_left(' ');
             // Only one argument was given
             if (delim < 0) {
@@ -915,7 +3010,7 @@ Metron::write_handler(
             if (!nic) {
                 return errh->error("Invalid NIC %s", nic_name.c_str());
             }
-            FromDPDKDevice *fd = dynamic_cast<FromDPDKDevice *>(nic->element);
+            FromDPDKDevice *fd = nic->cast();
             if (!fd) {
                 return errh->error("Invalid NIC %s", nic_name.c_str());
             }
@@ -931,7 +3026,7 @@ Metron::write_handler(
 
             return SUCCESS;
         }
-        case h_delete_rules: {
+        case h_rules_delete: {
             click_chatter("Metron controller requested rule deletion");
 
             int32_t deleted_rules = ServiceChain::delete_rule_batch_from_json(data, m, errh);
@@ -941,7 +3036,7 @@ Metron::write_handler(
 
             return SUCCESS;
         }
-        case h_verify_nic: {
+        case h_rules_verify: {
             // Split input arguments
             int delim = data.find_left(' ');
             if (delim < 0) {
@@ -956,7 +3051,7 @@ Metron::write_handler(
             if (!nic) {
                 return errh->error("Invalid NIC %s", nic_name.c_str());
             }
-            FromDPDKDevice *fd = dynamic_cast<FromDPDKDevice *>(nic->element);
+            FromDPDKDevice *fd = nic->cast();
             if (!fd) {
                 return errh->error("Invalid NIC %s", nic_name.c_str());
             }
@@ -981,7 +3076,7 @@ Metron::write_handler(
             FlowDispatcher::get_flow_dispatcher(port_id)->rule_consistency_check(rules_present);
             return SUCCESS;
         }
-        case h_flush_nics: {
+        case h_rules_flush: {
             click_chatter("Metron controller requested to flush all NICs");
             return m->flush_nics();
         }
@@ -1010,7 +3105,7 @@ Metron::param_handler(
 
         intptr_t what = reinterpret_cast<intptr_t>(h->read_user_data());
         switch (what) {
-            case h_chains: {
+            case h_service_chains: {
                 if (param == "") {
                     Json jscs = Json::make_array();
                     auto begin = m->_scs.begin();
@@ -1031,7 +3126,7 @@ Metron::param_handler(
                 }
                 break;
             }
-            case h_chains_stats: {
+            case h_service_chains_stats: {
                 if (param == "") {
                     Json jscs = Json::make_array();
                     auto begin = m->_scs.begin();
@@ -1052,10 +3147,27 @@ Metron::param_handler(
                 }
                 break;
             }
+            case h_service_chains_proxy: {
+                int pos = param.find_left("/");
+                if (pos <= 0) {
+                    param = "You must give a service chain ID, then a command";
+                    return SUCCESS;
+                }
+                String ids = param.substring(0, pos);
+                ServiceChain *sc = m->find_service_chain_by_id(ids);
+                if (!sc) {
+                    return errh->error(
+                        "Unknown service chain ID: %s",
+                        ids.c_str()
+                    );
+                }
+                param = sc->_manager->command(param.substring(pos + 1));
+                return SUCCESS;
+            }
         #if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
-            case h_chains_rules: {
+            case h_rules: {
                 if (param == "") {
-                    click_chatter("Metron controller requested local rules for all service chains");
+                    click_chatter("Metron controller requested local NIC rules for all service chains");
 
                     Json jscs = Json::make_array();
 
@@ -1075,7 +3187,7 @@ Metron::param_handler(
                         );
                     }
                     click_chatter(
-                        "Metron controller requested local rules for service chain %s",
+                        "Metron controller requested local NIC rules for service chain %s",
                         sc->get_id().c_str()
                     );
                     jroot = sc->rules_to_json();
@@ -1083,23 +3195,6 @@ Metron::param_handler(
                 break;
             }
         #endif
-            case h_chains_proxy: {
-                int pos = param.find_left("/");
-                if (pos <= 0) {
-                    param = "You must give a service chain ID, then a command";
-                    return SUCCESS;
-                }
-                String ids = param.substring(0, pos);
-                ServiceChain *sc = m->find_service_chain_by_id(ids);
-                if (!sc) {
-                    return errh->error(
-                        "Unknown service chain ID: %s",
-                        ids.c_str()
-                    );
-                }
-                param = sc->_manager->command(param.substring(pos + 1));
-                return SUCCESS;
-            }
             default: {
                 return errh->error("Invalid read operation in param handler");
             }
@@ -1112,7 +3207,7 @@ Metron::param_handler(
     } else if (operation == Handler::f_write) {
         intptr_t what = reinterpret_cast<intptr_t>(h->write_user_data());
         switch (what) {
-            case h_chains: {
+            case h_service_chains: {
                 Json jroot = Json::parse(param);
                 Json jlist = jroot.get("serviceChains");
                 if (jlist.size() == 0) {
@@ -1151,7 +3246,7 @@ Metron::param_handler(
 
                 return SUCCESS;
             }
-            case h_put_chains: {
+            case h_service_chains_put: {
                 String id = param.substring(0, param.find_left('\n'));
                 String changes = param.substring(id.length() + 1);
                 ServiceChain *sc = m->find_service_chain_by_id(id);
@@ -1171,7 +3266,7 @@ Metron::param_handler(
                 return SUCCESS;
             }
         #if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
-            case h_chains_rules: {
+            case h_rules: {
                 Json jroot = Json::parse(param);
                 Json jlist = jroot.get("rules");
                 for (auto jsc : jlist) {
@@ -1234,7 +3329,7 @@ Metron::rule_stats_handler(int operation, String &param, Element *e, const Handl
     if (!nic) {
         return errh->error("Handler %s requires a valid NIC instance as input parameter", h->name().c_str());
     }
-    FromDPDKDevice *fd = dynamic_cast<FromDPDKDevice *>(nic->element);
+    FromDPDKDevice *fd = nic->cast();
     if (!fd) {
         return errh->error("Handler %s requires a valid NIC instance as input parameter", h->name().c_str());
     }
@@ -1310,43 +3405,63 @@ Metron::rule_stats_handler(int operation, String &param, Element *e, const Handl
 #endif
 
 /**
- * Creates Metron agent's handlers.
+ * Metron's handlers and REST API.
  */
 void
 Metron::add_handlers()
 {
-    // HTTP get handlers
-    add_read_handler ("discovered",  read_handler,  h_discovered);
-    add_read_handler ("resources",   read_handler,  h_resources);
+    // Generic server resource handlers
+    add_write_handler("server_connect",    write_handler, h_server_connect);
+    add_write_handler("server_disconnect", write_handler, h_server_disconnect);
+    add_read_handler ("server_discovered", read_handler,  h_server_discovered);
+    add_read_handler ("server_time",       read_handler,  h_server_time);
+    add_read_handler ("server_resources",  read_handler,  h_server_resources);
+    add_read_handler ("server_stats",      read_handler,  h_server_stats);
+
+    // NIC device management handlers
+    add_write_handler("nic_ports",     write_handler, h_nic_ports);
+    add_read_handler ("nic_queues",    read_handler,  h_nic_queues);
+    add_read_handler ("nic_link_disc", read_handler,  h_nic_link_discovery);
+
+    // Controller management handlers
     add_read_handler ("controllers", read_handler,  h_controllers);
-    add_read_handler ("stats",       read_handler,  h_stats);
+    add_write_handler("controllers", write_handler, h_controllers_set);
+    add_write_handler("controllers_delete", write_handler, h_controllers_delete);
 
-    // HTTP post handlers
-    add_write_handler("controllers",     write_handler, h_controllers);
-#if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
-    add_write_handler("add_rules_from_file", write_handler, h_add_rules_from_file);
-#endif
-
-    // Get and POST HTTP handlers with parameters
+    // Service chain handlers
     set_handler(
-        "put_chains",
-        Handler::f_write,
-        param_handler, h_put_chains, h_put_chains);
-
-    set_handler(
-        "chains",
+        "service_chains",
         Handler::f_write | Handler::f_read | Handler::f_read_param,
-        param_handler, h_chains, h_chains
+        param_handler, h_service_chains, h_service_chains
     );
     set_handler(
-        "chains_stats", Handler::f_read | Handler::f_read_param,
-        param_handler, h_chains_stats
+        "service_chains_put",
+        Handler::f_write,
+        param_handler, h_service_chains_put, h_service_chains_put
     );
+    set_handler(
+        "service_chains_stats", Handler::f_read | Handler::f_read_param,
+        param_handler, h_service_chains_stats
+    );
+    set_handler(
+        "service_chains_proxy", Handler::f_read | Handler::f_read_param,
+        param_handler, h_service_chains_proxy
+    );
+    add_write_handler(
+        "service_chains_delete", write_handler, h_service_chains_delete
+    );
+
+    // Rule handlers
 #if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
     set_handler(
         "rules", Handler::f_write | Handler::f_read | Handler::f_read_param,
-        param_handler, h_chains_rules, h_chains_rules
+        param_handler, h_rules, h_rules
     );
+    add_write_handler("rules_add_from_file", write_handler, h_rules_add_from_file);
+    add_read_handler ("rules_table_stats",   read_handler,  h_rules_table_stats);
+    add_write_handler("rules_verify",        write_handler, h_rules_verify);
+    add_write_handler("rules_delete",        write_handler, h_rules_delete);
+    add_write_handler("rules_flush",         write_handler, h_rules_flush);
 
     set_handler(
         "rule_installation_lat_min", Handler::f_read | Handler::f_read_param,
@@ -1398,336 +3513,20 @@ Metron::add_handlers()
         rule_stats_handler, h_rule_del_rate_max, h_rule_del_rate_max
     );
 #endif
-    set_handler(
-        "chains_proxy", Handler::f_read | Handler::f_read_param,
-        param_handler, h_chains_proxy
-    );
-
-    // HTTP delete handlers
-    add_write_handler("delete_chains", write_handler, h_delete_chains);
-#if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
-    add_write_handler("delete_rules",  write_handler, h_delete_rules);
-    add_write_handler("verify_nic",    write_handler, h_verify_nic);
-    add_write_handler("flush_nics",    write_handler, h_flush_nics);
-#endif
-    add_write_handler("delete_controllers", write_handler, h_delete_controllers);
 }
-
-/**
- * Encodes hardware information to JSON.
- */
-void
-Metron::hw_info_to_json(Json &j)
-{
-    j.set("manufacturer", Json(_cpu_vendor));
-    j.set("hwVersion", Json(_hw));
-    j.set("swVersion", Json("Click " + _sw));
-}
-
-/**
- * Encodes Metron resources to JSON.
- */
-Json
-Metron::to_json()
-{
-    Json jroot = Json::make_object();
-
-    jroot.set("id", Json(_id));
-    jroot.set("serial", Json(_serial));
-
-    // Info
-    hw_info_to_json(jroot);
-
-    // CPU resources
-    Json jcpus = Json::make_array();
-    for (unsigned i = 0; i < get_cpus_nb(); i++) {
-        uint64_t cycles_mhz = cycles_hz() / CPU::MEGA_HZ;   // In MHz
-        assert(cycles_mhz > 0);
-
-        Json jcpu = Json::make_object();
-        jcpu.set("id", i);
-        jcpu.set("vendor", _cpu_vendor);
-        jcpu.set("frequency", cycles_mhz);
-        jcpus.push_back(jcpu);
-    }
-    jroot.set("cpus", jcpus);
-
-    // NIC resources
-    Json jnics = Json::make_array();
-    auto begin = _nics.begin();
-    while (begin != _nics.end()) {
-        jnics.push_back(begin.value().to_json(this->_rx_mode, false));
-        begin++;
-    }
-    jroot.set("nics", jnics);
-
-    return jroot;
-}
-
-#if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
-/**
- * Flushes all rules from all Metron NICs.
- */
-int
-Metron::flush_nics()
-{
-    auto it = _nics.begin();
-    while (it != _nics.end()) {
-        NIC *nic = &it.value();
-
-        FlowDispatcher::get_flow_dispatcher(nic->get_port_id())->flow_rules_flush();
-
-        it++;
-    }
-
-    return SUCCESS;
-}
-#endif
-
-/**
- * Encodes global Metron statistics to JSON.
- */
-Json
-Metron::stats_to_json()
-{
-    Json jroot = Json::make_object();
-
-    // No controller
-    if (!_discovered) {
-        click_chatter(
-            "Cannot report global statistics: Metron agent is not associated with a controller"
-        );
-        return jroot;
-    }
-
-    // High-level CPU resources
-    jroot.set("busyCpus", Json(get_assigned_cpus_nb()));
-    jroot.set("freeCpus", Json(get_cpus_nb() - get_assigned_cpus_nb()));
-
-    // Per core load
-    Json jcpus = Json::make_array();
-
-    /**
-     * First, go through the active chains and search for
-     * CPUs with some real load.
-     * Mark them so that we can find the idle ones next.
-     */
-    int assigned_cpus = 0;
-    Vector<int> busy_cpus;
-    auto sci = _scs.begin();
-    while (sci != _scs.end()) {
-        ServiceChain *sc = sci.value();
-
-        for (unsigned j = 0; j < sc->get_max_cpu_nb(); j++) {
-            Json jcpu = sc->get_cpu_stats(j);
-            jcpus.push_back(jcpu);
-
-            assigned_cpus++;
-            busy_cpus.push_back(sc->get_cpu_phys_id(j));
-        }
-
-        sci++;
-    }
-
-    // Now, inititialize the load of each idle core to 0
-    for (unsigned j = 0; j < get_cpus_nb(); j++) {
-        int *found = find(busy_cpus.begin(), busy_cpus.end(), (int) j);
-        // This is a busy one
-        if (found != busy_cpus.end()) {
-            continue;
-        }
-
-        Json jcpu = Json::make_object();
-        jcpu.set("id", j);
-        jcpu.set("load", 0);      // No load
-        jcpu.set("queue", -1);
-        jcpu.set("busy", -1);  // This CPU core is free
-
-        if (_monitoring_mode) {
-            add_per_core_monitoring_data(&jcpu, LatencyInfo());
-        }
-
-        jcpus.push_back(jcpu);
-    }
-
-    /*
-     * At this point the JSON array should have load
-     * information for each core of this server.
-     */
-    assert(jcpus.size() == get_cpus_nb());
-    assert(assigned_cpus == get_assigned_cpus_nb());
-
-    jroot.set("cpus", jcpus);
-
-    // NIC resources
-    Json jnics = Json::make_array();
-    auto begin = _nics.begin();
-    while (begin != _nics.end()) {
-        jnics.push_back(begin.value().to_json(this->_rx_mode, true));
-        begin++;
-    }
-    jroot.set("nics", jnics);
-
-    return jroot;
-}
-
-/**
- * Extends the input JSON object with additional fields.
- * These fields contain per-core measurements, such as
- * average throughput and several latency percentiles.
- */
-void
-Metron::add_per_core_monitoring_data(Json *jobj, const LatencyInfo &lat)
-{
-    if (!jobj) {
-        click_chatter("Input JSON object is NULL. Cannot add per-core monitoring data");
-        return;
-    }
-
-    if ((lat.avg_throughput < 0) || (lat.min_latency < 0) ||
-        (lat.average_latency < 0) || (lat.max_latency < 0)) {
-        click_chatter("Invalid per-core monitoring data");
-        return;
-    }
-
-    Json jtput = Json::make_object();
-    jtput.set("average", lat.avg_throughput);
-    jtput.set("unit", "bps");
-    jobj->set("throughput", jtput);
-
-    Json jlat = Json::make_object();
-    jlat.set("min", lat.min_latency);
-    jlat.set("average", lat.average_latency);
-    jlat.set("max", lat.max_latency);
-    jlat.set("unit", "ns");
-    jobj->set("latency", jlat);
-}
-
-/**
- * Encodes controller information to JSON.
- */
-Json
-Metron::controllers_to_json()
-{
-    Json jroot = Json::make_object();
-
-    // No controller
-    if (!_discovered) {
-        return jroot;
-    }
-
-    // A list with a single controller (always)
-    Json jctrls_list = Json::make_array();
-    Json jctrl = Json::make_object();
-    jctrl.set("ip", _discover_ip);
-    jctrl.set("port", _discover_port);
-    jctrl.set("type", "tcp");
-    jctrls_list.push_back(jctrl);
-
-    jroot.set("controllers", jctrls_list);
-
-    return jroot;
-}
-
-/**
- * Decodes controller information from JSON.
- */
-int
-Metron::controllers_from_json(const Json &j)
-{
-    // A list of controllers is expected
-    Json jlist = j.get("controllers");
-
-    for (unsigned short i = 0; i < jlist.size(); i++) {
-        String ctrl_ip;
-        int    ctrl_port = -1;
-        String ctrl_type;
-
-        // Get this controller's information
-        Json jctrl = jlist[i];
-
-        // Store the new parameters
-        ctrl_ip   = jctrl.get_s("ip");
-        ctrl_port = jctrl.get_i("port");
-        ctrl_type = jctrl.get_s("type");
-
-        // Incorrect information received
-        if (ctrl_ip.empty() || (ctrl_port < 0)) {
-            click_chatter(
-                "Invalid controller information: IP (%s), Port (%d)",
-                ctrl_ip.c_str(), ctrl_port
-            );
-            return ERROR;
-        }
-
-        // Need to re-discover, we got a new controller instance
-        if ((ctrl_ip != _discover_ip) || (!_discovered)) {
-            _discover_ip   = ctrl_ip;
-            _discover_port = ctrl_port;
-
-            click_chatter(
-                "Controller instance updated: IP (%s), Port (%d)",
-                ctrl_ip.c_str(), ctrl_port
-            );
-
-            // Initiate discovery
-            _discovered = discover();
-            return _discovered;
-        } else {
-            click_chatter(
-                "Controller instance persists: IP (%s), Port (%d)",
-                ctrl_ip.c_str(), ctrl_port
-            );
-        }
-
-        // No support for multiple controller instances
-        break;
-    }
-
-    return SUCCESS;
-}
-
-/**
- * Disassociates this Metron agent from a Metron controller.
- */
-int
-Metron::delete_controller_from_json(const String &ip)
-{
-    // This agent is not associated with a Metron controller at the moment
-    if (_discover_ip.empty()) {
-        click_chatter("No controller associated with this Metron agent");
-        return ERROR;
-    }
-
-    // Request to delete a controller must have correct IP
-    if ((!ip.empty()) && (ip != _discover_ip)) {
-        click_chatter("Metron agent is not associated with a Metron controller on %s", ip.c_str());
-        return ERROR;
-    }
-
-    click_chatter(
-        "Metron controller instance on %s:%d has been deleted",
-        _discover_ip.c_str(), _discover_port
-    );
-
-    // Reset controller information
-    _discovered    = false;
-    _discover_ip   = "";
-    _discover_port = -1;
-
-    return SUCCESS;
-}
-
-
 
 /***************************************
  * RxFilter
  **************************************/
+/**
+ * RxFilter constructor.
+ */
 ServiceChain::RxFilter::RxFilter(ServiceChain *sc) : sc(sc)
-{
+{}
 
-}
-
+/**
+ * RxFilter destructor.
+ */
 ServiceChain::RxFilter::~RxFilter()
 {
     values.clear();
@@ -1925,6 +3724,9 @@ ServiceChain::RxFilter::apply(NIC *nic, ErrorHandler *errh)
 /************************
  * Service Chain
  ************************/
+/**
+ * ServiceChain constructor.
+ */
 ServiceChain::ServiceChain(Metron *m)
     : id(), rx_filter(0), config(), config_type(UNKNOWN),
       _metron(m), _manager(0), _nics(), _cpus(), _nic_stats(),
@@ -1936,6 +3738,9 @@ ServiceChain::ServiceChain(Metron *m)
     _verbose = m->_verbose;
 }
 
+/**
+ * ServiceChain destructor.
+ */
 ServiceChain::~ServiceChain()
 {
     if (rx_filter) {
@@ -1959,10 +3764,7 @@ ServiceChain::initialize_cpus(int initial_cpu_nb, int max_cpu_nb)
     _initial_cpus_nb = initial_cpu_nb;
     _max_cpus_nb = max_cpu_nb;
     _autoscale = false;
-    _cpus.resize(max_cpu_nb,MetronCpuInfo());
-    for (unsigned i = 0; i < max_cpu_nb; i++) {
-        _cpus[i].cpu_phys_id = -1;
-    }
+    _cpus.resize(max_cpu_nb, CPUStats());
 }
 
 /**
@@ -1972,17 +3774,17 @@ Json
 ServiceChain::get_cpu_stats(int j)
 {
     ServiceChain *sc = this;
-    MetronCpuInfo &cpu = sc->get_cpu_info(j);
     int cpu_id = sc->get_cpu_phys_id(j);
+    CPUStats &cpu = sc->get_cpu_info(j);
     Json jcpu = Json::make_object();
     jcpu.set("id", cpu_id);
-    jcpu.set("queue", cpu.max_nic_queue);
-    jcpu.set("load", cpu.load);
+    jcpu.set("queue", cpu.get_max_nic_queue());
+    jcpu.set("load", cpu.get_load());
     jcpu.set("busy", cpu.active_since());
 
     // Additional per-core statistics in monitoring mode
     if (sc->_metron->_monitoring_mode) {
-        LatencyInfo lat = sc->get_cpu_info(j).latency;
+        LatencyStats lat = sc->get_cpu_info(j).get_latency();
         sc->_metron->add_per_core_monitoring_data(&jcpu, lat);
     }
 
@@ -2080,7 +3882,7 @@ ServiceChain::from_json(const Json &j, Metron *m, ErrorHandler *errh)
         }
     }
 
-    sc->_nic_stats.resize(sc->_nics.size() * sc->_max_cpus_nb,NicStat());
+    sc->_nic_stats.resize(sc->_nics.size() * sc->_max_cpus_nb, NicStat());
     sc->rx_filter = ServiceChain::RxFilter::from_json(j.get("rxFilter"), sc, errh);
 
     return sc;
@@ -2127,17 +3929,6 @@ ServiceChain::stats_to_json(bool monitoring_mode)
 
     Json jcpus = Json::make_array();
     for (unsigned j = 0; j < get_max_cpu_nb(); j++) {
-        String js = String(j);
-/*        int avg_max = 0;
-          for (unsigned i = 0; i < get_nics_nb(); i++) {
-            String is = String(i);
-            int avg = atoi(
-                simple_call_read("batchAvg" + is + "C" + js + ".average").c_str()
-            );
-            if (avg > avg_max)
-                avg_max = avg;
-        }*/
-
         Json jcpu = get_cpu_stats(j);
         jcpus.push_back(jcpu);
     }
@@ -2147,7 +3938,7 @@ ServiceChain::stats_to_json(bool monitoring_mode)
     jsc.set("nics", _manager->nic_stats_to_json());
 
     jsc.set("timingStats", _timing_stats.to_json());
-    jsc.set("autoScaleTimingStats", _as_timing_stats.to_json());
+    jsc.set("timingStatsAutoscale", _as_timing_stats.to_json());
 
     return jsc;
 }
@@ -2198,15 +3989,15 @@ ServiceChain::rules_from_json(Json j, Metron *m, ErrorHandler *errh)
 
         Json jcpus = jnic.second.get("cpus");
         for (auto jcpu : jcpus) {
-            int core_id = jcpu.second.get_i("cpuId");
-            assert(get_cpu_info(core_id).active());
+            int core_id = jcpu.second.get_i("id");
+            assert(get_cpu_info(core_id).is_active());
 
             HashMap<uint32_t, String> rules_map;
 
-            Json jrules = jcpu.second.get("cpuRules");
+            Json jrules = jcpu.second.get("rules");
             for (auto jrule : jrules) {
-                uint32_t rule_id = jrule.second.get_i("ruleId");
-                String rule = jrule.second.get_s("ruleContent");
+                uint32_t rule_id = jrule.second.get_i("id");
+                String rule = jrule.second.get_s("content");
                 rules_nb++;
 
                 // A '\n' must be appended at the end of this rule, if not there
@@ -2235,8 +4026,8 @@ ServiceChain::rules_from_json(Json j, Metron *m, ErrorHandler *errh)
                 HashMap<uint32_t, String> mirror_rules_map;
 
                 for (auto jrule : jrules) {
-                    uint32_t rule_id = jrule.second.get_i("ruleId");
-                    String rule = jrule.second.get_s("ruleContent");
+                    uint32_t rule_id = jrule.second.get_i("id");
+                    String rule = jrule.second.get_s("content");
                     rules_nb++;
 
                     // A '\n' must be appended at the end of this rule, if not there
@@ -2333,7 +4124,7 @@ ServiceChain::rules_to_json()
             }
 
             Json jcpu = Json::make_object();
-            jcpu.set("cpuId", j);
+            jcpu.set("id", j);
 
             Json jrules = Json::make_array();
 
@@ -2343,14 +4134,14 @@ ServiceChain::rules_to_json()
                 String rule = begin.value();
 
                 Json jrule = Json::make_object();
-                jrule.set("ruleId", rule_id);
-                jrule.set("ruleContent", rule);
+                jrule.set("id", rule_id);
+                jrule.set("content", rule);
                 jrules.push_back(jrule);
 
                 begin++;
             }
 
-            jcpu.set("cpuRules", jrules);
+            jcpu.set("rules", jrules);
 
             jcpus_array.push_back(jcpu);
         }
@@ -2658,7 +4449,7 @@ ServiceChain::do_autoscale(int n_cpu_change)
 
     int last_idx = get_active_cpu_nb() - 1;
     for (unsigned i = 0; i < abs(n_cpu_change); i++) {
-        get_cpu_info(last_idx + (n_cpu_change>0?i:-1)).set_active(n_cpu_change > 0);
+        get_cpu_info(last_idx + (n_cpu_change > 0 ? i : -1)).set_active(n_cpu_change > 0);
     }
     click_chatter(
         "Autoscale: Service chain %s uses %d CPU(s)",
@@ -2729,7 +4520,7 @@ ServiceChain::generate_configuration(bool add_extra)
     // Common parameters
     String rx_conf = "BURST 32, NUMA false, VERBOSE 99, ";
 
-    // NICs require an additional parameter if in Flow Director mode
+    // NICs require an additional parameter, if in FLOW mode
     if (get_rx_mode() == FLOW) {
         rx_conf += "MODE flow, ";
     }
@@ -2742,13 +4533,13 @@ ServiceChain::generate_configuration(bool add_extra)
         }
 
         for (unsigned j = 0; j < get_max_cpu_nb(); j++) {
-            assert(get_cpu_info(j).assigned());
+            assert(get_cpu_info(j).is_assigned());
             String js = String(j);
-            String active = (j < get_cpu_info(j).active() ? "1":"0");
+            String active = (j < get_cpu_info(j).is_active() ? "1":"0");
             int phys_cpu_id = get_cpu_phys_id(j);
             int queue_no = rx_filter->phys_cpu_to_queue(nic, phys_cpu_id);
             String ename = generate_configuration_slave_fd_name(i, j);
-            new_conf += ename + " :: " + nic->element->class_name() +
+            new_conf += ename + " :: " + nic->get_element()->class_name() +
                 "(" + nic->get_device_address() + ", QUEUE " + String(queue_no) +
                 ", N_QUEUES 1, MAXTHREADS 1, ";
             new_conf += rx_conf;
@@ -2763,7 +4554,7 @@ ServiceChain::generate_configuration(bool add_extra)
         new_conf += "\n";
 
         if (get_max_cpu_nb() == 1) {
-            assert(get_cpu_info(0).assigned());
+            assert(get_cpu_info(0).is_assigned());
             int phys_cpu_id = get_cpu_phys_id(0);
             int queue_no = rx_filter->phys_cpu_to_queue(nic, phys_cpu_id);
             new_conf += "slaveTD" + is + " :: Null -> " + _metron->_slave_td_args + "ToDPDKDevice(" + nic->get_device_address() + ", QUEUE " + String(queue_no) + ", VERBOSE 99);\n";
@@ -2771,7 +4562,7 @@ ServiceChain::generate_configuration(bool add_extra)
             new_conf += "slaveTD" + is + " :: ExactCPUSwitch();\n";
             for (unsigned j = 0; j < get_max_cpu_nb(); j++) {
                 String js = String(j);
-                assert(get_cpu_info(j).assigned());
+                assert(get_cpu_info(j).is_assigned());
                 int phys_cpu_id = get_cpu_phys_id(j);
                 String ename = generate_configuration_slave_fd_name(i, j, "TD");
                 int queue_no = rx_filter->phys_cpu_to_queue(nic, phys_cpu_id);
@@ -2798,7 +4589,7 @@ ServiceChain::active_cpus()
     Bitvector b;
     b.resize(get_max_cpu_nb());
     for (unsigned i = 0; i < b.size(); i++) {
-        b[i] = _cpus[i].active();
+        b[i] = _cpus[i].is_active();
     }
     return b;
 }
@@ -2812,215 +4603,12 @@ ServiceChain::assigned_phys_cpus()
     Bitvector b;
     b.resize(click_max_cpu_ids());
     for (unsigned i = 0; i < get_max_cpu_nb(); i++) {
-        int pid = _cpus[i].cpu_phys_id;
+        int pid = _cpus[i].get_physical_id();
         if (pid >= 0) {
             b[pid] = true;
         }
     }
     return b;
-}
-
-/******************************
- * CPU
- ******************************/
-/**
- * Retunrs a CPU ID.
- */
-int
-CPU::get_id()
-{
-    return this->_id;
-}
-
-/**
- * Retunrs a CPU's vendor name.
- */
-String
-CPU::get_vendor()
-{
-    return this->_vendor;
-}
-
-/**
- * Retunrs a CPU's frequency in MHz.
- */
-long
-CPU::get_frequency()
-{
-    return this->_frequency;
-}
-
-/**
- * Encodes CPU information to JSON.
- */
-Json
-CPU::to_json()
-{
-    Json cpu = Json::make_object();
-
-    cpu.set("id", get_id());
-    cpu.set("vendor", get_vendor());
-    cpu.set("frequency", get_frequency());
-
-    return cpu;
-}
-
-/******************************
- * NIC
- ******************************/
-/**
- * Return the DPDK port ID of a NIC.
- */
-portid_t
-NIC::get_port_id()
-{
-    return is_ghost() ? -1 :
-        static_cast<FromDPDKDevice *>(element)->get_device()->get_port_id();
-}
-
-/**
- * Return the device's adress suitable to use as a FromDPDKDevice reference.
- */
-String
-NIC::get_device_address()
-{
-    // TODO: Returning the PCI address would be better
-    return String(get_port_id());
-}
-
-/**
- * Return the device's name.
- */
-String
-NIC::get_name()
-{
-    return is_ghost() ? "" : element->name();
-}
-
-/**
- * Return the device's Click port index.
- */
-int
-NIC::get_index()
-{
-    return is_ghost() ? -1 : _index;
-}
-
-/**
- * Sets the device's Click port index.
- */
-void
-NIC::set_index(const int &index)
-{
-    assert(index >= 0);
-    _index = index;
-}
-
-/**
- * Returns the number of queues per VF pool.
- */
-int
-NIC::queue_per_pool()
-{
-    int nb_vf_pools = atoi(call_rx_read("nb_vf_pools").c_str());
-    if (nb_vf_pools == 0) {
-        return 1;
-    }
-
-    return atoi(call_rx_read("nb_rx_queues").c_str()) / nb_vf_pools;
-}
-
-/**
- * Encodes NIC information to JSON.
- * Depending on the value of the second argument,
- * this piece of information can either be generic
- * NIC information of NIC statistics.
- */
-Json
-NIC::to_json(const RxFilterType &rx_mode, const bool &stats)
-{
-    Json nic = Json::make_object();
-
-    nic.set("name", get_name());
-    nic.set("index", get_index());
-    if (!stats) {
-        nic.set("vendor", call_rx_read("vendor"));
-        nic.set("driver", call_rx_read("driver"));
-        nic.set("speed", call_rx_read("speed"));
-        nic.set("status", call_rx_read("carrier"));
-        nic.set("portType", call_rx_read("type"));
-        nic.set("hwAddr", call_rx_read("mac").replace('-',':'));
-        Json jtagging = Json::make_array();
-        jtagging.push_back(rx_filter_type_enum_to_str(rx_mode));
-        nic.set("rxFilter", jtagging);
-    } else {
-        nic.set("rxCount", call_rx_read("hw_count"));
-        nic.set("rxBytes", call_rx_read("hw_bytes"));
-        nic.set("rxDropped", call_rx_read("hw_dropped"));
-        nic.set("rxErrors", call_rx_read("hw_errors"));
-        nic.set("txCount", call_tx_read("hw_count"));
-        nic.set("txBytes", call_tx_read("hw_bytes"));
-        nic.set("txErrors", call_tx_read("hw_errors"));
-    }
-
-    return nic;
-}
-
-/**
- * Implements read handlers for a NIC.
- */
-String
-NIC::call_rx_read(String h)
-{
-    const Handler *hc = Router::handler(element, h);
-
-    if (hc && hc->visible()) {
-        return hc->call_read(element, ErrorHandler::default_handler());
-    }
-
-    return "undefined";
-}
-
-/**
- * Relays handler calls to a NIC's underlying TX element.
- */
-String
-NIC::call_tx_read(String h)
-{
-    // TODO: Ensure element type
-    ToDPDKDevice *td = dynamic_cast<FromDPDKDevice *>(element)->find_output_element();
-    if (!td) {
-        return "[NIC " + String(get_device_address()) + "] Could not find matching ToDPDKDevice";
-    }
-
-    const Handler *hc = Router::handler(td, h);
-    if (hc && hc->visible()) {
-        return hc->call_read(td, ErrorHandler::default_handler());
-    }
-
-    return "undefined";
-}
-
-/**
- * Relays handler calls to a NIC's underlying Rx element.
- */
-int
-NIC::call_rx_write(String h, const String input)
-{
-    FromDPDKDevice *fd = dynamic_cast<FromDPDKDevice *>(element);
-    if (!fd) {
-        click_chatter("[NIC %s] Could not find matching FromDPDKDevice", get_device_address().c_str());
-        return ERROR;
-    }
-
-    const Handler *hc = Router::handler(fd, h);
-    if (hc && hc->visible()) {
-        return hc->call_write(input, fd, ErrorHandler::default_handler());
-    }
-
-    click_chatter("[NIC %s] Could not find matching handler %s", get_device_address().c_str(), h.c_str());
-
-    return ERROR;
 }
 
 CLICK_ENDDECLS

--- a/elements/userlevel/metron.hh
+++ b/elements/userlevel/metron.hh
@@ -599,13 +599,13 @@ class CPUStats {
 
 class CPU {
     public:
-        CPU(int phy_id, int log_id, int socket, String vendor, long frequency);
+        CPU(CpuVendor vendor, int phy_id, int log_id, int socket, long frequency);
         ~CPU();
 
+        inline CpuVendor get_vendor() { return _vendor; };
         inline int get_physical_id() { return _physical_id; };
         inline int get_logical_id() {return _logical_id; };
         inline int get_socket() { return _socket; };
-        inline String get_vendor() { return _vendor; };
         inline long get_frequency() { return _frequency; };
         inline CPUStats &get_stats() { return _stats; };
 
@@ -618,10 +618,10 @@ class CPU {
         static const int MAX_CPU_CORE_NB = 512;
 
     private:
+        CpuVendor _vendor;       // CPU vendor
         int _physical_id;        // Physical core ID
         int _logical_id;         // Logical core ID
         int _socket;             // CPU socket ID
-        String _vendor;          // CPU vendor
         long _frequency;         // Clock frequency in MHz
         CPUStats _stats;         // Run-time CPU statistics
 };
@@ -875,7 +875,7 @@ class CPULayout {
         int _cores_nb;
         int _cores_per_socket;
         int _active_cores_nb;
-        String _vendor;
+        CpuVendor _vendor;
         long _frequency;
         String _numa_nodes;
 
@@ -903,7 +903,7 @@ class SystemResources {
 
         // Relay methods
         inline int get_cpu_sockets() { return _cpu_layout.get_sockets_nb(); };
-        inline String get_cpu_vendor() { return _cpu_layout.get_cpu_core(0)->get_vendor(); };
+        String get_cpu_vendor();
         inline String get_hw_info() { return _plat_info.get_hw_info(); };
         inline String get_sw_info() { return _plat_info.get_sw_info(); };
         inline String get_serial_number() { return _plat_info.get_serial_number(); };

--- a/elements/userlevel/metron.hh
+++ b/elements/userlevel/metron.hh
@@ -10,6 +10,8 @@
 #include <click/hashmap.hh>
 #include <click/dpdkdevice.hh>
 #include <click/handlercall.hh>
+
+#include "fromdpdkdevice.hh"
 #include "../json/json.hh"
 
 #if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
@@ -17,6 +19,130 @@
 #endif
 
 class ServiceChainManager;
+
+/**
+ * CPU Vendors.
+ */
+#define CPU_VENDORS \
+    cpuvendor(GENUINE_INTEL), \
+    cpuvendor(AUTHENTIC_AMD), \
+    cpuvendor(UNKNOWN_VENDOR)
+
+#define cpuvendor(x) x
+
+typedef enum { CPU_VENDORS } CpuVendor;
+
+#undef cpuvendor
+#define cpuvendor(x) #x
+
+/**
+ * Types of CPU caches:
+ * |-> Data cache
+ * |-> CPU instructions' cache
+ * |-> Unified (both data and instructions)
+ */
+#define CPU_CACHE_TYPES \
+    cpucachetype(DATA), \
+    cpucachetype(INSTRUCTION), \
+    cpucachetype(UNIFIED), \
+    cpucachetype(UNKNOWN_CACHE_TYPE)
+
+#define cpucachetype(x) x
+
+typedef enum { CPU_CACHE_TYPES } CpuCacheType;
+
+#undef cpucachetype
+#define cpucachetype(x) #x
+
+/**
+ * Levels of CPU caches:
+ * |-> Register
+ * |-> L1 cache
+ * |-> L2 cache
+ * |-> L3 cache
+ * |-> L4 cache
+ * |-> Last-level cache (LLC)
+ */
+#define CPU_CACHE_LEVELS \
+    cpucachelevel(REGISTER), \
+    cpucachelevel(L1), \
+    cpucachelevel(L2), \
+    cpucachelevel(L3), \
+    cpucachelevel(L4), \
+    cpucachelevel(LLC), \
+    cpucachelevel(UNKNOWN_LEVEL)
+
+#define cpucachelevel(x) x
+
+typedef enum { CPU_CACHE_LEVELS } CpuCacheLevel;
+
+#undef cpucachelevel
+#define cpucachelevel(x) #x
+
+/**
+ * Replacement policies of CPU caches:
+ * |-> Direct-Mapped"
+ * |-> Fully-Associative
+ * |-> Set-Associative
+ */
+#define CPU_CACHE_POLICIES \
+    cpucachepolicy(DIRECT_MAPPED), \
+    cpucachepolicy(FULLY_ASSOCIATIVE), \
+    cpucachepolicy(SET_ASSOCIATIVE), \
+    cpucachepolicy(UNKNOWN_POLICY)
+
+#define cpucachepolicy(x) x
+
+typedef enum { CPU_CACHE_POLICIES } CpuCachePolicy;
+
+#undef cpucachepolicy
+#define cpucachepolicy(x) #x
+
+/**
+ * Types of main memory modules:
+ * |-> Static Random Access Memory (SRAM)
+ * |-> Dynamic Random Access Memory (DRAM)
+ * |-> Synchronous DRAM (SDRAM)
+ * |-> Double data-rate synchronous DRAM (DDR-SDRAM)
+ *     |--> 2nd Generation DDR (DDR2)
+ *     |--> 3rd Generation DDR (DDR3)
+ *     |--> 4th Generation DDR (DDR4)
+ *     |--> 5th Generation DDR (DDR5) (coming soon)
+ * |-> Cached DRAM (CDRAM)
+ * |-> Embedded DRAM (EDRAM)
+ * |-> Synchronous Graphics RAM (SGRAM)
+ * |-> Video DRAM (VRAM)
+ *
+ * |-> Programmable read-only memory (PROM)
+ * |-> Erasable Programmable read only memory (EPROM)
+ * |-> Flash Erasable Programmable Read Only Memory (FEPROM)
+ * |-> Electrically erasable programmable read only memory (EEPROM)
+ */
+#define MEMORY_TYPES \
+    memorytype(SRAM), \
+    memorytype(DRAM), \
+    memorytype(SDRAM), \
+    memorytype(DDR), \
+    memorytype(DDR2), \
+    memorytype(DDR3), \
+    memorytype(DDR4), \
+    memorytype(DDR5), \
+    memorytype(CDRAM), \
+    memorytype(EDRAM), \
+    memorytype(SGRAM), \
+    memorytype(VRAM), \
+    memorytype(PROM), \
+    memorytype(EPROM), \
+    memorytype(FEPROM), \
+    memorytype(EEPROM), \
+    memorytype(UNKNOWN_MEMORY_TYPE)
+
+#define memorytype(x) x
+
+typedef enum { MEMORY_TYPES } MemoryType;
+
+#undef memorytype
+#define memorytype(x) #x
 
 /**
  * The service chain types supported by Metron:
@@ -70,8 +196,10 @@ Metron(
     DISCOVER_PATH, DISCOVER_USER,
     DISCOVER_PASSWORD, PIN_TO_CORE,
     MONITORING, FAIL, LOAD_TIMER,
-    ON_SCALE, VERBOSE
-    [, SLAVE_DPDK_ARGS, SLAVE_ARGS]
+    ON_SCALE, NODISCOVERY,
+    MIRROR, VERBOSE
+    [, SLAVE_DPDK_ARGS, SLAVE_ARGS,
+    SLAVE_EXTRA, SLAVE_TD_EXTRA]
 )
 
 =s userlevel
@@ -108,10 +236,10 @@ String. The mode of the underlying FromDPDKDevice elements.
 Three modes are supported as follows:
 1) FLOW: The NIC utilizes DPDK's Flow API to classify and
 dispatch input flows to the system's CPU cores. FromDPDKDevice
-elements must be configured with MODE flow_dir.
+elements must be configured with MODE flow.
 The Metron controller sends the rules to be installed in the NIC.
 There rules ressemble a typical match-action API, where one of the
-actions is to dispatch the matched flow to a certain hardware queue,
+actions is to dispatch the matched flow to a certain NIC hardware queue,
 where a CPU core is waiting for additional processing.
 2) MAC: The NIC utilizes the destination MAC address of incoming
 packets for dispatching to the correct CPU core, using Virtual
@@ -119,7 +247,7 @@ Machine Device queues (VMDq). FromDPDKDevice elements must be
 configured with MODE vmdq.
 This mode requires an additional network element (e.g., a programmable
 switch), prior to the Metron server, to set the destination MAC address
-of each packet according to the values advertize by the Metron agent.
+of each packet according to the values advertized by the Metron agent.
 If this is not done, incoming traffic will never be dispatched to
 a CPU core, as the destination MAC address will likely be wrong.
 3) RSS: The NIC utilizes its hash-based Receive-Side Scaling (RSS)
@@ -190,6 +318,22 @@ is rescheduled. Defaults to 1000 ms.
 
 Boolean. If true, a handler for scaling events is setup. Defaults to false.
 
+=item NODISCOVERY
+
+Boolean. If true, Metron controller should initiate Metron agents' discovery.
+Defaults to false.
+
+=item MIRROR
+
+Boolean. If true, the Metron agent mirrors the rules that correspond to
+forward traffic on a NIC where the backward traffic is expected.
+Defaults to false.
+
+=item VERBOSE
+
+Boolean. If true, more detailed messages about Metron are printed.
+Defaults to false.
+
 =item SLAVE_ARGS
 
 String. DPDK arguments to pass to the primary DPDK process, which is the
@@ -207,36 +351,112 @@ blacklisted by a service chain.
 String. Additional arguments for DPDK slave processes.
 Default is no additional argument.
 
-=item VERBOSE
+=item SLAVE_TD_EXTRA
 
-Boolean. If true, more detailed messages about Metron are printed.
-Defaults to false.
+String. Additional arguments for Tx elements of DPDK slave processes.
+Default is no additional argument.
 
 =back
 
-=h discovered read-only
+=h server_connect write
+
+Schedules the discovery timer to connect to the controller.
+
+=h server_disconnect write
+
+Un-schedules the discovery timer to disconnect from the controller.
+
+=h server_discovered read-only
 
 Returns whether the Metron agent is associated with a controller or not.
 
-=h resources read-only
+=h server_time read-only
+
+Returns a JSON object with the local time measured by the Metron agent.
+
+=h server_resources read-only
 
 Returns a JSON object with information about the Metron agent.
 
-=h stats read-only
+=h server_stats read-only
 
 Returns a JSON object with global statistics about the Metron agent.
 
-=h rule_installation_rate_min read-only
 
-Returns the minimum rate to install rules in the input DPDK-based NIC.
+=h nic_ports write
 
-=h rule_installation_rate_avg read-only
+Controller-driven port administration commands (i.e., enable/disable).
 
-Returns the average rate to install rules in the input DPDK-based NIC.
+=h nic_queues read-only
 
-=h rule_installation_rate_max read-only
+Returns a JSON object with information about NIC(s) queues.
 
-Returns the maximum rate to install rules in the input DPDK-based NIC.
+=h nic_link_disc read-only
+
+Returns a JSON object with link discovery information.
+
+
+=h controllers read/write
+
+Returns or sets the controller instance associated with this Metron agent.
+
+=h controllers_delete write-only
+
+Disassociates this Metron agent from a Metron controller instance.
+
+
+=h service_chains read/write
+
+Returns the currently deployed service chains or instantiates a set of new
+service chains encoded as a JSON object.
+
+=h service_chains_put write-only
+
+Reconfigures a set of already deployed service chains encoded as a JSON object.
+
+=h service_chains_proxy read-only
+
+Proxies controller commands to service chains.
+
+=h service_chains_stats read-only
+
+Returns a JSON object with either all service chain-level statistics of the
+deployed service chains or statistics only for a desired service chain.
+
+=h service_chains_delete write-only
+
+Tears down a deployed service chain.
+
+
+=h rules read/write
+
+Returns or sets the rules associated with either all deployed service chains or a specific
+service chain.
+
+=h rules_add_from_file write-only
+
+Installs a set of NIC rules from file.
+
+=h rules_table_stats read-only
+
+Returns a JSON object with table statistics from the Metron agent's NICs.
+
+=h rules_verify write-only
+
+Verifies the consistency between the rules in the FlowCache (software) and the rules
+installed into the NIC (hardware). The user must know the correct number of rules in
+the NIC.
+Usage example (assuming that NIC fd0 has 150 rules): rules_verify fd0 150
+
+=h rules_delete write-only
+
+Removes a given list of comma-separated rules associated with (a) service chain(s).
+This command is issued by an associated Metron controller.
+To manually delete rules from a given NIC, use the FromDPDKDevice rules_del handler.
+
+=h rules_flush write-only
+
+Flushes the rules from all Metron NICs.
 
 =h rule_installation_lat_min read-only
 
@@ -250,17 +470,18 @@ Returns the average latency (ms) to install rules in the input DPDK-based NIC.
 
 Returns the maximum latency (ms) to install rules in the input DPDK-based NIC.
 
-=h rule_deletion_rate_min read-only
+=h rule_installation_rate_min read-only
 
-Returns the minimum rate to remove rules from the input DPDK-based NIC.
+Returns the minimum rate to install rules in the input DPDK-based NIC.
 
-=h rule_deletion_rate_avg read-only
+=h rule_installation_rate_avg read-only
 
-Returns the average rate to remove rules from the input DPDK-based NIC.
+Returns the average rate to install rules in the input DPDK-based NIC.
 
-=h rule_deletion_rate_max read-only
+=h rule_installation_rate_max read-only
 
-Returns the maximum rate to remove rules from the input DPDK-based NIC.
+Returns the maximum rate to install rules in the input DPDK-based NIC.
+
 
 =h rule_deletion_lat_min read-only
 
@@ -274,127 +495,351 @@ Returns the average latency (ms) to remove rules from the input DPDK-based NIC.
 
 Returns the maximum latency (ms) to remove rules from the input DPDK-based NIC.
 
-=h controllers read/write
+=h rule_deletion_rate_min read-only
 
-Returns or sets the conteoller instance associated with this Metron agent.
+Returns the minimum rate to remove rules from the input DPDK-based NIC.
 
-=h delete_controllers write-only
+=h rule_deletion_rate_avg read-only
 
-Disassociates this Metron agent from a Metron controller instance.
+Returns the average rate to remove rules from the input DPDK-based NIC.
 
-=h chains read/write
+=h rule_deletion_rate_max read-only
 
-Returns the currently deployed service chains or instantiates a set of new
-service chains encoded as a JSON object.
-
-=h chains_stats read-only
-
-Returns a JSON object with either all service chain-level statistics of the
-deployed service chains or statistics only for a desired service chain.
-
-=h put_chains write-only
-
-Reconfigures a set of already deployed service chains encoded as a JSON object.
-
-=h delete_chains write-only
-
-Tears down a deployed service chain.
-
-=h add_rules_from_file write-only
-
-Installs a set of NIC rules from file.
-
-=h rules read/write
-
-Returns or sets the rules associated with either all deployed service chains or a specific
-service chain.
-
-=h delete_rules write-only
-
-Removes a given list of comma-separated rules associated with (a) service chain(s).
-This command is issued by an associated Metron controller.
-To manually delete rules from a given NIC, use the FromDPDKDevice rules_del handler.
-
-=h verify_nic write-only
-
-Verifies the consistency between the rules in the FlowCache (software) and the rules
-installed into the NIC (hardware). The user must know the correct number of rules in
-the NIC.
-Usage example (assuming that NIC fd0 has 150 rules): verify_nic fd0 150
-
-=h flush_nics write-only
-
-Flushes the rules from all Metron NICs.
-
+Returns the maximum rate to remove rules from the input DPDK-based NIC.
 */
 
 // Return status
 const int ERROR = -1;
 const int SUCCESS = 0;
 
-class Metron;
+class PlatformInfo {
+    public:
+        PlatformInfo();
+        PlatformInfo(String hw, String sw, String serial, String chassis);
+        ~PlatformInfo();
+
+        inline void set_hw_info(const String &hw_info) { _hw_info = hw_info; };
+        inline void set_sw_info(const String &sw_info) { _sw_info = sw_info; };
+        inline void set_serial_number(const String &serial_nb) { _serial_nb = serial_nb; };
+        inline void set_chassis_id(const String &chassis_id) { _chassis_id = chassis_id; };
+
+        inline String get_hw_info() { return _hw_info; };
+        inline String get_sw_info() { return _sw_info; };
+        inline String get_serial_number() { return _serial_nb; };
+        inline String get_chassis_id() { return _chassis_id; };
+
+        void print();
+
+    private:
+        String _hw_info;
+        String _sw_info;
+        String _serial_nb;
+        String _chassis_id;
+};
+
+class LatencyStats {
+    public:
+        LatencyStats();
+        ~LatencyStats();
+
+        inline void set_avg_throughput(uint64_t avg_throughput) { _avg_throughput = avg_throughput; };
+        inline void set_min_latency(uint64_t min_latency) { _min_latency = min_latency; };
+        inline void set_avg_latency(uint64_t avg_latency) { _avg_latency = avg_latency; };
+        inline void set_max_latency(uint64_t max_latency) { _max_latency = max_latency; };
+
+        inline uint64_t get_avg_throughput() { return _avg_throughput; };
+        inline uint64_t get_min_latency() { return _min_latency; };
+        inline uint64_t get_avg_latency() { return _avg_latency; };
+        inline uint64_t get_max_latency() { return _max_latency; };
+
+        void print();
+
+    private:
+        uint64_t _avg_throughput;
+        uint64_t _min_latency;
+        uint64_t _avg_latency;
+        uint64_t _max_latency;
+};
+
+class CPUStats {
+    public:
+        CPUStats();
+        CPUStats &operator=(CPUStats &r);
+        ~CPUStats();
+
+        inline void set_physical_id(int physical_id) { _physical_id = physical_id; };
+        inline void set_load(float load) { _load = load; };
+        inline void set_max_nic_queue(int max_nic_queue) { _max_nic_queue = max_nic_queue; };
+        inline void set_active(bool active) {
+            _active = active;
+            if (active)
+                _active_time = Timestamp::now_steady();
+        };
+        inline void set_latency(LatencyStats &latency) { _latency = latency; };
+
+        inline int get_physical_id() { return _physical_id; };
+        inline bool is_assigned() { return _physical_id >= 0; };
+        inline float get_load() { return _load; };
+        inline int get_max_nic_queue() { return _max_nic_queue; };
+        inline bool is_active() { return _active; };
+        inline Timestamp &get_active_time() { return _active_time; };
+        inline LatencyStats &get_latency() { return _latency; };
+
+        int active_since();
+        void print();
+
+    private:
+        int _physical_id;        // CPU core's physical ID
+        float _load;             // CPU load in [0, 100]
+        int _max_nic_queue;      // Maximum assigned NIC queue index
+        bool _active;            // CPU activity status
+        Timestamp _active_time;  // Amount of time being active
+        LatencyStats _latency;   // Latency information
+};
 
 class CPU {
     public:
-        CPU(int id, String vendor, long _frequency)
-            : _id(id), _vendor(vendor), _frequency(_frequency) {
-        }
+        CPU(int phy_id, int log_id, int socket, String vendor, long frequency);
+        ~CPU();
 
-        int get_id();
-        String get_vendor();
-        long get_frequency();
+        inline int get_physical_id() { return _physical_id; };
+        inline int get_logical_id() {return _logical_id; };
+        inline int get_socket() { return _socket; };
+        inline String get_vendor() { return _vendor; };
+        inline long get_frequency() { return _frequency; };
+        inline CPUStats &get_stats() { return _stats; };
 
+        inline void set_stats(CPUStats &s) { _stats = s; };
+
+        void print();
         Json to_json();
 
         static const int MEGA_HZ = 1000000;
+        static const int MAX_CPU_CORE_NB = 512;
+
+    private:
+        int _physical_id;        // Physical core ID
+        int _logical_id;         // Logical core ID
+        int _socket;             // CPU socket ID
+        String _vendor;          // CPU vendor
+        long _frequency;         // Clock frequency in MHz
+        CPUStats _stats;         // Run-time CPU statistics
+};
+
+class CpuCacheId {
+    public:
+        CpuCacheId();
+        CpuCacheId(CpuCacheLevel level, CpuCacheType type);
+        CpuCacheId(String level_str, String type_str);
+        ~CpuCacheId();
+
+        inline CpuCacheLevel get_level() { return _level; };
+        inline CpuCacheType get_type() { return _type; };
+
+    private:
+        CpuCacheLevel _level;
+        CpuCacheType _type;
+};
+
+class CpuCache {
+    public:
+        CpuCache();
+        CpuCache(CpuCacheLevel level, CpuCacheType type,
+            CpuCachePolicy policy, CpuVendor vendor,
+            long capacity, int sets, int ways, int line_length, bool shared);
+        CpuCache(String level_str, String type_str, String policy_str, String vendor_str,
+            long capacity, int sets, int ways, int line_length, bool shared);
+        ~CpuCache();
+
+        inline CpuCacheId *get_cache_id() { return _cache_id; };
+        inline CpuCachePolicy get_policy() { return _policy; };
+        inline CpuVendor get_vendor() { return _vendor; };
+        inline long get_capacity() { return _capacity; };
+        inline int get_sets() { return _sets; };
+        inline int get_ways() { return _ways; };
+        inline int get_line_length() { return _line_length; };
+        inline bool is_shared() { return _shared; };
+
+        void print();
+        Json to_json();
+
+        static CpuCacheLevel level_from_integer(const int &level);
+        static int level_to_integer(const CpuCacheLevel &level);
+        static CpuCacheType type_from_string(const String &type);
+        static CpuCachePolicy policy_from_ways(const int &ways, const int &sets);
+
+    private:
+        CpuCacheId *_cache_id;
+        CpuCachePolicy _policy;
+        CpuVendor _vendor;
+        long _capacity;
+        int _sets;
+        int _ways;
+        int _line_length;
+        bool _shared;
+};
+
+class CpuCacheHierarchy {
+    public:
+        CpuCacheHierarchy(CpuVendor vendor, int sockets_nb, int cores_nb);
+        CpuCacheHierarchy(String vendor_str, int sockets_nb, int cores_nb);
+        ~CpuCacheHierarchy();
+
+        inline CpuVendor get_vendor() { return _vendor; };
+        inline int get_sockets_nb() { return _sockets_nb; };
+        inline int get_cores_nb() { return _cores_nb; };
+        inline int get_levels() { return _levels; };
+        inline int get_per_core_capacity() { return _per_core_capacity; };
+        inline int get_llc_capacity() { return _llc_capacity; };
+        inline int get_total_capacity() { return _total_capacity; };
+        inline HashMap<CpuCacheId *, CpuCache *> &get_cache_hierarchy() { return _cache_hierarchy; };
+
+        void add_cache(CpuCache *cache);
+        void compute_total_capacity();
+        void query();
+        void print();
+        Json to_json();
+
+        static const int MAX_CPU_CACHE_LEVELS = 4;
+        static const int BYTES_IN_KILO_BYTE = 1024;
+
+    private:
+        CpuVendor _vendor;
+        int _sockets_nb;          // Number of CPU sockets
+        int _cores_nb;            // Number of CPU cores
+        int _levels;              // Number of cache levels
+        long _per_core_capacity;  // CPU cache capacity per core (kB)
+        long _llc_capacity;       // Shared CPU cache capacity per socket (kB)
+        long _total_capacity;     // Total CPU cache capacity (kB)
+        HashMap<CpuCacheId *, CpuCache *> _cache_hierarchy;
+};
+
+class MemoryStats {
+    public:
+        MemoryStats();
+        MemoryStats &operator=(MemoryStats &m);
+        ~MemoryStats();
+
+        inline long get_memory_used() { return _used; };
+        inline long get_memory_free() { return _free; };
+        inline long get_memory_total() { return _total; };
+
+        inline long get_memory_used_gb() { return _used / KILO_TO_GIGA_BYTES; };
+        inline long get_memory_free_gb() { return _free / KILO_TO_GIGA_BYTES; };
+        inline long get_memory_total_gb() { return _total / KILO_TO_GIGA_BYTES; };
+
+        void capacity_query();
+        void utilization_query();
+
+        void print();
+        Json to_json();
+
+        static const long KILO_TO_GIGA_BYTES = 1000000;
+
+    private:
+        long _used;
+        long _free;
+        long _total;  // kBytes
+};
+
+class MemoryModule {
+    public:
+        MemoryModule();
+        MemoryModule(int id, MemoryType type, String manufacturer, String serial_nb,
+                     int data_width, int total_width, long capacity, long speed,
+                     long configured_speed);
+        ~MemoryModule();
+
+        inline void set_id(const int &id) { _id = id; };
+        inline void set_type(const MemoryType &type) { _type = type; };
+        inline void set_manufacturer(const String &manufacturer) { _manufacturer = manufacturer; };
+        inline void set_serial_nb(const String &serial_nb) { _serial_nb = serial_nb; };
+        inline void set_data_width(const int &data_width) { _data_width = data_width; };
+        inline void set_total_width(const int &total_width) { _total_width = total_width; };
+        inline void set_capacity(const long &capacity) { _capacity = capacity; };
+        inline void set_speed(const long &speed) { _speed = speed; };
+        inline void set_configured_speed(const long &configured_speed) { _configured_speed = configured_speed; };
+
+        inline int get_id() { return _id; };
+        inline MemoryType get_type() { return _type; };
+        inline String &get_manufacturer() { return _manufacturer; };
+        inline String &get_serial_number() { return _serial_nb; };
+        inline int get_data_width() { return _data_width; };
+        inline int get_total_width() { return _total_width; };
+        inline long get_capacity() { return _capacity; };
+        inline long get_speed() { return _speed; };
+        inline long get_configured_speed() { return _configured_speed; };
+
+        void print();
+        Json to_json();
 
     private:
         int _id;
-        String _vendor;
-        long _frequency;
+        MemoryType _type;
+        String _manufacturer;
+        String _serial_nb;
+        int _data_width;
+        int _total_width;
+        long _capacity;
+        long _speed;
+        long _configured_speed;
+
+};
+
+class MemoryHierarchy {
+    public:
+        MemoryHierarchy();
+        ~MemoryHierarchy();
+
+        inline int get_modules_number() { return _modules_nb; };
+        inline long get_total_capacity() { return _total_capacity; };
+        inline MemoryModule *get_module(const unsigned &i) { return _memory_modules[i]; };
+        inline MemoryStats &get_memory_stats() { return _stats; };
+
+        void capacity_query();
+        void query();
+        long get_module_capacity();
+        long get_module_speed();
+        void fill_missing();
+        void print();
+        Json to_json();
+
+    private:
+        int _modules_nb;
+        long _total_capacity;
+        Vector<MemoryModule *> _memory_modules;
+        MemoryStats _stats;
 };
 
 class NIC {
     public:
-        NIC(bool verbose = false) : _index(-1), _verbose(verbose) {
-        }
-
-        ~NIC() {
-        }
-
-        NIC(const NIC &n) {
-            _index = n._index;
-            _verbose = n._verbose;
-            element = n.element;
-        }
-
-        Element *element;
         NIC *mirror;
 
-        inline bool is_ghost() {
-            return element == NULL;
-        }
+        NIC(bool verbose = false);
+        NIC(const NIC &n);
+        ~NIC();
 
-        portid_t get_port_id();
-        String get_name();
-        String get_device_address();
-        int get_index();
+        inline Element *get_element() { return _element; };
+        inline bool is_ghost() { return (get_element() == NULL); };
+        inline int get_index() { return is_ghost() ? -1 : _index; };
+        inline bool is_active() { return cast()->is_active(); };
+        inline portid_t get_port_id() { return is_ghost() ? -1 : cast()->get_device()->get_port_id(); };
+        inline String get_name() { return is_ghost() ? "" : _element->name(); };
+        inline String get_device_address() { return String(get_port_id()); };
+
+        void set_element(Element *el);
         void set_index(const int &index);
+        void set_active(const bool &active);
+
+        FromDPDKDevice *cast();
 
     #if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
-        FlowDispatcher *get_flow_dispatcher(int sriov = 0) {
-            return FlowDispatcher::get_flow_dispatcher(get_port_id() + sriov);
-        };
-        FlowCache *get_flow_cache(int sriov = 0) {
-            return get_flow_dispatcher(sriov)->get_flow_cache();
-        };
+        FlowDispatcher *get_flow_dispatcher(int sriov = 0);
+        FlowCache *get_flow_cache(int sriov = 0);
     #endif
 
         int queue_per_pool();
-        int phys_cpu_to_queue(int phys_cpu_id) {
-            assert(phys_cpu_id >= 0);
-            return phys_cpu_id * (queue_per_pool());
-        }
+        int phys_cpu_to_queue(int phys_cpu_id);
 
         Json to_json(const RxFilterType &rx_mode, const bool &stats = false);
 
@@ -403,71 +848,99 @@ class NIC {
         int    call_rx_write(String h, const String input);
 
     private:
-        /* Click port index of this NIC. */
-        int _index;
-        /* Verbosity flag. */
-        bool _verbose;
+        Element *_element; // Click element associated with this NIC
+        int _index;        // Click port index of this NIC
+        bool _verbose;     // Verbosity flag
 };
 
-struct LatencyInfo {
-    uint64_t avg_throughput;
-    uint64_t min_latency;
-    uint64_t average_latency;
-    uint64_t max_latency;
-};
-
-class MetronCpuInfo {
+class CPULayout {
     public:
-        MetronCpuInfo() : cpu_phys_id(-1), load(0), max_nic_queue(0),
-                    latency(), _active(false) {
-            _active_time = Timestamp::now_steady();
-        }
+        CPULayout(int sockets_nb, int cores_nb, int active_cores_nb,
+                  String vendor, long frequency, String numa_nodes);
+        ~CPULayout();
 
-        int cpu_phys_id;
-        float load;
-        int max_nic_queue;
+        inline int get_sockets_nb() { return _sockets_nb; };
+        inline int get_cores_nb() { return _cores_nb; };
+        inline int get_active_cores_nb() { return _active_cores_nb; };
+        inline CPU *get_cpu_core(const int& id) { return _cpus[id]; };
 
-        LatencyInfo latency;
+        inline int get_phy_core_by_lcore(int lcore) { return _lcore_to_phy_core[lcore]; };
+        inline int get_socket_by_lcore(int lcore) { return _lcore_to_socket[lcore]; };
 
-        bool assigned() {
-           return cpu_phys_id >= 0;
-        }
-
-        void set_active(bool active) {
-            _active = active;
-            _active_time = Timestamp::now_steady();
-        }
-
-        bool active() {
-            return _active;
-        }
-
-        int active_since() {
-            int cpu_time;
-            if (_active) {
-                cpu_time = (Timestamp::now_steady() - _active_time).msecval();
-            } else {
-                cpu_time = -(Timestamp::now_steady() - _active_time).msecval();
-            }
-            return cpu_time;
-        }
+        void compose();
+        void print();
 
     private:
-        bool _active;
-        Timestamp _active_time;
+        int _sockets_nb;
+        int _cores_nb;
+        int _cores_per_socket;
+        int _active_cores_nb;
+        String _vendor;
+        long _frequency;
+        String _numa_nodes;
 
+        Vector<CPU *> _cpus;
+        HashMap<int, int> _lcore_to_phy_core;
+        HashMap<int, int> _lcore_to_socket;
+};
+
+class SystemResources {
+    public:
+        SystemResources(
+            int sockets_nb, int cores_nb, int active_cores_nb, String vendor, long frequency,
+            String numa_nodes, String hw, String sw, String serial, String chassis);
+        ~SystemResources();
+
+        inline void set_platform_info(const PlatformInfo &plat_info) { _plat_info = plat_info; };
+        inline void set_cpu_layout(const CPULayout &cpu_layout) { _cpu_layout = cpu_layout; };
+        inline void set_cpu_cache_hierarchy(const CpuCacheHierarchy &cache) { _cpu_cache_hierarchy = cache; };
+        inline void set_memory(MemoryHierarchy &MemoryHierarchy) { _memory_hierarchy = _memory_hierarchy; };
+
+        inline PlatformInfo &get_platform_info() { return _plat_info; };
+        inline CPULayout &get_cpu_layout() { return _cpu_layout; };
+        inline CpuCacheHierarchy &get_cpu_cache_hiearchy() { return _cpu_cache_hierarchy; };
+        inline MemoryHierarchy &get_memory() { return _memory_hierarchy; };
+
+        // Relay methods
+        inline int get_cpu_sockets() { return _cpu_layout.get_sockets_nb(); };
+        inline String get_cpu_vendor() { return _cpu_layout.get_cpu_core(0)->get_vendor(); };
+        inline String get_hw_info() { return _plat_info.get_hw_info(); };
+        inline String get_sw_info() { return _plat_info.get_sw_info(); };
+        inline String get_serial_number() { return _plat_info.get_serial_number(); };
+        inline String get_chassis_id() { return _plat_info.get_chassis_id(); };
+
+        void print();
+
+    private:
+        PlatformInfo _plat_info;
+        CPULayout _cpu_layout;
+        CpuCacheHierarchy _cpu_cache_hierarchy;
+        MemoryHierarchy _memory_hierarchy;
 };
 
 class NicStat {
     public:
-        long long useless;
-        long long useful;
-        long long count;
-        float load;
+        NicStat() : _useless(0), _useful(0), _count(0), _load(0) {};
+        ~NicStat() {};
 
-        NicStat() : useless(0), useful(0), count(0), load(0) {
-        }
+        inline void set_useless(const long long &useless) { _useless = useless; };
+        inline void set_useful(const long long &useful) { _useful = useful; };
+        inline void set_count(const long long &count) { _count = count; };
+        inline void set_useless(const float &load) { _load = load; };
+
+        inline long long get_useless() { return _useless ; };
+        inline long long get_useful() { return _useful ; };
+        inline long long get_count() { return _count ; };
+        inline float get_load() { return _load; };
+
+    private:
+        long long _useless;
+        long long _useful;
+        long long _count;
+        float _load;
 };
+
+class Metron;
 
 class ServiceChain {
     public:
@@ -485,29 +958,27 @@ class ServiceChain {
                 inline int phys_cpu_to_queue(NIC *nic, const int &phys_cpu_id) {
                     return nic->phys_cpu_to_queue(phys_cpu_id);
                 }
-
                 inline void allocate_nic_space_for_tags(const int &size);
-
                 inline void allocate_tag_space_for_nic(const int &nic_id, const int &size);
-
                 inline void set_tag_value(
                         const int &nic_id, const int &cpu_id, const String &value);
-
                 inline String get_tag_value(const int &nic_id, const int &cpu_id);
-
                 inline bool has_tag_value(const int &nic_id, const int &cpu_id);
-
                 virtual int apply(NIC *nic, ErrorHandler *errh);
 
                 Vector<Vector<String>> values;
         };
 
-        /* Public service chain attributes. */
+        /**
+         * Public service chain attributes.
+         */
         String id;
         RxFilter *rx_filter;
         String config;
 
-        /* Service chain type. */
+        /**
+         * Service chain type.
+         */
         ScType config_type;
 
         enum ScStatus {
@@ -547,7 +1018,7 @@ class ServiceChain {
         inline int get_active_cpu_nb() {
             int nb = 0;
             for (int i = 0; i < get_max_cpu_nb(); i++) {
-                if (get_cpu_info(i).active()) {
+                if (get_cpu_info(i).is_active()) {
                     nb++;
                 }
             }
@@ -558,12 +1029,12 @@ class ServiceChain {
             return _max_cpus_nb;
         }
 
-        inline MetronCpuInfo &get_cpu_info(int cpu_id) {
+        inline CPUStats &get_cpu_info(int cpu_id) {
             return _cpus[cpu_id];
         }
 
         inline int get_cpu_phys_id(int cpu_id) {
-            return _cpus[cpu_id].cpu_phys_id;
+            return _cpus[cpu_id].get_physical_id();
         }
 
         inline int get_nics_nb() {
@@ -622,7 +1093,7 @@ class ServiceChain {
         Metron *_metron;
         ServiceChainManager *_manager;
         Vector<NIC *> _nics;
-        Vector<MetronCpuInfo> _cpus;
+        Vector<CPUStats> _cpus;
         Vector<NicStat> _nic_stats;
         int _initial_cpus_nb;
         int _max_cpus_nb;
@@ -675,30 +1146,45 @@ class Metron : public Element {
         static int rule_stats_handler(int operation, String &param, Element *e, const Handler *h, ErrorHandler *errh);
     #endif
 
-        void hw_info_to_json(Json &j);
+        void sys_info_to_json(Json &j);
 
         Json to_json();
-        Json stats_to_json();
+        Json time_to_json();
+        Json system_stats_to_json();
+        Json setup_link_discovery();
+    #if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
+        Json nics_table_stats_to_json();
+    #endif
         Json controllers_to_json();
         int  controllers_from_json(const Json &j);
-        int  delete_controller_from_json(const String &ip);
+        int  controller_delete_from_json(const String &ip);
 
-        /* Read and write handlers */
+        /**
+         * Read and write handlers.
+         */
         enum {
-            h_discovered, h_resources, h_controllers, h_stats,
+            h_server_connect, h_server_disconnect,
+            h_server_discovered, h_server_time,
+            h_server_resources, h_server_stats,
+
+            h_nic_ports, h_nic_queues, h_nic_link_discovery,
+
+            h_controllers, h_controllers_set, h_controllers_delete,
+
+            h_service_chains, h_service_chains_put,
+            h_service_chains_stats, h_service_chains_proxy,
+            h_service_chains_delete,
         #if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
+            h_rules,
+            h_rules_add_from_file,
+            h_rules_table_stats,
+            h_rules_verify,
+            h_rules_delete,
+            h_rules_flush,
             h_rule_inst_lat_min,  h_rule_inst_lat_avg,  h_rule_inst_lat_max,
             h_rule_del_lat_min,   h_rule_del_lat_avg,   h_rule_del_lat_max,
             h_rule_inst_rate_min, h_rule_inst_rate_avg, h_rule_inst_rate_max,
-            h_rule_del_rate_min,  h_rule_del_rate_avg,  h_rule_del_rate_max,
-        #endif
-            h_put_chains, h_chains, h_chains_stats, h_chains_proxy,
-        #if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
-            h_chains_rules, h_add_rules_from_file, h_verify_nic,
-        #endif
-            h_delete_chains, h_delete_controllers,
-        #if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
-            h_delete_rules, h_flush_nics
+            h_rule_del_rate_min,  h_rule_del_rate_avg,  h_rule_del_rate_max
         #endif
         };
 
@@ -709,13 +1195,9 @@ class Metron : public Element {
         int delete_service_chain(ServiceChain *sc, ErrorHandler *errh);
         void call_scale(ServiceChain *sc, const String &event);
 
-        bool get_monitoring_mode() {
-            return _monitoring_mode;
-        }
-
-        int get_cpus_nb() {
-            return click_max_cpu_ids();
-        }
+        SystemResources *get_system_resources() { return _sys_res; }
+        bool get_monitoring_mode() { return _monitoring_mode; }
+        int get_cpus_nb() { return click_max_cpu_ids(); }
 
         NIC *get_nic_by_index(int i) {
             auto it = _nics.begin();
@@ -741,14 +1223,8 @@ class Metron : public Element {
             return NULL;
         }
 
-        int get_nics_nb() {
-            return _nics.size();
-        }
-
-        int get_service_chains_nb() {
-            return _scs.size();
-        }
-
+        int get_nics_nb() { return _nics.size(); }
+        int get_service_chains_nb() { return _scs.size(); }
         int get_assigned_cpus_nb();
 
         bool assign_cpus(ServiceChain *sc, Vector<int> &map);
@@ -764,7 +1240,7 @@ class Metron : public Element {
         /* Controller's default REST configuration */
         const int    DEF_DISCOVER_PORT      = 80;
         const int    DEF_DISCOVER_REST_PORT = 8181;
-        const String DEF_DISCOVER_DRIVER    = "restServer";
+        const String DEF_DISCOVER_DRIVER    = "rest-server";
         const String DEF_DISCOVER_USER      = "onos";
         const String DEF_DISCOVER_PATH      = "/onos/v1/network/configuration/";
 
@@ -772,18 +1248,14 @@ class Metron : public Element {
         const unsigned DISCOVERY_WAIT = 5;
 
     private:
-        String _id;
+        String _agent_id;
+        SystemResources *_sys_res;
         int _core_id;
 
         HashMap<String, NIC> _nics;
         HashMap<String, ServiceChain *> _scs;
 
-        Vector<ServiceChain *> _cpu_map;
-
-        String _cpu_vendor;
-        String _hw;
-        String _sw;
-        String _serial;
+        Vector<ServiceChain *> _sc_to_core_map;
 
         /* Rx filter mode */
         RxFilterType _rx_mode;
@@ -833,6 +1305,17 @@ class Metron : public Element {
          */
         Vector<int> _cpu_click_to_phys;
 
+        Timer _timer;
+        Timer _discover_timer;
+
+        Spinlock _command_lock;
+
+        int connect(const Json &j);
+        int disconnect(const Json &j);
+        int nic_port_administrator(const Json &j);
+        Json nic_queues_report();
+        void collect_system_resources();
+
         int try_slaves(ErrorHandler *errh);
 
         int confirm_nic_mode(ErrorHandler *errh);
@@ -841,13 +1324,9 @@ class Metron : public Element {
     #endif
 
         static void add_per_core_monitoring_data(
-            Json *jobj, const LatencyInfo &lat
+            Json *jobj, LatencyStats &lat
         );
 
-        Timer _timer;
-        Timer _discover_timer;
-
-        Spinlock _command_lock;
         friend class ServiceChain;
         friend class ClickSCManager;
 };

--- a/elements/userlevel/queuedevice.hh
+++ b/elements/userlevel/queuedevice.hh
@@ -19,10 +19,17 @@ class TXQueueDevice;
 class QueueDevice : public BatchElement {
 
 public:
-
     QueueDevice() CLICK_COLD;
 
     static void static_initialize();
+
+    inline bool is_active() {
+        return _active;
+    }
+
+    inline void set_active(const bool &active) {
+        _active = active;
+    }
 
 private :
     /* Those two are only used during configurations. On runtime, the final
@@ -31,10 +38,9 @@ private :
     int _maxqueues;
     friend RXQueueDevice;
     friend TXQueueDevice;
+
 protected:
-
 	int _burst; //Max size of burst
-
 
     #define NO_LOCK 2
     /**

--- a/include/click/string.hh
+++ b/include/click/string.hh
@@ -39,6 +39,8 @@ class String { public:
     typedef intmax_t int_large_t;
     typedef uintmax_t uint_large_t;
 
+    static const int npos = -1;
+
     inline String();
     inline String(const String& x);
 #if HAVE_CXX_RVALUE_REFERENCES
@@ -107,6 +109,9 @@ class String { public:
     String trim_space_left() const;
     String replace(char from, char to) const;
     String replace(String from, String to) const;
+    String &erase(int start = 0, int len = npos);
+    inline void pop_back();
+    inline void clear();
 
     inline bool equals(const String &x) const;
     inline bool equals(const char *s, int len) const;
@@ -128,15 +133,23 @@ class String { public:
     // bool operator>(const String &, const String &);
     // bool operator>=(const String &, const String &);
     Vector<String> split(char c) const;
+    Vector<String> split(const String &delim) const;
 
     int find_left(char c, int start = 0) const;
     int find_left(const String &x, int start = 0) const;
-    int find_right(char c, int start = 0x7FFFFFFF) const;
+    int find_right(char c, int start = npos) const;
+    int find_first_of(const char *delim, int pos = 0) const;
+    int find_first_of(const String &delim, int pos = 0) const;
+    int find_first_not_of(const char *delim, int pos = 0) const;
+    int find_first_not_of(const String &delim, int pos = 0) const;
+    int find_last_of(const char delim, int pos = npos) const;
+    int find_last_not_of(const char *delim, int pos = npos) const;
 
     const char* search(String pattern);
 
     String lower() const;
     String upper() const;
+    String camel() const;
     String printable() const;
     String quoted_hex() const;
     String encode_json() const;
@@ -762,6 +775,18 @@ inline char *String::append_garbage(int len) {
     return append_uninitialized(len);
 }
 /** @endcond never */
+
+/** @brief Pop the last character of this string. */
+inline void String::pop_back() {
+    erase(length() - 1, 1);
+    return;
+}
+
+/** @brief Erases the contents of the string, which becomes an empty string. */
+inline void String::clear() {
+    erase();
+    return;
+}
 
 /** @brief Append @a x to this string.
     @return *this */

--- a/lib/dpdkdevice.cc
+++ b/lib/dpdkdevice.cc
@@ -181,13 +181,13 @@ DPDKDevice::dpdk_get_rss_reta() const
  */
 void DPDKDevice::initialize_flow_dispatcher(const portid_t &port_id, ErrorHandler *errh)
 {
-    FlowDispatcher *flow_dir = FlowDispatcher::get_flow_dispatcher(port_id, errh);
-    if (!flow_dir) {
+    FlowDispatcher *flow_disp = FlowDispatcher::get_flow_dispatcher(port_id, errh);
+    if (!flow_disp) {
         return;
     }
 
     // Verify
-    const portid_t p_id = flow_dir->get_port_id();
+    const portid_t p_id = flow_disp->get_port_id();
     assert((p_id >= 0) && (p_id == port_id));
 }
 #endif /* RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0) */
@@ -457,13 +457,13 @@ int DPDKDevice::set_mode(
 
 #if RTE_VERSION >= RTE_VERSION_NUM(17,5,0,0)
     if (mode == FlowDispatcher::DISPATCHING_MODE) {
-        FlowDispatcher *flow_dir = FlowDispatcher::get_flow_dispatcher(port_id, errh);
-        flow_dir->set_active(true);
-        flow_dir->set_rules_filename(flow_rules_filename);
+        FlowDispatcher *flow_disp = FlowDispatcher::get_flow_dispatcher(port_id, errh);
+        flow_disp->set_active(true);
+        flow_disp->set_rules_filename(flow_rules_filename);
         errh->message(
             "Flow Dispatcher (port %u): State %s - Isolation Mode %s - Source file '%s'",
             port_id,
-            flow_dir->active() ? "active" : "inactive",
+            flow_disp->active() ? "active" : "inactive",
             FlowDispatcher::isolated(port_id) ? "active" : "inactive",
             flow_rules_filename.empty() ? "None" : flow_rules_filename.c_str()
         );
@@ -1162,17 +1162,17 @@ int DPDKDevice::configure_nic(const portid_t &port_id)
         return -1;
     }
 
-    FlowDispatcher *flow_dir = FlowDispatcher::get_flow_dispatcher(port_id);
-    assert(flow_dir);
+    FlowDispatcher *flow_disp = FlowDispatcher::get_flow_dispatcher(port_id);
+    assert(flow_disp);
 
     // Invoke Flow Dispatcher only if active
-    if (flow_dir->active()) {
+    if (flow_disp->active()) {
         // Retrieve the file that contains the rules (if any)
-        String rules_file = flow_dir->rules_filename();
+        String rules_file = flow_disp->rules_filename();
 
         // There is a file with (user-defined) rules
         if (!rules_file.empty()) {
-            if (flow_dir->add_rules_from_file(rules_file) >= 0)
+            if (flow_disp->add_rules_from_file(rules_file) >= 0)
                 return 0;
             else
                 return -1;
@@ -1200,13 +1200,13 @@ void DPDKDevice::cleanup(ErrorHandler *errh)
         }
 
         portid_t port_id = it.key();
-        FlowDispatcher *flow_dir = it.value();
+        FlowDispatcher *flow_disp = it.value();
 
         // Flush
-        uint32_t rules_flushed = flow_dir->flow_rules_flush();
+        uint32_t rules_flushed = flow_disp->flow_rules_flush();
 
         // Delete this instance
-        delete flow_dir;
+        delete flow_disp;
 
         // Report
         if (rules_flushed > 0) {

--- a/userlevel/dpdk.mk
+++ b/userlevel/dpdk.mk
@@ -484,7 +484,7 @@ else
 endif
 
 ############################################################
-## Flow director library available at or after DPDK v17.05
+## Flow API library available at or after DPDK v17.05
 ############################################################
 ifeq ($(shell [ -n $(RTE_VER_YEAR) ] && ( ( [ $(RTE_VER_YEAR) -ge 17 ] && [ $(RTE_VER_MONTH) -ge 05 ] ) || [ $(RTE_VER_YEAR) -ge 18 ] ) && [ -n $(HAVE_FLOW_API) ] && echo true),true)
 


### PR DESCRIPTION
This upgrade follows a pull request to ONOS for the
control plane part of Metron, including:
 * Refactored REST API with consistent resource names
 * Extended REST API with more management operations
    * Time exchange between Metron server and ONOS
    * Controller-driven NIC port configuration
    * NIC table statistics' report to ONOS
    * NIC queue descriptions' report to ONOS
    * Server connect/disconnect operations driven by ONOS
    * Additional system statisticss (CPU caches and memory)
 * Click's string library extended
 * Fixed deprecated naming conventions (e.g., Flow Director)
 * Metron example configurations updated
 * Metron documentation updated

Signed-off-by: Georgios Katsikas <katsikas.gp@gmail.com>