### PR TITLE
Reworked initialize_device()

### DIFF
--- a/include/click/dpdkdevice.hh
+++ b/include/click/dpdkdevice.hh
@@ -132,6 +132,8 @@ public:
         FlowControlMode init_fc_mode;
         uint64_t rx_offload;
         uint64_t tx_offload;
+
+        const uint16_t LRO_MTU = 9000;
     };
 
     int add_rx_queue(


### PR DESCRIPTION
An issue before this patch was that rte_eth_dev_configure
was invoked before the offloading capabilites were set.
Now, all the configuration is applied and rte_eth_dev_start
is moved at the end of the initialize_device method.

Signed-off-by: Georgios Katsikas <katsikas.gp@gmail.com>