### PR TITLE
Fully-functional LRO and Jumbo

### DIFF
--- a/elements/userlevel/fromdpdkdevice.cc
+++ b/elements/userlevel/fromdpdkdevice.cc
@@ -118,6 +118,9 @@ int FromDPDKDevice::configure(Vector<String> &conf, ErrorHandler *errh)
     if (fc_mode != FC_UNSET)
         _dev->set_init_fc_mode(fc_mode);
 
+    _dev->set_lro(_lro);
+    _dev->set_jumbo(_jumbo);
+
     if (set_timestamp) {
 #if RTE_VERSION >= RTE_VERSION_NUM(18,02,0,0)
         _dev->set_rx_offload(DEV_RX_OFFLOAD_TIMESTAMP);
@@ -171,7 +174,7 @@ int FromDPDKDevice::initialize(ErrorHandler *errh)
     if (ret != 0) return ret;
 
     for (unsigned i = (unsigned)firstqueue; i <= (unsigned)lastqueue; i++) {
-        ret = _dev->add_rx_queue(i , _promisc, _vlan_filter, _vlan_strip, _vlan_extend, _lro, _jumbo, ndesc, errh);
+        ret = _dev->add_rx_queue(i , _promisc, _vlan_filter, _vlan_strip, _vlan_extend, _lro > 0, _jumbo > 0, ndesc, errh);
         if (ret != 0) return ret;
     }
 

--- a/elements/userlevel/queuedevice.cc
+++ b/elements/userlevel/queuedevice.cc
@@ -114,8 +114,8 @@ int RXQueueDevice::parse(Vector<String> &conf, ErrorHandler *errh) {
     _vlan_filter = false;
     _vlan_strip = false;
     _vlan_extend = false;
-    _lro = false;
-    _jumbo = false;
+    _lro = 0;
+    _jumbo = 0;
 
     if (Args(this, errh).bind(conf)
            .read_p("PROMISC", _promisc)

--- a/elements/userlevel/queuedevice.hh
+++ b/elements/userlevel/queuedevice.hh
@@ -227,8 +227,8 @@ protected:
     bool _vlan_filter;
     bool _vlan_strip;
     bool _vlan_extend;
-    bool _lro;
-    bool _jumbo;
+    int _lro;
+    int _jumbo;
     bool _set_rss_aggregate;
     bool _set_paint_anno;
     int _threadoffset;

--- a/include/click/dpdkdevice.hh
+++ b/include/click/dpdkdevice.hh
@@ -79,7 +79,8 @@ public:
             rx_queues(0, false), tx_queues(0, false),
             promisc(false),
             vlan_filter(false), vlan_strip(false), vlan_extend(false),
-            lro(false), jumbo(false),
+            lro(false), lro_max_pkt_size(0),
+            jumbo(false), jumbo_max_rx_pkt_size(0),
             n_rx_descs(0), n_tx_descs(0),
             init_mac(), init_mtu(0), init_rss(-1), init_fc_mode(FC_UNSET), rx_offload(0), tx_offload(0) {
             rx_queues.reserve(128);
@@ -90,26 +91,28 @@ public:
             if (device_id == PCI_ANY_ID) {
                 return;
             }
-            click_chatter("                Vendor   ID: %d", vendor_id);
-            click_chatter("                Vendor Name: %s", vendor_name.c_str());
-            click_chatter("                Device   ID: %d", device_id);
-            click_chatter("                Driver Name: %s", driver);
-            click_chatter("                MAC Address: %s", init_mac.unparse().c_str());
-            click_chatter("      Maximum Transfer Unit: %u", init_mtu);
-            click_chatter("Receive Side Scaling queues: %d", init_rss);
-            click_chatter("          Flow Control Mode: %d", init_fc_mode);
-            click_chatter("             # of Rx Queues: %d", rx_queues.size());
-            click_chatter("             # of Tx Queues: %d", tx_queues.size());
-            click_chatter("             # of Rx  Descs: %d", n_rx_descs);
-            click_chatter("             # of Tx  Descs: %d", n_tx_descs);
-            click_chatter("           Promiscuous Mode: %s", promisc? "true":"false");
-            click_chatter("           Rx Offloads flag: %" PRIu64, rx_offload);
-            click_chatter("           Tx Offloads flag: %" PRIu64, tx_offload);
-            click_chatter("          VLAN    Filtering: %s", vlan_filter? "true":"false");
-            click_chatter("          VLAN    Stripping: %s", vlan_strip? "true":"false");
-            click_chatter("          VLAN QinQ(extend): %s", vlan_extend? "true":"false");
-            click_chatter("Large Receive Offload (LRO): %s", lro ? "true":"false");
-            click_chatter("    Rx Jumbo Frames Offload: %s", jumbo ? "true":"false");
+            click_chatter("                 Vendor   ID: %d", vendor_id);
+            click_chatter("                 Vendor Name: %s", vendor_name.c_str());
+            click_chatter("                 Device   ID: %d", device_id);
+            click_chatter("                 Driver Name: %s", driver);
+            click_chatter("                 MAC Address: %s", init_mac.unparse().c_str());
+            click_chatter("       Maximum Transfer Unit: %u", init_mtu);
+            click_chatter(" Receive Side Scaling queues: %d", init_rss);
+            click_chatter("           Flow Control Mode: %d", init_fc_mode);
+            click_chatter("              # of Rx Queues: %d", rx_queues.size());
+            click_chatter("              # of Tx Queues: %d", tx_queues.size());
+            click_chatter("              # of Rx  Descs: %d", n_rx_descs);
+            click_chatter("              # of Tx  Descs: %d", n_tx_descs);
+            click_chatter("            Promiscuous Mode: %s", promisc? "true":"false");
+            click_chatter("            Rx Offloads flag: %" PRIu64, rx_offload);
+            click_chatter("            Tx Offloads flag: %" PRIu64, tx_offload);
+            click_chatter("           VLAN    Filtering: %s", vlan_filter? "true":"false");
+            click_chatter("           VLAN    Stripping: %s", vlan_strip? "true":"false");
+            click_chatter("           VLAN QinQ(extend): %s", vlan_extend? "true":"false");
+            click_chatter(" Large Receive Offload (LRO): %s", lro? "true":"false");
+            click_chatter("     Maximum LRO Packet Size: %" PRIu32 " bytes", lro? lro_max_pkt_size : 0);
+            click_chatter("     Rx Jumbo Frames Offload: %s", jumbo ? "true":"false");
+            click_chatter("Maximum Jumbo Rx Packet Size: %" PRIu32 " bytes", jumbo? jumbo_max_rx_pkt_size : 0);
         }
 
         uint16_t vendor_id;
@@ -123,7 +126,9 @@ public:
         bool vlan_strip;
         bool vlan_extend;
         bool lro;
+        uint32_t lro_max_pkt_size;
         bool jumbo;
+        uint32_t jumbo_max_rx_pkt_size;
         unsigned n_rx_descs;
         unsigned n_tx_descs;
         EtherAddress init_mac;
@@ -133,7 +138,7 @@ public:
         uint64_t rx_offload;
         uint64_t tx_offload;
 
-        const uint16_t LRO_MTU = 9000;
+        const uint16_t DEF_LARGE_MTU = 9000;
     };
 
     int add_rx_queue(
@@ -151,6 +156,8 @@ public:
     void set_init_mtu(uint16_t mtu);
     void set_init_rss_max(int rss_max);
     void set_init_fc_mode(FlowControlMode fc);
+    void set_lro(int lro);
+    void set_jumbo(int jumbo);
     void set_rx_offload(uint64_t offload);
     void set_tx_offload(uint64_t offload);
 


### PR DESCRIPTION
 * LRO and JUMBO params are now integers
 * With value=0, both features are disabled
 * With value=1, each feature gets a default value (9000 bytes)
 * with value>1, each feature is configurable in [64, 65536]

Signed-off-by: Georgios Katsikas <katsikas.gp@gmail.com>