### PR TITLE
Add mininet/Vagrant examples

### DIFF
--- a/mininet/README.md
+++ b/mininet/README.md
@@ -1,0 +1,17 @@
+# Mininet examples for FastClick configurations
+
+Use `vagrant up` to build a pre-configured VM with all dependencies. Of course, vagrant and virtualbox must be installed themselves.
+
+Then, run `vagrant ssh` to jump into the VM.
+
+Then, simply run the Mininet topology with:
+
+```
+sudo mn -c ; cd /vagrant && sudo python EXAMPLE/topology.py
+```
+
+EXAMPLE is one of the folder in this repository:
+ * switch: A switch between two hosts (there is also a topology-mininetonly.py file that does the same switch without Click, for learning purposes)
+ * router: A router between 4 hosts TODO
+
+The examples use the click configuration in the conf/EXAMPLE/ folders, just tweaking a few variables through the command line.

--- a/mininet/Vagrantfile
+++ b/mininet/Vagrantfile
@@ -1,0 +1,107 @@
+$init = <<SCRIPT
+  apt update
+  DEBIAN_FRONTEND=noninteractive apt install -y build-essential fakeroot debhelper autoconf automake libssl-dev graphviz python-all python-qt4 python-twisted-conch libtool git tmux vim python-pip python-paramiko python-sphinx graphviz autoconf automake bzip2 debhelper dh-autoreconf libssl-dev libtool openssl procps python-all python-qt4 python-twisted-conch python-zopeinterface module-assistant dkms make libc6-dev python-argparse uuid-runtime netbase kmod python-twisted-web iproute2 ipsec-tools openvswitch-switch libpcap-dev libnuma-dev libmicrohttpd-dev python3-pip python3-matplotlib htop wireshark-gtk python3 linux-tools-generic lynx gdb evince nginx libre2-dev
+  pip install alabaster
+  python3 -m pip install --upgrade pip
+SCRIPT
+
+$ovs = <<SCRIPT
+  wget http://openvswitch.org/releases/openvswitch-2.5.9.tar.gz
+  tar xf openvswitch-2.5.9.tar.gz
+  pushd openvswitch-2.5.9
+  DEB_BUILD_OPTIONS='parallel=8 nocheck' fakeroot debian/rules binary
+  popd
+  sudo dpkg -i openvswitch-common*.deb openvswitch-datapath-*.deb python-openvswitch*.deb openvswitch-pki*.deb openvswitch-switch*.deb
+  rm -rf *openvswitch*
+SCRIPT
+
+
+$mininet = <<SCRIPT
+  git clone git://github.com/mininet/mininet
+  pushd mininet
+  git checkout 2.2.2
+  ./util/install.sh -fn
+  popd
+  echo "PATH=$PATH:/home/vagrant/mininet/util/" >> ~/.bashrc
+SCRIPT
+
+$dpdk = <<SCRIPT
+  wget http://fast.dpdk.org/rel/dpdk-19.11.1.tar.xz
+  tar xf dpdk-19.11.1.tar.xz
+  rm dpdk-19.11.1.tar.xz
+  pushd dpdk-stable-19.11.1
+  make config T=x86_64-native-linuxapp-gcc O=x86_64-native-linuxapp-gcc
+  echo "export RTE_SDK=$(pwd)" >> ~/.profile
+  echo "export RTE_TARGET=x86_64-native-linuxapp-gcc" >> ~/.profile
+  cd x86_64-native-linuxapp-gcc
+  make -j 4
+  popd
+SCRIPT
+
+$huge = <<SCRIPT
+  mkdir -p /mnt/huge
+  (mount | grep hugetlbfs) > /dev/null || mount -t hugetlbfs nodev /mnt/huge
+  echo "nodev /mnt/huge hugetlbfs       defaults        0 0" >> /etc/fstab
+  echo 512 > /sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages
+  echo "vm.nr_hugepages=512" >> /etc/sysctl.conf
+SCRIPT
+
+$fastclick = <<SCRIPT
+  git clone https://github.com/tbarbette/fastclick.git fastclick
+  pushd fastclick
+  source ~/.profile
+  git checkout fastclick
+  ./configure --enable-dpdk --enable-multithread --disable-linuxmodule --enable-intel-cpu --enable-user-multithread --verbose --enable-select=poll CFLAGS="-O3" CXXFLAGS="-std=c++11 -O3"  --disable-dynamic-linking --enable-poll --enable-bound-port-transfer --enable-local --enable-flow --disable-task-stats --enable-cpu-load  --enable-user-timestamp --enable-all-elements
+  make -j 4
+  sudo make install
+  popd
+SCRIPT
+
+$deps = <<SCRIPT
+  python3 -m pip install --user pandas
+  mkdir ~/.vimhistory/
+  echo 'set undofile' >> .vimrc
+  echo 'set undodir=/home/vagrant/.vimhistory/' >> .vimrc
+  echo 'filetype plugin indent on' >> .vimrc
+  echo 'set smarttab' >> .vimrc
+  echo 'set shiftwidth=4' >> .vimrc
+  echo 'set autowrite' >> .vimrc
+  echo 'augroup filetypedetect' >> .vimrc
+  echo '    au BufRead,BufNewFile *.click setfiletype click' >> .vimrc
+  echo 'augroup END' >> .vimrc
+  sudo locale-gen en_GB.UTF-8
+  sudo service nginx stop
+SCRIPT
+
+$cleanup = <<SCRIPT
+  apt clean
+  rm -rf /tmp/*
+SCRIPT
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/xenial64"
+
+  config.vm.provider "virtualbox" do |v|
+	v.cpus = 3
+	v.memory = 3072
+  end
+
+  config.vm.synced_folder "../conf", "/conf"
+
+  ## Provisioning
+  config.vm.provision :shell, :inline => $init
+  config.vm.provision :shell, privileged: false, :inline => $ovs
+  config.vm.provision :shell, privileged: false, :inline => $mininet
+  config.vm.provision :shell, privileged: false, :inline => $dpdk
+  config.vm.provision :shell, :inline => $huge
+  config.vm.provision :shell, privileged: false, :inline => $fastclick
+  config.vm.provision :shell, privileged: false, :inline => $deps
+  config.vm.provision :shell, :inline => $cleanup
+
+  config.ssh.forward_x11 = true
+
+  config.vm.post_up_message = <<-HEREDOC
+  Setup finished!
+HEREDOC
+
+end

--- a/mininet/switch/topology-mininetonly.py
+++ b/mininet/switch/topology-mininetonly.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+#This is a python (Mininet) script that will generate a simple h1-sw1-h2 two-hosts topology
+
+from mininet.topo import Topo
+from mininet.net import Mininet
+from mininet.util import dumpNodeConnections
+from mininet.log import setLogLevel
+from mininet.cli import CLI
+
+import sys
+import time
+
+class MyTopo(Topo):
+
+
+    "Single switch connected to n hosts."
+    def build(self):
+
+        self.h1 = self.addHost('h1', ip="10.220.0.5/16")
+        self.h2 = self.addHost('h2', ip="10.220.0.10/16")
+        self.sw1 = self.addSwitch('sw1')
+        self.addLink(self.h1, self.sw1)
+        self.addLink(self.h2, self.sw1)
+
+def simpleTest():
+    "Create and test a simple network"
+    topo = MyTopo()
+    net = Mininet(topo)
+    net.start()
+
+    print "Dumping host connections"
+    dumpNodeConnections(net.hosts)
+
+    CLI(net)
+    net.stop()
+
+if __name__ == '__main__':
+    # Tell mininet to print useful information
+    setLogLevel('info')
+    simpleTest()

--- a/mininet/switch/topology.py
+++ b/mininet/switch/topology.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python
+#This is a python (Mininet) script that will generate a topology
+#with 2 hosts interconnected by a switch, but the switch runs using FastClick
+
+from mininet.topo import Topo
+from mininet.net import Mininet
+from mininet.util import dumpNodeConnections
+from mininet.log import setLogLevel
+from mininet.cli import CLI
+
+import sys
+import time
+
+class MyTopo(Topo):
+
+    "Single switch connected to 2 hosts."
+    def build(self):
+
+        self.h1 = self.addHost('h1', ip="10.220.0.5/16")
+        self.h2 = self.addHost('h2', ip="10.220.0.10/16")
+        self.sw1 = self.addHost('sw1')
+        self.addLink(self.h1, self.sw1)
+        self.addLink(self.h2, self.sw1)
+
+
+def simpleTest():
+    "Create and test a simple network"
+    topo = MyTopo()
+    net = Mininet(topo)
+    net.start()
+
+    print "Dumping host connections"
+    dumpNodeConnections(net.hosts)
+
+    sw1 = net.get(topo.sw1)
+
+    cmd = "cd /home/vagrant/fastclick && ./bin/click /home/vagrant/fastclick/conf/switch/switch-2ports-vanilla.click "+ ' '.join(sys.argv[1:])+" 2>&1 | tee click.log &"
+    print("Launching FastClick with " + cmd)
+    sw1.cmd(cmd)
+
+
+    print("Waiting for FastClick to set up...")
+    time.sleep(3)
+
+    client = net.get("h1")
+    print("Waiting for everything to set up...")
+    time.sleep(2)
+
+    CLI(net)
+    net.stop()
+
+if __name__ == '__main__':
+    # Tell mininet to print useful information
+    setLogLevel('info')
+    simpleTest()


### PR DESCRIPTION
For now just a switch but I'd like to add a router.

In the mininet folder one can simply run "vagrant up" to launch a VM with fastclick and mininet configured.

Then, inside the VM one can run one of the provided mininet topologies that will run Click on one host to run the functionality, and try it out with the mininet CLI. Hopefully this will be useful for learning purposes, and to write repeatable (functional) experiments in the future.