### PR TITLE
Use march=native by default, and check for AVX2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ script:
       FRAMEWORK_FLAGS="--enable-user-multithread";
     fi
 
-  - ./configure $CONFIG $FLAGS $FRAMEWORK_FLAGS && make
+  - ./configure $CONFIG $FLAGS $FRAMEWORK_FLAGS && ( make || make V=1 )
   - travis_retry make check
 
 install:

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1,7 +1,7 @@
-# generated automatically by aclocal 1.9.6 -*- Autoconf -*-
+# generated automatically by aclocal 1.15.1 -*- Autoconf -*-
 
-# Copyright (C) 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004,
-# 2005  Free Software Foundation, Inc.
+# Copyright (C) 1996-2017 Free Software Foundation, Inc.
+
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
 # with or without modifications, as long as this notice is preserved.
@@ -11,5 +11,6 @@
 # even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE.
 
-m4_include([m4/click.m4])
+m4_ifndef([AC_CONFIG_MACRO_DIRS], [m4_defun([_AM_CONFIG_MACRO_DIRS], [])m4_defun([AC_CONFIG_MACRO_DIRS], [_AM_CONFIG_MACRO_DIRS($@)])])
 m4_include([m4/ax_check_compile_flag.m4])
+m4_include([m4/click.m4])

--- a/config.h.in
+++ b/config.h.in
@@ -101,6 +101,9 @@
 /* Define if you want to use Intel-specific instructions. */
 #undef HAVE_INTEL_CPU
 
+/* Define if AVX2 instruction is available. */
+#undef HAVE_AVX2
+
 /* Define if 64-bit integer types are enabled. */
 #undef HAVE_INT64_TYPES
 

--- a/configure
+++ b/configure
@@ -11225,6 +11225,76 @@ fi
 
 
 if test "${check_avx2}" = "yes"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -mavx" >&5
+$as_echo_n "checking whether C++ compiler accepts -mavx... " >&6; }
+if ${ax_cv_check_cxxflags___mavx+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+  ax_check_save_flags=$CXXFLAGS
+  CXXFLAGS="$CXXFLAGS  -mavx"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  ax_cv_check_cxxflags___mavx=yes
+else
+  ax_cv_check_cxxflags___mavx=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CXXFLAGS=$ax_check_save_flags
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cxxflags___mavx" >&5
+$as_echo "$ax_cv_check_cxxflags___mavx" >&6; }
+if test "x$ax_cv_check_cxxflags___mavx" = xyes; then :
+  CXXFLAGS="-mavx $CXXFLAGS";CFLAGS="-mavx $CFLAGS"
+else
+  :
+fi
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -mavx2" >&5
+$as_echo_n "checking whether C++ compiler accepts -mavx2... " >&6; }
+if ${ax_cv_check_cxxflags___mavx2+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+  ax_check_save_flags=$CXXFLAGS
+  CXXFLAGS="$CXXFLAGS  -mavx2"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  ax_cv_check_cxxflags___mavx2=yes
+else
+  ax_cv_check_cxxflags___mavx2=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CXXFLAGS=$ax_check_save_flags
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cxxflags___mavx2" >&5
+$as_echo "$ax_cv_check_cxxflags___mavx2" >&6; }
+if test "x$ax_cv_check_cxxflags___mavx2" = xyes; then :
+  CXXFLAGS="-mavx2 $CXXFLAGS";CFLAGS="-mavx2 $CFLAGS"
+else
+  :
+fi
+
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we can compile AVX2 intrinsics in C" >&5
 $as_echo_n "checking whether we can compile AVX2 intrinsics in C... " >&6; }
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext

--- a/configure
+++ b/configure
@@ -874,7 +874,9 @@ enable_hash_iterator_epochs
 enable_force_expensive
 enable_valgrind
 enable_schedule_debugging
+enable_portable_binary
 enable_intel_cpu
+enable_avx2
 with_numa
 with_netmap
 with_proper
@@ -1603,7 +1605,11 @@ Optional Features:
   --enable-valgrind       extra support for debugging with valgrind
   --enable-schedule-debugging[=WHAT] enable Click scheduler debugging
                           (no/yes/extra) [yes]
+  --enable-portable-binary
+                          disable compiler optimizations that would produce
+                          unportable binaries
   --enable-intel-cpu      enable Intel-specific machine instructions
+  --enable-avx2           check whether AVX2 is enabled, default yes
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -11151,6 +11157,51 @@ _ACEOF
 fi
 
 
+# Check whether --enable-portable-binary was given.
+if test "${enable_portable_binary+set}" = set; then :
+  enableval=$enable_portable_binary; acx_maxopt_portable=$enableval
+else
+  acx_maxopt_portable=no
+fi
+
+if test $acx_maxopt_portable = no; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -march=native" >&5
+$as_echo_n "checking whether C++ compiler accepts -march=native... " >&6; }
+if ${ax_cv_check_cxxflags___march_native+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+  ax_check_save_flags=$CXXFLAGS
+  CXXFLAGS="$CXXFLAGS  -march=native"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  ax_cv_check_cxxflags___march_native=yes
+else
+  ax_cv_check_cxxflags___march_native=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  CXXFLAGS=$ax_check_save_flags
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cxxflags___march_native" >&5
+$as_echo "$ax_cv_check_cxxflags___march_native" >&6; }
+if test "x$ax_cv_check_cxxflags___march_native" = xyes; then :
+  CXXFLAGS="-march=native $CXXFLAGS";CFLAGS="-march=native $CFLAGS"
+else
+  :
+fi
+
+fi
+
 
 # Check whether --enable-intel-cpu was given.
 if test "${enable_intel_cpu+set}" = set; then :
@@ -11164,6 +11215,44 @@ if test $enable_intel_cpu = yes; then
 
 fi
 
+
+# Check whether --enable-avx2 was given.
+if test "${enable_avx2+set}" = set; then :
+  enableval=$enable_avx2; check_avx2=no
+else
+  check_avx2=yes
+fi
+
+
+if test "${check_avx2}" = "yes"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we can compile AVX2 intrinsics in C" >&5
+$as_echo_n "checking whether we can compile AVX2 intrinsics in C... " >&6; }
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+   #include <x86intrin.h>
+   int main(int argc, char **argv){
+   double* q;
+   __m256d a = _mm256_load_pd(q);
+   double d = _mm256_cvtsd_f64(a);
+   return 0;
+   }
+
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  HAVE_AVX2=yes
+else
+  HAVE_AVX2=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${HAVE_AVX2}" >&5
+$as_echo "${HAVE_AVX2}" >&6; }
+fi
+if test "${HAVE_AVX2}" = "yes"; then
+  $as_echo "#define HAVE_AVX2 1" >>confdefs.h
+
+fi
 
 
 shell_expand () {

--- a/configure.in
+++ b/configure.in
@@ -1424,6 +1424,8 @@ AC_ARG_ENABLE([avx2],
           [check_avx2=yes])
 
 if test "${check_avx2}" = "yes"; then
+  AX_CHECK_COMPILE_FLAG([-mavx], [CXXFLAGS="-mavx $CXXFLAGS";CFLAGS="-mavx $CFLAGS"])
+  AX_CHECK_COMPILE_FLAG([-mavx2], [CXXFLAGS="-mavx2 $CXXFLAGS";CFLAGS="-mavx2 $CFLAGS"])
   AC_MSG_CHECKING([whether we can compile AVX2 intrinsics in C])
   AC_COMPILE_IFELSE([AC_LANG_SOURCE([
    #include <x86intrin.h>

--- a/configure.in
+++ b/configure.in
@@ -1401,6 +1401,13 @@ if test "$value" != 0; then
 fi
 
 
+dnl Compile for the native architecture
+AC_ARG_ENABLE(portable-binary, [AS_HELP_STRING([--enable-portable-binary], [disable compiler optimizations that would produce unportable binaries])],
+	acx_maxopt_portable=$enableval, acx_maxopt_portable=no)
+if test $acx_maxopt_portable = no; then
+    AX_CHECK_COMPILE_FLAG([-march=native], [CXXFLAGS="-march=native $CXXFLAGS";CFLAGS="-march=native $CFLAGS"])
+fi
+
 dnl use Intel-specific machine instructions
 
 AC_ARG_ENABLE([intel-cpu], [AS_HELP_STRING([--enable-intel-cpu], [enable Intel-specific machine instructions])], :, enable_intel_cpu=no)
@@ -1408,6 +1415,33 @@ if test $enable_intel_cpu = yes; then
     AC_DEFINE(HAVE_INTEL_CPU)
 fi
 
+dnl Support AVX2 instructions
+
+AC_ARG_ENABLE([avx2],
+        AS_HELP_STRING([--enable-avx2],
+                   [check whether AVX2 is enabled, default yes]),
+          [check_avx2=no],
+          [check_avx2=yes])
+
+if test "${check_avx2}" = "yes"; then
+  AC_MSG_CHECKING([whether we can compile AVX2 intrinsics in C])
+  AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+   #include <x86intrin.h>
+   int main(int argc, char **argv){
+   double* q;
+   __m256d a = _mm256_load_pd(q);
+   double d = _mm256_cvtsd_f64(a);
+   return 0;
+   }
+   ])],
+   [HAVE_AVX2=yes],
+   [HAVE_AVX2=no]
+  )
+  AC_MSG_RESULT([${HAVE_AVX2}])
+fi
+if test "${HAVE_AVX2}" = "yes"; then
+  AC_DEFINE(HAVE_AVX2)
+fi
 
 dnl
 dnl expand path variables

--- a/elements/standard/paint2.cc
+++ b/elements/standard/paint2.cc
@@ -1,0 +1,58 @@
+/*
+ * Paint2.{cc,hh} -- element sets packets' Paint2 annotation
+ * Eddie Kohler, Robert Morris
+ *
+ * Copyright (c) 1999-2000 Massachusetts Institute of Technology
+ * Copyright (c) 2008 Meraki, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
+#include <click/config.h>
+#include "paint2.hh"
+#include <click/args.hh>
+#include <click/error.hh>
+#include <click/glue.hh>
+#include <click/packet_anno.hh>
+CLICK_DECLS
+
+Paint2::Paint2()
+{
+}
+
+int
+Paint2::configure(Vector<String> &conf, ErrorHandler *errh)
+{
+    int anno = PAINT2_ANNO_OFFSET;
+    if (Args(conf, this, errh)
+	.read_mp("COLOR", _color)
+	.read_p("ANNO", AnnoArg(2), anno).complete() < 0)
+	return -1;
+    _anno = anno;
+    return 0;
+}
+
+Packet *
+Paint2::simple_action(Packet *p)
+{
+    p->set_anno_u16(_anno, _color);
+    return p;
+}
+
+void
+Paint2::add_handlers()
+{
+    add_data_handlers("color", Handler::OP_READ | Handler::OP_WRITE, &_color);
+}
+
+CLICK_ENDDECLS
+EXPORT_ELEMENT(Paint2)
+ELEMENT_MT_SAFE(Paint2)

--- a/elements/standard/paint2.hh
+++ b/elements/standard/paint2.hh
@@ -1,0 +1,49 @@
+#ifndef CLICK_Paint2_HH
+#define CLICK_Paint2_HH
+#include <click/element.hh>
+CLICK_DECLS
+
+/*
+=c
+
+Paint2(COLOR [, ANNO])
+
+=s Paint2
+
+sets packet Paint2 annotations
+
+=d
+
+Sets each packet's PAINT2 annotation to COLOR, an integer 0..255.
+
+Paint2 sets the packet's PAINT2 annotation by default, but the ANNO argument can
+specify any two-byte annotation.
+
+=h color read/write
+
+Get/set the color to PAINT2.
+
+=a Paint */
+
+class Paint2 : public Element { public:
+
+    Paint2() CLICK_COLD;
+
+    const char *class_name() const		{ return "Paint2"; }
+    const char *port_count() const		{ return PORTS_1_1; }
+
+    int configure(Vector<String> &, ErrorHandler *) CLICK_COLD;
+    bool can_live_reconfigure() const		{ return true; }
+    void add_handlers() CLICK_COLD;
+
+    Packet *simple_action(Packet *);
+
+  private:
+
+    uint8_t _anno;
+    uint16_t _color;
+
+};
+
+CLICK_ENDDECLS
+#endif

--- a/elements/standard/search.cc
+++ b/elements/standard/search.cc
@@ -1,0 +1,77 @@
+// -*- mode: c++; c-basic-offset: 4 -*-
+/*
+ * Search.{cc,hh} -- element strips TCP header from front of packet
+ * Tom Barbette
+ *
+ * Copyright (c) 2020 KTH Royal Institute of Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
+#include <click/config.h>
+#include <click/args.hh>
+#include <click/error.hh>
+#include <click/glue.hh>
+#include <click/packet_anno.hh>
+#include <clicknet/tcp.h>
+#include "search.hh"
+CLICK_DECLS
+
+Search::Search()
+{
+}
+
+int
+Search::configure(Vector<String> &conf, ErrorHandler *errh)
+{
+	int anno = PAINT2_ANNO_OFFSET;
+	String pattern;
+	bool strip_after = true;
+	bool set_anno = true;
+    if (Args(conf, this, errh)
+    		.read_mp("PATTERN", pattern)
+			.read("STRIP_AFTER", strip_after)
+			.read("ANNO", AnnoArg(2), anno)
+			.read("SET_ANNO", _set_anno)
+			.complete() < 0)
+				return -1;
+    if (pattern.length() == 0) {
+	return errh->error("Cannot search for an empty string!");
+    }
+    _anno = anno;
+    _set_anno = set_anno;
+    _pattern = pattern;
+    _strip_after = strip_after;
+
+    return 0;
+}
+
+void
+Search::push(int, Packet *p) {
+
+	const char* f = String::make_stable((const char*)p->data(), p->length()).search(_pattern);
+	if (f == 0) {
+		output(1).push(p);
+		return;
+	}
+
+	unsigned n = (f - (const char*)p->data());
+	if (_strip_after)
+		n += _pattern.length();
+	p->pull(n);
+	if (_set_anno)
+		p->set_anno_u16(_anno, p->anno_u16(_anno) + n);
+	output(0).push(p);
+}
+
+CLICK_ENDDECLS
+EXPORT_ELEMENT(Search)
+ELEMENT_MT_SAFE(Search)

--- a/elements/standard/search.hh
+++ b/elements/standard/search.hh
@@ -1,0 +1,53 @@
+// -*- mode: c++; c-basic-offset: 4 -*-
+#ifndef CLICK_Search_HH
+#define CLICK_Search_HH
+#include <click/element.hh>
+CLICK_DECLS
+
+/*
+ * =c
+ * Search()
+ * =s basicmod
+ * Strip the TCP header from front of packets
+ * =d
+ * Removes all bytes from the beginning of the packet up to the end of the TCP header.
+ * It will also increase an annotation (by default Paint2) by the number of bytes poped
+ * to remember how long was the header and allow to revert the operation later. This is
+ * intended to be used with UnstripAnno
+ * =e
+ * Use this to get rid of all headers up to the end of the TCP layer, print the HTTP request payload, and
+ * go back to the previous pointer:
+ *
+ *   s :: Search("\n\r\n\r") //Strips to the end of the pattern
+ *   -> Print("HTTP REQUEST PAYLOAD") //So Print will show the content
+ *   -> UntripAnno(); //Go back to where we were
+ *
+ *   s[1] -> Print("Malformed HTTP");
+ *
+ *
+ * =a UnstripAnno
+ */
+
+class Search : public Element { public:
+
+    Search() CLICK_COLD;
+
+    const char *class_name() const		{ return "Search"; }
+    const char *port_count() const		{ return PORTS_1_1X2; }
+    const char *processing() const		{ return PUSH; }
+
+    int configure(Vector<String> &, ErrorHandler *) CLICK_COLD;
+
+    void push(int, Packet *) override;
+
+  private:
+
+    int _anno;
+    String _pattern;
+    bool _set_anno;
+    bool _strip_after;
+
+};
+
+CLICK_ENDDECLS
+#endif

--- a/elements/standard/unstripanno.cc
+++ b/elements/standard/unstripanno.cc
@@ -1,0 +1,50 @@
+/*
+ * UnstripAnno.{cc,hh} -- element strips a dynamic amount of bytes from front of packet
+ * Tom Barbette
+ *
+ * Copyright (c) 2020 KTH Royal Institute of Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
+#include <click/config.h>
+#include <click/args.hh>
+#include <click/error.hh>
+#include <click/glue.hh>
+#include <click/packet_anno.hh>
+#include "unstripanno.hh"
+CLICK_DECLS
+
+UnstripAnno::UnstripAnno()
+{
+}
+
+int
+UnstripAnno::configure(Vector<String> &conf, ErrorHandler *errh)
+{
+	int anno = PAINT2_ANNO_OFFSET;
+    if (Args(conf, this, errh)
+			.read_p("ANNO", AnnoArg(2), anno)
+			.complete() < 0)
+				return -1;
+    _anno = anno;
+    return 0;
+}
+
+Packet *
+UnstripAnno::simple_action(Packet *p)
+{
+  return p->push(p->anno_u16(_anno));
+}
+
+CLICK_ENDDECLS
+EXPORT_ELEMENT(UnstripAnno)
+ELEMENT_MT_SAFE(UnstripAnno)

--- a/elements/standard/unstripanno.hh
+++ b/elements/standard/unstripanno.hh
@@ -1,0 +1,36 @@
+#ifndef CLICK_UNSTRIPANNO_HH
+#define CLICK_UNSTRIPANNO_HH
+#include <click/element.hh>
+CLICK_DECLS
+
+/*
+ * =c
+ * UnstripAnno(LENGTH)
+ * =s basicmod
+ * Unstrip the number of bytes specified by an annotation from front of packets
+ * =d
+ * Put the bytes specified in an annotation at the front of the packet. These bytes may be bytes
+ * previously removed by StripTCPHeader.
+ *
+ * =a StripTCPHeader
+ */
+
+class UnstripAnno : public Element {
+
+ public:
+
+  UnstripAnno();
+
+  const char *class_name() const	{ return "UnstripAnno"; }
+  const char *port_count() const	{ return PORTS_1_1; }
+
+  int configure(Vector<String> &, ErrorHandler *) CLICK_COLD;
+
+  Packet *simple_action(Packet *);
+
+private:
+  int _anno;
+};
+
+CLICK_ENDDECLS
+#endif

--- a/elements/tcpudp/striptcpheader.cc
+++ b/elements/tcpudp/striptcpheader.cc
@@ -1,0 +1,43 @@
+// -*- mode: c++; c-basic-offset: 4 -*-
+/*
+ * striptcpheader.{cc,hh} -- element strips TCP header from front of packet
+ * Tom Barbette
+ *
+ * Copyright (c) 2020 KTH Royal Institute of Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
+#include <click/config.h>
+#include <click/args.hh>
+#include <click/error.hh>
+#include <click/glue.hh>
+#include <click/packet_anno.hh>
+#include <clicknet/tcp.h>
+#include "striptcpheader.hh"
+CLICK_DECLS
+
+StripTCPHeader::StripTCPHeader()
+{
+}
+
+Packet *
+StripTCPHeader::simple_action(Packet *p)
+{
+	const click_tcp *th = p->tcp_header();
+	unsigned n = th->th_off << 2;
+	p->pull(n);
+    return p;
+}
+
+CLICK_ENDDECLS
+EXPORT_ELEMENT(StripTCPHeader)
+ELEMENT_MT_SAFE(StripTCPHeader)

--- a/elements/tcpudp/striptcpheader.hh
+++ b/elements/tcpudp/striptcpheader.hh
@@ -1,0 +1,41 @@
+// -*- mode: c++; c-basic-offset: 4 -*-
+#ifndef CLICK_STRIPTCPHEADER_HH
+#define CLICK_STRIPTCPHEADER_HH
+#include <click/batchelement.hh>
+CLICK_DECLS
+
+/*
+ * =c
+ * StripTCPHeader()
+ *
+ * =s tcp
+ * Strip the TCP header from the front of packets
+ *
+ * =d
+ * Removes all bytes from the beginning of the packet up to the end of the TCP header.
+ *
+ * =e
+ * Use this to get rid of all headers up to the end of the TCP layer, check if the first bytes are "GET", and
+ * set back the pointer to the beginning of the IP layer:
+ *
+ *   StripTCPHeader()
+ *   -> c :: Classifier(0/474552,-)
+ *   -> UnstripIPHeader()
+ *
+ *
+ * =a Strip, StripIPHeader, UnstripTCPHeader
+ */
+
+class StripTCPHeader : public SimpleElement<StripTCPHeader> { public:
+
+    StripTCPHeader() CLICK_COLD;
+
+    const char *class_name() const		{ return "StripTCPHeader"; }
+    const char *port_count() const		{ return PORTS_1_1; }
+
+    Packet *simple_action(Packet *);
+
+};
+
+CLICK_ENDDECLS
+#endif

--- a/elements/tcpudp/unstriptcpheader.cc
+++ b/elements/tcpudp/unstriptcpheader.cc
@@ -1,0 +1,44 @@
+/*
+ * unstriptcpheader.{cc,hh} -- put TCP header back based on annotation
+ * Benjie Chen, Tom Barbette
+ *
+ * Copyright (c) 2000 Massachusetts Institute of Technology
+ * Copyright (c) 2020 KTH Royal Institute of Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
+#include <click/config.h>
+#include "unstriptcpheader.hh"
+#include <clicknet/ip.h>
+CLICK_DECLS
+
+UnstripTCPHeader::UnstripTCPHeader()
+{
+}
+
+UnstripTCPHeader::~UnstripTCPHeader()
+{
+}
+
+Packet *
+UnstripTCPHeader::simple_action(Packet *p)
+{
+    assert(p->transport_header());
+    ptrdiff_t offset = p->transport_header() - p->data();
+    if (offset < 0)
+	p = p->push(-offset);	// should never create a new packet
+    return p;
+}
+
+CLICK_ENDDECLS
+EXPORT_ELEMENT(UnstripTCPHeader)
+ELEMENT_MT_SAFE(UnstripTCPHeader)

--- a/elements/tcpudp/unstriptcpheader.hh
+++ b/elements/tcpudp/unstriptcpheader.hh
@@ -1,0 +1,34 @@
+#ifndef CLICK_UNSTRIPTCPHEADER_HH
+#define CLICK_UNSTRIPTCPHEADER_HH
+#include <click/batchelement.hh>
+CLICK_DECLS
+
+/*
+ * =c
+ * UnstripTCPHeader()
+ *
+ * =s tcp
+ *
+ * restores outermost TCP header
+ * =d
+ *
+ * Put outermost TCP header back onto a stripped packet, based on the TCP Header
+ * annotation from MarkTCPHeader or CheckTCPHeader. If TCP header already on,
+ * forwards packet unmodified.
+ *
+ * =a StripTCPHeader, CheckIPHeader, MarkIPHeader, StripIPHeader */
+
+class UnstripTCPHeader : public SimpleElement<UnstripTCPHeader> { public:
+
+  UnstripTCPHeader() CLICK_COLD;
+  ~UnstripTCPHeader() CLICK_COLD;
+
+  const char *class_name() const		{ return "UnstripTCPHeader"; }
+  const char *port_count() const		{ return PORTS_1_1; }
+
+  Packet *simple_action(Packet *);
+
+};
+
+CLICK_ENDDECLS
+#endif

--- a/elements/test/stringtest.cc
+++ b/elements/test/stringtest.cc
@@ -44,6 +44,13 @@ StringTest::initialize(ErrorHandler *errh)
     CHECK(String("HELLO;YOU").split(';')[0] == "HELLO");
     CHECK(String("HELLO;YOU").split(';')[1] == "YOU");
 
+    String s = String("HELLO YOU !");
+    CHECK(s.search("HELLO") == s.data());
+    CHECK(s.search("YOU") == s.data() + 6);
+    CHECK(s.search("ME") == 0);
+    CHECK(s.search("!") == s.data() + s.length() - 1);
+    CHECK(String("").search("!") == 0);
+
     if (!errh->nerrors()) {
     	errh->message("All tests pass!");
 		return 0;

--- a/include/click/packet_anno.hh
+++ b/include/click/packet_anno.hh
@@ -22,17 +22,23 @@
 #define WIFI_EXTRA_ANNO_SIZE		24
 #define WIFI_EXTRA_ANNO(p)		((click_wifi_extra *) ((p)->anno_u8() + WIFI_EXTRA_ANNO_OFFSET))
 
-// byte 16
-#define PAINT_ANNO_OFFSET		16
-#define PAINT_ANNO_SIZE			1
-#define PAINT_ANNO(p)			((p)->anno_u8(PAINT_ANNO_OFFSET))
-#define SET_PAINT_ANNO(p, v)		((p)->set_anno_u8(PAINT_ANNO_OFFSET, (v)))
+// byte 16-17
+#define PAINT2_ANNO_OFFSET		16
+#define PAINT2_ANNO_SIZE			2
+#define PAINT2_ANNO(p)			((p)->anno_u16(PAINT2_ANNO_OFFSET))
+#define SET_PAINT2_ANNO(p, v)		((p)->set_anno_u16(PAINT2_ANNO_OFFSET, (v)))
 
-// byte 17
-#define ICMP_PARAMPROB_ANNO_OFFSET	17
+// byte 16
+#define ICMP_PARAMPROB_ANNO_OFFSET	16
 #define ICMP_PARAMPROB_ANNO_SIZE	1
 #define ICMP_PARAMPROB_ANNO(p)		((p)->anno_u8(ICMP_PARAMPROB_ANNO_OFFSET))
 #define SET_ICMP_PARAMPROB_ANNO(p, v)	((p)->set_anno_u8(ICMP_PARAMPROB_ANNO_OFFSET, (v)))
+
+// byte 17 (lower byte of PAINT2)
+#define PAINT_ANNO_OFFSET		17
+#define PAINT_ANNO_SIZE			1
+#define PAINT_ANNO(p)			((p)->anno_u8(PAINT_ANNO_OFFSET))
+#define SET_PAINT_ANNO(p, v)		((p)->set_anno_u8(PAINT_ANNO_OFFSET, (v)))
 
 // byte 19
 #define FIX_IP_SRC_ANNO_OFFSET		19

--- a/lib/nameinfo.cc
+++ b/lib/nameinfo.cc
@@ -127,6 +127,7 @@ static const StaticNameDB::Entry annotation_entries[] = {
     { "MISC_IP", MKAI(MISC_IP) },
     { "PACKET_NUMBER", MKAI(PACKET_NUMBER) },
     { "PAINT", MKAI(PAINT) },
+    { "PAINT2", MKAI(PAINT2) },
 #if HAVE_INT64_TYPES
     { "PERFCTR", MKAI(PERFCTR) },
 #endif

--- a/lib/string.cc
+++ b/lib/string.cc
@@ -24,6 +24,7 @@
 #include <click/straccum.hh>
 #include <click/glue.hh>
 #include <click/vector.hh>
+
 CLICK_DECLS
 
 /** @file string.hh
@@ -1149,5 +1150,36 @@ String::skip_utf8_char(const unsigned char *first, const unsigned char *last)
     }
     return first;
 }
+
+const char* String::searchLegacy(const char* pattern, const int pattern_length)
+{
+    const char* start = data();
+    const char* content_end = end();
+    const char* pattern_end = pattern + pattern_length;
+
+    // Search until we reach the end of the buffer
+    while(start != content_end)
+    {
+	const char* current_pattern = pattern;
+        const char* current_content = start;
+
+        // Check if the characters in the buffer and in the pattern match (case insensitive)
+        while(current_content != content_end
+            && (*current_content == *current_pattern))
+        {
+            ++current_pattern;
+            ++current_content;
+		if (current_pattern == pattern_end)
+			return start;
+        }
+
+        ++start;
+    }
+
+    return 0;
+}
+
+
+
 
 CLICK_ENDDECLS

--- a/test/standard/search-01.testie
+++ b/test/standard/search-01.testie
@@ -1,0 +1,12 @@
+%info
+Tests String class with the StringTest element.
+
+%require
+click-buildtool provides StringTest
+
+%script
+click -e 'InfiniteSource("HELLO WORLD !", STOP 1, LIMIT 1) -> s :: Search("LO ") -> Print(FOUND) -> UnstripAnno() -> Print(FOUNDFULL) -> Discard; s[1] -> Print(NOTFOUND)-> Discard;'
+
+%expect stderr
+FOUND:    7 | 574f524c 442021
+FOUNDFULL:   13 | 48454c4c 4f20574f 524c4420 21

--- a/test/standard/string-01.testie
+++ b/test/standard/string-01.testie
@@ -1,0 +1,12 @@
+%info
+Tests String class with the StringTest element.
+
+%require
+click-buildtool provides StringTest
+
+%script
+click -qe StringTest
+
+%expect stderr
+config:1:{{.*}}
+  All tests pass!

--- a/test/tcpudp/StripTCPHeader-01.testie
+++ b/test/tcpudp/StripTCPHeader-01.testie
@@ -1,0 +1,39 @@
+%info
+
+TCPRewriter and FTPPortMapper sequence number translation, even for SACK.
+
+%script
+$VALGRIND click -e "
+FromIPSummaryDump(IN1, STOP true, CHECKSUM true)
+	-> CheckIPHeader(VERBOSE true)
+	-> CheckTCPHeader(VERBOSE true)
+    -> StripIPHeader
+    -> StripTCPHeader
+    -> Print(PAY)
+    -> StoreData(OFFSET 0, DATA "ABC")
+    -> UnstripIPHeader()
+    -> Print(FULLTCP)
+	-> ToIPSummaryDump(OUT1, FIELDS src sport dst dport proto tcp_seq tcp_ack payload tcp_opt)
+"
+
+%file IN1
+!data src sport dst dport proto tcp_seq tcp_ack payload tcp_opt
+200.200.200.200 30 2.0.0.2 21 T 0 0 "XYZ" .
+200.200.200.200 30 2.0.0.2 21 T 30 0 "XYZ" .
+2.0.0.2 21 1.0.0.1 1024 T 0 0 "XYZ" sack1-10;sack1-18;sack18-20
+
+%expect OUT1
+!IPSummaryDump 1.3
+!data ip_src sport ip_dst dport ip_proto tcp_seq tcp_ack payload tcp_opt
+200.200.200.200 30 2.0.0.2 21 T 0 0 "ABC" .
+200.200.200.200 30 2.0.0.2 21 T 30 0 "ABC" .
+2.0.0.2 21 1.0.0.1 1024 T 0 0 "ABC" sack1-10;sack1-18;sack18-20
+
+
+%expect stderr
+PAY:    3 | 58595a
+FULLTCP:   43 | 4500002b 00000000 6406c33a c8c8c8c8 02000002 001e0015
+PAY:    3 | 58595a
+FULLTCP:   43 | 4500002b 00000000 6406c33a c8c8c8c8 02000002 001e0015
+PAY:    3 | 58595a
+FULLTCP:   75 | 4500004b 00000000 640653ab 02000002 01000001 00150400


### PR DESCRIPTION
Add the Search element that searchs for a pattern in the packet, using AVX2 if available. Hence all the importance of AVX2.

At the same time I think we should have -march=native by default (it was probably already added by DPDK anyway). One can disable it with --enable-portable-binary.