### PR TITLE
FromDPDKDevice: avoid global enum definition

### DIFF
--- a/elements/userlevel/fromdpdkdevice.cc
+++ b/elements/userlevel/fromdpdkdevice.cc
@@ -391,6 +391,25 @@ void FromDPDKDevice::selected(int fd, int mask) {
 }
 #endif
 
+enum {
+    h_vendor, h_driver, h_carrier, h_duplex, h_autoneg, h_speed, h_type,
+    h_ipackets, h_ibytes, h_imissed, h_ierrors, h_nombufs,
+    h_stats_packets, h_stats_bytes,
+    h_active, h_safe_active,
+    h_xstats, h_queue_count,
+    h_nb_rx_queues, h_nb_tx_queues, h_nb_vf_pools,
+    h_rss,
+    h_mac, h_add_mac, h_remove_mac, h_vf_mac,
+    h_mtu,
+    h_device,
+#if RTE_VERSION >= RTE_VERSION_NUM(20,2,0,0)
+    h_rule_add, h_rules_del, h_rules_isolate, h_rules_flush,
+    h_rules_list, h_rules_list_with_hits, h_rules_ids_global, h_rules_ids_internal,
+    h_rules_count, h_rules_count_with_hits, h_rule_packet_hits, h_rule_byte_count,
+    h_rules_aggr_stats
+#endif
+};
+
 String FromDPDKDevice::read_handler(Element *e, void * thunk)
 {
     FromDPDKDevice *fd = static_cast<FromDPDKDevice *>(e);

--- a/elements/userlevel/fromdpdkdevice.hh
+++ b/elements/userlevel/fromdpdkdevice.hh
@@ -447,25 +447,6 @@ private:
     static String statistics_handler(Element *e, void *thunk) CLICK_COLD;
     static int xstats_handler(int operation, String &input, Element *e,
                               const Handler *handler, ErrorHandler *errh);
-    enum {
-        h_vendor, h_driver, h_carrier, h_duplex, h_autoneg, h_speed, h_type,
-        h_ipackets, h_ibytes, h_imissed, h_ierrors, h_nombufs,
-        h_stats_packets, h_stats_bytes,
-        h_active, h_safe_active,
-        h_xstats, h_queue_count,
-        h_nb_rx_queues, h_nb_tx_queues, h_nb_vf_pools,
-        h_rss,
-        h_mac, h_add_mac, h_remove_mac, h_vf_mac,
-        h_mtu,
-        h_device,
-    #if RTE_VERSION >= RTE_VERSION_NUM(20,2,0,0)
-        h_rule_add, h_rules_del, h_rules_isolate, h_rules_flush,
-        h_rules_list, h_rules_list_with_hits, h_rules_ids_global, h_rules_ids_internal,
-        h_rules_count, h_rules_count_with_hits, h_rule_packet_hits, h_rule_byte_count,
-        h_rules_aggr_stats
-    #endif
-    };
-
     DPDKDevice* _dev;
 
 #if HAVE_DPDK_INTERRUPT


### PR DESCRIPTION
I saw this way of doing things in multiple elements. Seems better to avoid names that could clash between inherited instances etc.