### PR TITLE
Checksum offloading for TX (UDP) and RX (IP, TCP, UDP) with DPDK

### DIFF
--- a/elements/userlevel/fromdpdkdevice.hh
+++ b/elements/userlevel/fromdpdkdevice.hh
@@ -458,6 +458,9 @@ private:
     per_thread<FDState> _fdstate;
 #endif
     bool _set_timestamp;
+    bool _tco;
+    bool _uco;
+    bool _ipco;
 };
 
 CLICK_ENDDECLS

--- a/elements/userlevel/todpdkdevice.cc
+++ b/elements/userlevel/todpdkdevice.cc
@@ -27,7 +27,7 @@ CLICK_DECLS
 ToDPDKDevice::ToDPDKDevice() :
     _iqueues(), _dev(0),
     _timeout(0), _congestion_warning_printed(false), _create(true),
-    _tso(0), _tco(false), _ipco(false)
+    _tso(0), _tco(false), _uco(false), _ipco(false)
 {
      _blocking = false;
      _burst = -1;
@@ -61,6 +61,7 @@ int ToDPDKDevice::configure(Vector<String> &conf, ErrorHandler *errh)
         .read("TSO", _tso)
         .read("IPCO", _ipco)
         .read("TCO", _tco)
+        .read("UCO", _uco)
 #endif
         .complete() < 0)
             return -1;
@@ -82,12 +83,12 @@ int ToDPDKDevice::configure(Vector<String> &conf, ErrorHandler *errh)
 
     if (_tso)
         _dev->set_tx_offload(DEV_TX_OFFLOAD_TCP_TSO);
-    if (_ipco)
+    if (_ipco || _tco || _uco)
         _dev->set_tx_offload(DEV_TX_OFFLOAD_IPV4_CKSUM);
-    if (_tco) {
-        _dev->set_tx_offload(DEV_TX_OFFLOAD_IPV4_CKSUM);
+    if (_tco)
         _dev->set_tx_offload(DEV_TX_OFFLOAD_TCP_CKSUM);
-    }
+    if (_uco)
+        _dev->set_tx_offload(DEV_TX_OFFLOAD_UDP_CKSUM);
     return 0;
 }
 

--- a/elements/userlevel/todpdkdevice.hh
+++ b/elements/userlevel/todpdkdevice.hh
@@ -163,6 +163,7 @@ private:
     bool _vlan;
     uint32_t _tso;
     bool _tco;
+    bool _uco;
     bool _ipco;
 
     friend class FromDPDKDevice;


### PR DESCRIPTION
This allows to activate UDP checksum offloading for ToDPDKDevice, and allows to activate IP, TCP and UDP checksum offloading for FromDPDKDevice.