### PR TITLE
Minor fixes and improvements

### DIFF
--- a/elements/analysis/cyclecountaccum.cc
+++ b/elements/analysis/cyclecountaccum.cc
@@ -87,7 +87,11 @@ CycleCountAccum::read_handler(Element *e, void *thunk)
       case 3: {
 	  PER_THREAD_MEMBER_SUM(uint64_t,accum,cca->_state,accum);
 	  PER_THREAD_MEMBER_SUM(uint64_t,count,cca->_state,count);
-	  return String(accum / count); }
+	  if(likely(count))
+	    return String(accum / count);
+	  else
+	    return String(0);
+	  }
       default:
 	  return String();
     }

--- a/elements/flow/flowipmanagerimp.hh
+++ b/elements/flow/flowipmanagerimp.hh
@@ -69,6 +69,7 @@ class FlowIPManagerIMP: public VirtualFlowManager, public Router::InitFuture {
 
         gtable* _tables;
 
+	int _tables_count;
         int _table_size;
         int _flow_state_size_full;
         int _verbose;

--- a/elements/userlevel/fromdpdkdevice.cc
+++ b/elements/userlevel/fromdpdkdevice.cc
@@ -405,7 +405,7 @@ void FromDPDKDevice::selected(int fd, int mask) {
 
 enum {
     h_vendor, h_driver, h_carrier, h_duplex, h_autoneg, h_speed, h_type,
-    h_ipackets, h_ibytes, h_imissed, h_ierrors, h_nombufs, h_out_of_buffer,
+    h_ipackets, h_ibytes, h_imissed, h_ierrors, h_nombufs,
     h_stats_packets, h_stats_bytes,
     h_active, h_safe_active,
     h_xstats, h_queue_count,
@@ -570,22 +570,6 @@ String FromDPDKDevice::statistics_handler(Element *e, void *thunk)
     #endif
         case h_nombufs:
             return String(stats.rx_nombuf);
-	case h_out_of_buffer:
-	{
-	  const char *name = "rx_out_of_buffer";
-	  uint64_t id = 0;
-	  if (rte_eth_xstats_get_id_by_name(fd->_dev->port_id, name, &id))
-	    return String("Could not retrieve rx_out_of_buffer counter");
-	  else {
-	    struct rte_eth_xstat *xstat;
-	    uint64_t val = 0;
-	    if (rte_eth_xstats_get_by_id(fd->_dev->port_id, &id, &val, 1) == 1)
-	      return String(val);
-	    else
-	      return String("Error while retrieving rx_out_of_buffer counter");
-	  }
-	}
-
         default:
             return "<unknown>";
     }
@@ -899,7 +883,6 @@ void FromDPDKDevice::add_handlers()
     add_read_handler("hw_dropped",statistics_handler, h_imissed);
     add_read_handler("hw_errors",statistics_handler, h_ierrors);
     add_read_handler("nombufs",statistics_handler, h_nombufs);
-    add_read_handler("out_of_buffer",statistics_handler, h_out_of_buffer);
 
 #if RTE_VERSION >= RTE_VERSION_NUM(20,2,0,0)
     add_write_handler(FlowRuleManager::FLOW_RULE_ADD,     flow_handler, h_rule_add,    0);

--- a/elements/userlevel/fromdpdkdevice.hh
+++ b/elements/userlevel/fromdpdkdevice.hh
@@ -341,7 +341,11 @@ Returns the number of errors of this device, as computed by the hardware.
 
 =h nombufs read-only
 
-Returns the number of mbufs allocated for this devce.
+Returns the total number of RX mbuf allocation failures. 
+
+=h out_of_buffer read-only
+
+Returns the number of times receive queue had no software buffers allocated for the adapter's incoming traffic.
 
 =h rule_add write-only
 

--- a/elements/userlevel/fromdpdkdevice.hh
+++ b/elements/userlevel/fromdpdkdevice.hh
@@ -228,6 +228,7 @@ Returns the device's link type (only fiber is currently supported).
 =h xstats read-only
 
 Returns a device's detailed packet and byte counters.
+If a parameter is given, only the matching counter will be returned.
 
 =h queue_count read-only
 
@@ -342,10 +343,6 @@ Returns the number of errors of this device, as computed by the hardware.
 =h nombufs read-only
 
 Returns the total number of RX mbuf allocation failures. 
-
-=h out_of_buffer read-only
-
-Returns the number of times receive queue had no software buffers allocated for the adapter's incoming traffic.
 
 =h rule_add write-only
 

--- a/include/click/flowrulemanager.hh
+++ b/include/click/flowrulemanager.hh
@@ -166,11 +166,12 @@ class FlowRuleManager {
         String flow_rules_from_file_to_string(const String &filename);
 
         // Install flow rule(s) in a NIC
-        int flow_rules_install(const String &rules, const uint32_t &rules_nb);
+        int flow_rules_install(const String &rules, const uint32_t &rules_nb, const bool verbose=true);
         int flow_rule_install(
             const uint32_t &int_rule_id, const uint32_t &rule_id,
             const int &core_id, const String &rule,
-            const bool with_cache = true
+            const bool with_cache = true,
+	    const bool verbose=true
         );
 
         // Verify the presence/absence of a list of rules in/from the NIC

--- a/lib/flowrulemanager.cc
+++ b/lib/flowrulemanager.cc
@@ -649,15 +649,17 @@ FlowRuleManager::flow_rules_add_from_file(const String &filename)
  * Translates a set of newline-separated flow rules into flow rule objects and installs them in a NIC.
  *
  * @args rules: a string of newline-separated flow rules
- * @args rules_nb: the number of flow rules to install
+ * @args rules_nb: the number of flow rules to installS
+ * @args verbose: if true, prints messages (dafults to true)
  * @return installation status
  */
 int
-FlowRuleManager::flow_rules_install(const String &rules, const uint32_t &rules_nb)
+FlowRuleManager::flow_rules_install(const String &rules, const uint32_t &rules_nb, const bool verbose)
 {
     // Only active instances can configure a NIC
     if (!active()) {
-        _errh->error("DPDK Flow Rule Manager (port %u): Inactive instance cannot install rules", _port_id);
+	//if(unlikely(verbose))
+	 _errh->error("DPDK Flow Rule Manager (port %u): Inactive instance cannot install rules", _port_id);
         return FLOWRULEPARSER_ERROR;
     }
 
@@ -671,11 +673,13 @@ FlowRuleManager::flow_rules_install(const String &rules, const uint32_t &rules_n
     if (res >= 0) {
         // Workaround DPDK's deficiency to report rule installation issues
         if ((rules_before + rules_nb) != rules_after) {
-            _errh->message("DPDK Flow Rule Manager (port %u): Flow installation failed - Has %" PRIu32 ", but expected %" PRIu32 " rules", _port_id, rules_after, rules_before + rules_nb);
+	    if(unlikely(verbose))
+		_errh->message("DPDK Flow Rule Manager (port %u): Flow installation failed - Has %" PRIu32 ", but expected %" PRIu32 " rules", _port_id, rules_after, rules_before + rules_nb);
             return FLOWRULEPARSER_ERROR;
         } else {
-            _errh->message("DPDK Flow Rule Manager (port %u): Parsed and installed a batch of %" PRIu32 " rules", _port_id, rules_nb);
-            return FLOWRULEPARSER_SUCCESS;
+	    if(unlikely(verbose))
+	        _errh->message("DPDK Flow Rule Manager (port %u): Parsed and installed a batch of %" PRIu32 " rules", _port_id, rules_nb);
+	    return FLOWRULEPARSER_SUCCESS;
         }
     }
 
@@ -713,13 +717,14 @@ FlowRuleManager::flow_rules_install(const String &rules, const uint32_t &rules_n
  * @args core_id: a CPU core ID associated with this flow rule
  * @args rule: a flow rule as a string
  * @args with_cache: if true, the flow cache is updated accordingly (defaults to true)
+ * @args verbose: if true, print messages about the operations (defaults to true)
  * @return installation status
  */
 int
-FlowRuleManager::flow_rule_install(const uint32_t &int_rule_id, const uint32_t &rule_id, const int &core_id, const String &rule, const bool with_cache)
+FlowRuleManager::flow_rule_install(const uint32_t &int_rule_id, const uint32_t &rule_id, const int &core_id, const String &rule, const bool with_cache, const bool verbose)
 {
     // Insert in NIC
-    if (flow_rules_install(rule, 1) != FLOWRULEPARSER_SUCCESS) {
+    if (flow_rules_install(rule, 1, verbose) != FLOWRULEPARSER_SUCCESS) {
         return FLOWRULEPARSER_ERROR;
     }
 


### PR DESCRIPTION
- Fix handlers for counters in FromDPDKDevice
- Fix count handler in FlowIPManagerIMP, now it returns the total number of flows
- Add `verbose` to FlowRuleManager to allow silent operations
- Solve division by zero error in CyccleCountAccum when packet count is 0