### PR TITLE
Atomics variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ share/click/elementmap.xml
 share/click/pkg-config.mk
 stamp-egroup
 stamp-h
+cscope.*
+**/.nfs*
+compile_commands.json

--- a/Makefile.in
+++ b/Makefile.in
@@ -177,7 +177,7 @@ check-filenames:
 	@a=`find . \( -name \*.cc -or -name \*.c \) -print | sed 's/.*\/\(.*\)\.c*$$/\1.o/' | grep -v 'elements\.o' | sort | uniq -d`; \
 	if test -z $$a; then echo OK; else echo "*** warning: duplicate object file names:"; echo "$$a"; fi
 
-clean: $(CLEAN_TARGETS) clean-doc clean-local
+clean: $(CLEAN_TARGETS) clean-doc clean-local clean-cscope
 clean-doc:
 	@cd doc && $(MAKE) clean
 clean-local:
@@ -250,9 +250,16 @@ distdir: $(srcdir)/configure
 	fi
 
 
+cscope: clean-cscope
+	ack -f --cpp > cscope.files
+	cscope -b -R -q -k
+
+clean-cscope:
+	rm -rf cscope.*
+
 .PHONY: all always elemlist elemlists \
 	bsdmodule linuxmodule ns userlevel minios tools \
 	install install-doc install-lib install-man install-local install-include install-local-include $(INSTALL_TARGETS) \
-	clean clean-doc clean-local $(CLEAN_TARGETS) distclean \
+	clean clean-doc clean-local $(CLEAN_TARGETS) distclean clean-cscope \
 	uninstall uninstall-local uninstall-local-include \
-	dist distdir check
+	dist distdir check cscope

--- a/config-userlevel.h.in
+++ b/config-userlevel.h.in
@@ -229,6 +229,9 @@
 /* Define if a Click user-level driver might run multiple threads. */
 #undef HAVE_USER_MULTITHREAD
 
+/* Define if we are using builtins atomics or Click implementation. */
+#undef HAVE_ATOMIC_BUILTINS
+
 /* Define if Zero-copy is enabled. */
 #undef HAVE_ZEROCOPY
 
@@ -313,6 +316,21 @@ typedef unsigned long uintptr_t;
 #ifdef HAVE_USER_MULTITHREAD
 # define HAVE_MULTITHREAD HAVE_USER_MULTITHREAD
 #endif
+
+/* Define HAVE_ATOMIC_BUILTINS based on HAVE_ATOMIC_BUILTINS. */
+#ifdef HAVE_ATOMIC_BUILTINS
+#if __GNUC__ > 4 || \
+    (__GNUC__ == 4 && (__GNUC_MINOR__ > 7 || \
+    (__GNUC_MINOR__ == 7 && \
+     __GNUC_PATCHLEVEL__ > 0)))
+
+    # define HAVE_ATOMIC_BUILTINS 1
+#else
+    # error "Cannot enable atomic builtins! GCC must be >= 4.7.0"
+    # define HAVE_ATOMIC_BUILTINS 0
+#endif
+#endif
+
 
 /* Define HAVE_USE_CLOCK_GETTIME if the clock_gettime function is usable. */
 #ifndef HAVE_USE_CLOCK_GETTIME

--- a/configure
+++ b/configure
@@ -882,6 +882,7 @@ with_numa
 with_netmap
 with_proper
 with_expat
+enable_atomic_builtins
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1613,6 +1614,9 @@ Optional Features:
                           unportable binaries
   --enable-intel-cpu      enable Intel-specific machine instructions
   --enable-avx2           check whether AVX2 is enabled, default yes
+  --enable-atomic-builtins If specified, use the GCC builtins function to
+			  implement the atomic variables. It should be specified
+			  when not on a x86 platform. Requires GCC >= 4.7.0
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -6496,6 +6500,10 @@ fi
 
 if test "x$enable_fullpush_nonatomic" = "xyes"; then
     $as_echo "#define HAVE_FULLPUSH_NONATOMIC 1" >>confdefs.h
+
+fi
+if test "${enable_atomic_builtins+set}" = "set"; then
+    $as_echo "#define HAVE_ATOMIC_BUILTINS 1" >>confdefs.h
 
 fi
 

--- a/elements/standard/rrswitch.cc
+++ b/elements/standard/rrswitch.cc
@@ -58,7 +58,11 @@ RoundRobinSwitch::next(Packet*)
     uint32_t newval = i+1;
     if (newval >= _max)
       newval = 0;
+#if ! CLICK_ATOMIC_COMPARE_SWAP
+    _next.compare_and_swap(i, newval);
+#else
     _next.compare_swap(i, newval);
+#endif
   #endif
     return i;
 }

--- a/elements/standard/threadsafequeue.cc
+++ b/elements/standard/threadsafequeue.cc
@@ -67,7 +67,11 @@ ThreadSafeQueue::push(int, Packet *p)
     do {
 	t = tail();
 	nt = next_i(t);
+#if ! CLICK_ATOMIC_COMPARE_SWAP
+    } while (!_xtail.compare_and_swap(t, nt));
+#else
     } while (_xtail.compare_swap(t, nt) != t);
+#endif
     // Other pushers spin until _tail := nt (or _xtail := t)
 
     Storage::index_type h = head();
@@ -89,7 +93,12 @@ ThreadSafeQueue::pull(int)
     do {
 	h = head();
 	nh = next_i(h);
+#if ! CLICK_ATOMIC_COMPARE_SWAP
+    } while (!_xhead.compare_and_swap(h, nh));
+#else
     } while (_xhead.compare_swap(h, nh) != h);
+#endif
+
     // Other pullers spin until _head := nh (or _xhead := h)
 
     Storage::index_type t = tail();

--- a/elements/test/atomic.cc
+++ b/elements/test/atomic.cc
@@ -1,0 +1,124 @@
+#include <click/config.h>
+#include "atomic.hh"
+#include <click/error.hh>
+CLICK_DECLS
+
+AtomicTest::AtomicTest()
+{
+}
+
+static void test_32(ErrorHandler *errh)
+{
+    click_chatter("atomic_uint32_t is using %s implementation", atomic_uint32_t::use_builtins() ? "builtins" : "click" );
+
+    atomic_uint32_t a;
+    a = 0;
+    click_chatter("[01] a=%i -> %s", a, a==0 ? "PASS" : "FAIL");
+    a++;
+    click_chatter("[02] a=%i -> %s", a, a==1 ? "PASS" : "FAIL");
+    a+=1;
+    click_chatter("[03] a=%i -> %s", a, a==2 ? "PASS" : "FAIL");
+    a-=1;
+    click_chatter("[04] a=%i -> %s", a, a==1 ? "PASS" : "FAIL");
+    uint32_t u = a.swap(5);
+    click_chatter("[05] a=%i, u=%i -> %s", a, u,  a==5 && u==1 ? "PASS" : "FAIL");
+    u = a.fetch_and_add(10);
+    click_chatter("[06] a=%i, u=%i -> %s", a, u,  a==15 && u==5 ? "PASS" : "FAIL");
+    u = a.dec_and_test();
+    click_chatter("[07] a=%i, u=%i -> %s", a, u,  a==14 && u==0 ? "PASS" : "FAIL");
+    a=1;
+    u = a.dec_and_test();
+    click_chatter("[08] a=%i, u=%i -> %s", a, u,  a==0 && u==1 ? "PASS" : "FAIL");
+    a=2;
+    u = a.nonatomic_dec_and_test();
+    click_chatter("[09] a=%i, u=%i -> %s", a, u,  a==1 && u==0 ? "PASS" : "FAIL");
+    a=1;
+    u = a.nonatomic_dec_and_test();
+    click_chatter("[10] a=%i, u=%i -> %s", a, u,  a==0 && u==1 ? "PASS" : "FAIL");
+    u = a.compare_and_swap(0,2);
+    click_chatter("[11] a=%i, u=%i -> %s", a, u,  a==2 && u==1 ? "PASS" : "FAIL");
+    u = a.compare_and_swap(0,5);
+    click_chatter("[12] a=%i, u=%i -> %s", a, u,  a==2 && u==0 ? "PASS" : "FAIL");
+    uint32_t b =5;
+    u = atomic_uint32_t::swap(b,7);
+    click_chatter("[13] b=%i, u=%i -> %s", b, u,  b==7 && u==5 ? "PASS" : "FAIL");
+    atomic_uint32_t::inc(b);
+    click_chatter("[14] b=%i -> %s", b,  b==8 ? "PASS" : "FAIL");
+    u=atomic_uint32_t::dec_and_test(b);
+    click_chatter("[15] b=%i, u=%i -> %s", b, u,  b==7 && u==0 ? "PASS" : "FAIL");
+    b=1;
+    u=atomic_uint32_t::dec_and_test(b);
+    click_chatter("[16] b=%i, u=%i -> %s", b, u,  b==0 && u==1 ? "PASS" : "FAIL");
+    
+    b=5;
+    u = atomic_uint32_t::compare_and_swap(b,0,2);
+    click_chatter("[17] b=%i, u=%i -> %s", b, u,  b==5 && u==0 ? "PASS" : "FAIL");
+    u = atomic_uint32_t::compare_and_swap(b,5,2);
+    click_chatter("[18] b=%i, u=%i -> %s", b, u,  b==2 && u==1 ? "PASS" : "FAIL");
+
+#if CLICK_ATOMIC_BUILTINS
+    click_chatter("[--] Not testing compare_swap!");
+#else
+    a=11;
+    u = a.compare_swap(0,2);
+    click_chatter("[19] a=%i, u=%i -> %s", a, u,  a==11 && u==11 ? "PASS" : "FAIL");
+    u = a.compare_swap(11,5);
+    click_chatter("[20] a=%i, u=%i -> %s", a, u,  a==5 && u==11 ? "PASS" : "FAIL");
+    b=5; 
+    u = atomic_uint32_t::compare_swap(b,0,2);
+    click_chatter("[21] b=%i, u=%i -> %s", b, u,  b==5 && u==5 ? "PASS" : "FAIL");
+    u = atomic_uint32_t::compare_swap(b,5,2);
+    click_chatter("[22] b=%i, u=%i -> %s", b, u,  b==2 && u==5 ? "PASS" : "FAIL");
+#endif
+}
+
+
+static void test_64(ErrorHandler *errh)
+{
+    click_chatter("atomic_uint64_t is using %s implementation", atomic_uint32_t::use_builtins() ? "builtins" : "click" );
+
+    atomic_uint64_t a;
+    a = 0;
+    click_chatter("[01] a=%i -> %s", a, a==0 ? "PASS" : "FAIL");
+    a++;
+    click_chatter("[02] a=%i -> %s", a, a==1 ? "PASS" : "FAIL");
+    a+=1;
+    click_chatter("[03] a=%i -> %s", a, a==2 ? "PASS" : "FAIL");
+    a-=1;
+    click_chatter("[04] a=%i -> %s", a, a==1 ? "PASS" : "FAIL");
+    uint32_t u = a.fetch_and_add(10);
+    click_chatter("[05] a=%i, u=%i -> %s", a, u,  a==11 && u==1 ? "PASS" : "FAIL");
+   
+#if CLICK_ATOMIC_BUILTINS
+    click_chatter("[--] Not testing compare_swap!");
+#else
+    u = a.compare_swap(0,2);
+    click_chatter("[06] a=%i, u=%i -> %s", a, u,  a==11 && u==11 ? "PASS" : "FAIL");
+    u = a.compare_swap(11,5);
+    click_chatter("[07] a=%i, u=%i -> %s", a, u,  a==5 && u==11 ? "PASS" : "FAIL");
+    uint64_t b =5;
+    
+    u = atomic_uint64_t::compare_swap(b,0,2);
+    click_chatter("[08] b=%i, u=%i -> %s", b, u,  b==5 && u==5 ? "PASS" : "FAIL");
+    u = atomic_uint64_t::compare_swap(b,5,2);
+    click_chatter("[09] b=%i, u=%i -> %s", b, u,  b==2 && u==5 ? "PASS" : "FAIL");
+#endif
+}
+
+
+
+
+int
+AtomicTest::initialize(ErrorHandler *errh)
+{
+
+    test_32(errh);
+    test_64(errh);
+
+    errh->message("Test finished");
+    exit(0);
+    return 0;
+}
+
+EXPORT_ELEMENT(AtomicTest)
+CLICK_ENDDECLS

--- a/elements/test/atomic.hh
+++ b/elements/test/atomic.hh
@@ -1,0 +1,33 @@
+// -*- c-basic-offset: 4 -*-
+#ifndef CLICK_ATOMICTEST_HH
+#define CLICK_ATOMICTEST_HH
+#include <click/element.hh>
+CLICK_DECLS
+
+/*
+=c
+
+AtomicTest()
+
+=s test
+
+Test atomic variables implementation
+
+=d
+
+This element routes no packets and does all its work at initialization time.
+
+*/
+
+class AtomicTest : public Element { public:
+
+    AtomicTest() CLICK_COLD;
+
+    const char *class_name() const		{ return "AtomicTest"; }
+
+    int initialize(ErrorHandler *) CLICK_COLD;
+
+};
+
+CLICK_ENDDECLS
+#endif

--- a/include/click/atomic.hh
+++ b/include/click/atomic.hh
@@ -28,6 +28,25 @@ CLICK_CXX_UNPROTECT
 # endif
 #endif
 
+
+#if HAVE_MULTITHREAD && HAVE_ATOMIC_BUILTINS
+//    #pragma message "atomic.hh: using builtins implementation"
+    # define CLICK_ATOMIC_BUILTINS 1
+    # define CLICK_ATOMIC_MEMORDER __ATOMIC_SEQ_CST
+    //	compare_swap methods are not atomic if using builtins. Disable them
+    # define CLICK_BUILTINS_DEPRECATED = delete
+    # define CLICK_BUILTINS_NONDEPRECATED
+    # define CLICK_ATOMIC_COMPARE_SWAP 0
+#else
+    # define CLICK_ATOMIC_BUILTINS 0
+//    #pragma message "atomic.hh: Using click own implementation"
+    // compare_swap are truly atomics if correctly implemented (e.g. x86).
+    // In this case, we maintain the original Click's deprecation flags
+    # define CLICK_BUILTINS_DEPRECATED
+    # define CLICK_BUILTINS_NONDEPRECATED CLICK_DEPRECATED
+    # define CLICK_ATOMIC_COMPARE_SWAP 1
+#endif
+
 /** @file <click/atomic.hh>
  * @brief An atomic 32-bit integer.
  */
@@ -76,15 +95,16 @@ class atomic_uint32_t { public:
     inline uint32_t fetch_and_add(uint32_t delta);
     inline bool dec_and_test();
     inline bool nonatomic_dec_and_test();
-    inline uint32_t compare_swap(uint32_t expected, uint32_t desired);
-    inline bool compare_and_swap(uint32_t expected, uint32_t desired) CLICK_DEPRECATED;
+    inline uint32_t compare_swap(uint32_t expected, uint32_t desired) CLICK_BUILTINS_DEPRECATED;
+    inline bool compare_and_swap(uint32_t expected, uint32_t desired) CLICK_BUILTINS_NONDEPRECATED;
 
     inline static uint32_t swap(volatile uint32_t &x, uint32_t desired);
     inline static void inc(volatile uint32_t &x);
     inline static bool dec_and_test(volatile uint32_t &x);
-    inline static uint32_t compare_swap(volatile uint32_t &x, uint32_t expected, uint32_t desired);
-    inline static bool compare_and_swap(volatile uint32_t &x, uint32_t expected, uint32_t desired) CLICK_DEPRECATED;
+    inline static uint32_t compare_swap(volatile uint32_t &x, uint32_t expected, uint32_t desired) CLICK_BUILTINS_DEPRECATED;
+    inline static bool compare_and_swap(volatile uint32_t &x, uint32_t expected, uint32_t desired) CLICK_BUILTINS_NONDEPRECATED;
 
+    inline static bool use_builtins(){return CLICK_ATOMIC_BUILTINS;}
   private:
 
 #if CLICK_LINUXMODULE
@@ -135,11 +155,13 @@ class atomic_uint64_t { public:
     inline void operator--();
     inline void operator--(int);
 
-    inline uint64_t compare_swap(uint64_t expected, uint64_t desired);
+    inline uint64_t compare_swap(uint64_t expected, uint64_t desired) CLICK_BUILTINS_DEPRECATED;
     inline uint64_t fetch_and_add(uint64_t delta);
 
     inline static void add(volatile uint64_t &x, uint64_t delta);
-    inline static uint64_t compare_swap(volatile uint64_t &x, uint64_t expected, uint64_t desired);
+    inline static uint64_t compare_swap(volatile uint64_t &x, uint64_t expected, uint64_t desired) CLICK_BUILTINS_DEPRECATED;
+    
+    inline static bool use_builtins(){return CLICK_ATOMIC_BUILTINS;}
   private:
 
 #if CLICK_LINUXMODULE
@@ -195,6 +217,8 @@ atomic_uint32_t::operator+=(int32_t delta)
 {
 #if CLICK_LINUXMODULE
     atomic_add(delta, &_val);
+#elif CLICK_ATOMIC_BUILTINS
+    __atomic_add_fetch(&CLICK_ATOMIC_VAL, delta, CLICK_ATOMIC_MEMORDER);
 #elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "addl %1,%0"
 		  : "=m" (CLICK_ATOMIC_VAL)
@@ -212,6 +236,8 @@ atomic_uint32_t::operator-=(int32_t delta)
 {
 #if CLICK_LINUXMODULE
     atomic_sub(delta, &_val);
+#elif CLICK_ATOMIC_BUILTINS
+    __atomic_sub_fetch(&CLICK_ATOMIC_VAL, delta, CLICK_ATOMIC_MEMORDER);
 #elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "subl %1,%0"
 		  : "=m" (CLICK_ATOMIC_VAL)
@@ -229,6 +255,8 @@ atomic_uint32_t::operator|=(uint32_t mask)
 {
 #if CLICK_LINUXMODULE && HAVE_LINUX_ATOMIC_SET_MASK
     atomic_set_mask(mask, &_val);
+#elif CLICK_ATOMIC_BUILTINS
+    __atomic_or_fetch(&CLICK_ATOMIC_VAL, mask, CLICK_ATOMIC_MEMORDER);
 #elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "orl %1,%0"
 		  : "=m" (CLICK_ATOMIC_VAL)
@@ -252,6 +280,8 @@ atomic_uint32_t::operator&=(uint32_t mask)
 {
 #if CLICK_LINUXMODULE && HAVE_LINUX_ATOMIC_SET_MASK
     atomic_clear_mask(~mask, &_val);
+#elif CLICK_ATOMIC_BUILTINS
+    __atomic_and_fetch(&CLICK_ATOMIC_VAL, mask, CLICK_ATOMIC_MEMORDER);
 #elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "andl %1,%0"
 		  : "=m" (CLICK_ATOMIC_VAL)
@@ -276,6 +306,8 @@ atomic_uint32_t::inc(volatile uint32_t &x)
 #if CLICK_LINUXMODULE
     static_assert(sizeof(atomic_t) == sizeof(x), "atomic_t expected to take 32 bits.");
     atomic_inc((atomic_t *) &x);
+#elif CLICK_ATOMIC_BUILTINS
+    __atomic_add_fetch(&x, 1, CLICK_ATOMIC_MEMORDER);
 #elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "incl %0"
 		  : "=m" (x)
@@ -299,6 +331,8 @@ atomic_uint32_t::operator++()
 {
 #if CLICK_LINUXMODULE
     atomic_inc(&_val);
+#elif CLICK_ATOMIC_BUILTINS
+    __atomic_add_fetch(&_val, 1, CLICK_ATOMIC_MEMORDER);
 #elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "incl %0"
 		  : "=m" (CLICK_ATOMIC_VAL)
@@ -315,6 +349,8 @@ atomic_uint32_t::operator++(int)
 {
 #if CLICK_LINUXMODULE
     atomic_inc(&_val);
+#elif CLICK_ATOMIC_BUILTINS
+    __atomic_add_fetch(&CLICK_ATOMIC_VAL, 1, CLICK_ATOMIC_MEMORDER);
 #elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "incl %0"
 		  : "=m" (CLICK_ATOMIC_VAL)
@@ -331,6 +367,8 @@ atomic_uint32_t::operator--()
 {
 #if CLICK_LINUXMODULE
     atomic_dec(&_val);
+#elif CLICK_ATOMIC_BUILTINS
+    __atomic_sub_fetch(&CLICK_ATOMIC_VAL, 1, CLICK_ATOMIC_MEMORDER);
 #elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "decl %0"
 		  : "=m" (CLICK_ATOMIC_VAL)
@@ -354,6 +392,8 @@ atomic_uint32_t::operator--(int)
 {
 #if CLICK_LINUXMODULE
     atomic_dec(&_val);
+#elif CLICK_ATOMIC_BUILTINS
+    __atomic_sub_fetch(&CLICK_ATOMIC_VAL, 1, CLICK_ATOMIC_MEMORDER);
 #elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "decl %0"
 		  : "=m" (CLICK_ATOMIC_VAL)
@@ -377,7 +417,12 @@ atomic_uint32_t::operator--(int)
 inline uint32_t
 atomic_uint32_t::swap(volatile uint32_t &x, uint32_t desired)
 {
-#if CLICK_ATOMIC_X86
+#if CLICK_ATOMIC_BUILTINS
+    uint32_t actual = x;
+    __atomic_exchange(&x, &desired, &actual, CLICK_ATOMIC_MEMORDER);
+    return actual;
+
+#elif CLICK_ATOMIC_X86
     asm volatile ("xchgl %0,%1"
 		  : "=r" (desired), "=m" (x)
 		  : "0" (desired), "m" (x)
@@ -427,7 +472,9 @@ atomic_uint32_t::swap(uint32_t desired)
 inline uint32_t
 atomic_uint32_t::fetch_and_add(uint32_t delta)
 {
-#if CLICK_ATOMIC_X86
+#if CLICK_ATOMIC_BUILTINS
+    return __atomic_fetch_add(&_val, delta, CLICK_ATOMIC_MEMORDER);
+#elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "xaddl %0,%1"
 		  : "=r" (delta), "=m" (CLICK_ATOMIC_VAL)
 		  : "0" (delta), "m" (CLICK_ATOMIC_VAL)
@@ -464,6 +511,8 @@ atomic_uint32_t::dec_and_test(volatile uint32_t &x)
 #if CLICK_LINUXMODULE
     static_assert(sizeof(atomic_t) == sizeof(x), "atomic_t expected to take 32 bits.");
     return atomic_dec_and_test((atomic_t *) &x);
+#elif CLICK_ATOMIC_BUILTINS
+    return __atomic_sub_fetch(&x,1 , CLICK_ATOMIC_MEMORDER) == 0;
 #elif CLICK_ATOMIC_X86
     uint8_t result;
     asm volatile (CLICK_ATOMIC_LOCK "decl %0 ; sete %1"
@@ -492,10 +541,15 @@ atomic_uint32_t::dec_and_test(volatile uint32_t &x)
  * @endcode
  *
  * Also acts as a memory barrier. */
+#if CLICK_ATOMIC_COMPARE_SWAP
 inline uint32_t
 atomic_uint32_t::compare_swap(volatile uint32_t &x, uint32_t expected, uint32_t desired)
 {
-#if CLICK_ATOMIC_X86
+#if CLICK_ATOMIC_BUILTINS
+# warning "compare_swap is not truly atomic with system builtins"
+    return __atomic_compare_exchange(&x,&expected,&desired,0,CLICK_ATOMIC_MEMORDER, CLICK_ATOMIC_MEMORDER)
+	? expected : x;
+#elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "cmpxchgl %2,%1"
 		  : "=a" (expected), "=m" (x)
 		  : "r" (desired), "0" (expected), "m" (x)
@@ -519,7 +573,7 @@ atomic_uint32_t::compare_swap(volatile uint32_t &x, uint32_t expected, uint32_t 
     return actual;
 #endif
 }
-
+#endif
 
 /** @brief  Perform a compare-and-swap operation.
  *  @param  x         value
@@ -541,7 +595,10 @@ atomic_uint32_t::compare_swap(volatile uint32_t &x, uint32_t expected, uint32_t 
 inline bool
 atomic_uint32_t::compare_and_swap(volatile uint32_t &x, uint32_t expected, uint32_t desired)
 {
-#if CLICK_ATOMIC_X86
+#if CLICK_ATOMIC_BUILTINS
+    return __atomic_compare_exchange(&x,&expected,&desired,0,CLICK_ATOMIC_MEMORDER, CLICK_ATOMIC_MEMORDER);
+
+#elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "cmpxchgl %2,%0 ; sete %%al"
 		  : "=m" (x), "=a" (expected)
 		  : "r" (desired), "m" (x), "a" (expected)
@@ -579,6 +636,8 @@ atomic_uint32_t::dec_and_test()
 {
 #if CLICK_LINUXMODULE
     return atomic_dec_and_test(&_val);
+#elif CLICK_ATOMIC_BUILTINS
+    return __atomic_sub_fetch(&_val, 1, CLICK_ATOMIC_MEMORDER) == 0;
 #elif CLICK_ATOMIC_X86
     uint8_t result;
     asm volatile (CLICK_ATOMIC_LOCK "decl %0 ; sete %1"
@@ -621,10 +680,15 @@ atomic_uint32_t::nonatomic_dec_and_test()
  * @endcode
  *
  * Also acts as a memory barrier. */
+#if CLICK_ATOMIC_COMPARE_SWAP
 inline uint32_t
 atomic_uint32_t::compare_swap(uint32_t expected, uint32_t desired)
 {
-#if CLICK_ATOMIC_X86
+#if CLICK_ATOMIC_BUILTINS
+# warning "compare_swap is not truly atomic with system builtins"
+    return __atomic_compare_exchange(&_val, &expected, &desired, 0, CLICK_ATOMIC_MEMORDER, CLICK_ATOMIC_MEMORDER) 
+	? expected: _val;
+#elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "cmpxchgl %2,%1"
 		  : "=a" (expected), "=m" (CLICK_ATOMIC_VAL)
 		  : "r" (desired), "0" (expected), "m" (CLICK_ATOMIC_VAL)
@@ -648,6 +712,7 @@ atomic_uint32_t::compare_swap(uint32_t expected, uint32_t desired)
     return actual;
 #endif
 }
+#endif
 
 /** @brief  Perform a compare-and-swap operation.
  *  @param  expected  test value
@@ -668,7 +733,9 @@ atomic_uint32_t::compare_swap(uint32_t expected, uint32_t desired)
 inline bool
 atomic_uint32_t::compare_and_swap(uint32_t expected, uint32_t desired)
 {
-#if CLICK_ATOMIC_X86
+#if CLICK_ATOMIC_BUILTINS
+    return __atomic_compare_exchange(&_val, &expected, &desired, 0, CLICK_ATOMIC_MEMORDER, CLICK_ATOMIC_MEMORDER);
+#elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "cmpxchgl %2,%0 ; sete %%al"
 		  : "=m" (CLICK_ATOMIC_VAL), "=a" (expected)
 		  : "r" (desired), "m" (CLICK_ATOMIC_VAL), "a" (expected)
@@ -788,6 +855,8 @@ atomic_uint64_t::operator+=(int64_t delta)
 {
 #if CLICK_LINUXMODULE
     atomic64_add(delta, &_val);
+#elif CLICK_ATOMIC_BUILTINS
+    __atomic_add_fetch(&_val, delta, CLICK_ATOMIC_MEMORDER);
 #elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "addq %1,%0"
           : "=m" (CLICK_ATOMIC_VAL)
@@ -805,6 +874,8 @@ atomic_uint64_t::add(volatile uint64_t &x, uint64_t delta)
 {
 #if CLICK_LINUXMODULE
     atomic64_add(delta, (atomic64_t*)&x);
+#elif CLICK_ATOMIC_BUILTINS
+    __atomic_add_fetch(&x, delta, CLICK_ATOMIC_MEMORDER);
 #elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "addq %1,%0"
           : "=m" (x)
@@ -821,6 +892,8 @@ atomic_uint64_t::operator-=(int64_t delta)
 {
 #if CLICK_LINUXMODULE
     atomic64_sub(delta, &_val);
+#elif CLICK_ATOMIC_BUILTINS
+    __atomic_sub_fetch(&CLICK_ATOMIC_VAL, delta, CLICK_ATOMIC_MEMORDER);
 #elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "subq %1,%0"
           : "=m" (CLICK_ATOMIC_VAL)
@@ -862,6 +935,8 @@ atomic_uint64_t::operator++(int)
 {
 #if CLICK_LINUXMODULE
     atomic64_inc(&_val);
+#elif CLICK_ATOMIC_BUILTINS
+    __atomic_add_fetch(&CLICK_ATOMIC_VAL, 1, CLICK_ATOMIC_MEMORDER);
 #elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "incq %0"
           : "=m" (CLICK_ATOMIC_VAL)
@@ -878,6 +953,8 @@ atomic_uint64_t::operator--()
 {
 #if CLICK_LINUXMODULE
     atomic64_dec(&_val);
+#elif CLICK_ATOMIC_BUILTINS
+    __atomic_sub_fetch(&CLICK_ATOMIC_VAL, 1, CLICK_ATOMIC_MEMORDER);
 #elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "decq %0"
           : "=m" (CLICK_ATOMIC_VAL)
@@ -901,6 +978,8 @@ atomic_uint64_t::operator--(int)
 {
 #if CLICK_LINUXMODULE
     atomic64_dec(&_val);
+#elif CLICK_ATOMIC_BUILTINS
+    __atomic_sub_fetch(&CLICK_ATOMIC_VAL, 1, CLICK_ATOMIC_MEMORDER);
 #elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "decq %0"
           : "=m" (CLICK_ATOMIC_VAL)
@@ -927,10 +1006,15 @@ atomic_uint64_t::operator--(int)
  * @endcode
  *
  * Also acts as a memory barrier. */
+#if CLICK_ATOMIC_COMPARE_SWAP
 inline uint64_t
 atomic_uint64_t::compare_swap(volatile uint64_t &x, uint64_t expected, uint64_t desired)
 {
-#if CLICK_ATOMIC_X86
+#if CLICK_ATOMIC_BUILTINS
+# warning "compare_swap is not truly atomic with system builtins"
+    return __atomic_compare_exchange(&x,&expected,&desired,0,CLICK_ATOMIC_MEMORDER, CLICK_ATOMIC_MEMORDER)
+	? expected : x;
+#elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "cmpxchgq %2,%1"
 		  : "=a" (expected), "=m" (x)
 		  : "r" (desired), "0" (expected), "m" (x)
@@ -963,6 +1047,7 @@ atomic_uint64_t::compare_swap(uint64_t expected, uint64_t desired) {
     return atomic_uint64_t::compare_swap(*(volatile uint64_t*)&CLICK_ATOMIC_VAL, expected, desired);
 #endif
 }
+#endif
 
 /** @brief  Atomically add @a delta to the value, returning the old value.
  *
@@ -975,7 +1060,9 @@ atomic_uint64_t::compare_swap(uint64_t expected, uint64_t desired) {
 inline uint64_t
 atomic_uint64_t::fetch_and_add(uint64_t delta)
 {
-#if CLICK_ATOMIC_X86
+#if CLICK_ATOMIC_BUILTINS
+    return __atomic_fetch_add(&_val, delta, CLICK_ATOMIC_MEMORDER);
+#elif CLICK_ATOMIC_X86
     asm volatile (CLICK_ATOMIC_LOCK "xaddq %0,%1"
           : "=r" (delta), "=m" (CLICK_ATOMIC_VAL)
           : "0" (delta), "m" (CLICK_ATOMIC_VAL)

--- a/include/click/glue.hh
+++ b/include/click/glue.hh
@@ -715,6 +715,7 @@ typedef uint32_t click_cycles_t;
 inline click_cycles_t
 click_get_cycles()
 {
+
 #if CLICK_LINUXMODULE && HAVE_INT64_TYPES && __i386__
     uint64_t x;
     __asm__ __volatile__ ("rdtsc" : "=A" (x));
@@ -741,14 +742,13 @@ click_get_cycles()
     uint32_t xlo, xhi;
     __asm__ __volatile__ ("rdtsc" : "=a" (xlo), "=d" (xhi));
     return xlo;
-#elif CLICK_MINIOS
-    /* FIXME: Implement click_get_cycles for MiniOS */
-    return 0;
-#elif HAVE_DPDK
+#elif CLICK_USERLEVEL && HAVE_DPDK && _RTE_CYCLES_H_
     // On other architectures we use DPDK implementation, if available
     return rte_get_tsc_cycles();
+#elif CLICK_USERLEVEL
+    #error "click_get_cycles is not implemented for your architecture!"
+    return 0;
 #else
-#error "click_get_cycles is not implemented for your architecture!"
     // add other architectures here
     return 0;
 #endif

--- a/include/click/glue.hh
+++ b/include/click/glue.hh
@@ -744,7 +744,11 @@ click_get_cycles()
 #elif CLICK_MINIOS
     /* FIXME: Implement click_get_cycles for MiniOS */
     return 0;
+#elif HAVE_DPDK
+    // On other architectures we use DPDK implementation, if available
+    return rte_get_tsc_cycles();
 #else
+#error "click_get_cycles is not implemented for your architecture!"
     // add other architectures here
     return 0;
 #endif

--- a/include/click/routerthread.hh
+++ b/include/click/routerthread.hh
@@ -245,9 +245,13 @@ class RouterThread { public:
     // task running functions
     void driver_lock_tasks();
     inline void driver_unlock_tasks() {
+#if ! CLICK_ATOMIC_COMPARE_SWAP
+        assert(_task_blocker.compare_and_swap((uint32_t) -1, 0));
+#else
         uint32_t val = _task_blocker.compare_swap((uint32_t) -1, 0);
         (void) val;
         assert(val == (uint32_t) -1);
+#endif
     }
 
     inline void run_tasks(int ntasks);
@@ -432,7 +436,11 @@ RouterThread::block_tasks(bool scheduled)
     while (1) {
         uint32_t blocker = _task_blocker.value();
         if ((int32_t) blocker >= 0
+#if ! CLICK_ATOMIC_COMPARE_SWAP
+            && _task_blocker.compare_and_swap(blocker, blocker + 1))
+#else
             && _task_blocker.compare_swap(blocker, blocker + 1) == blocker)
+#endif
             break;
 #if CLICK_LINUXMODULE
         // 3.Nov.2008: Must allow other threads a chance to run.  Otherwise,

--- a/include/click/standard/storage.hh
+++ b/include/click/standard/storage.hh
@@ -103,7 +103,11 @@ Storage::reserve_tail_atomic()
         nt = next_i(t);
         if (nt == _head)
             return invalid_index;
+#if ! CLICK_ATOMIC_COMPARE_SWAP
+    } while (!atomic_uint32_t::compare_and_swap(_tail, t, nt));
+#else
     } while (atomic_uint32_t::compare_swap(_tail, t, nt) != t);
+#endif
     return t;
 }
 

--- a/lib/router.cc
+++ b/lib/router.cc
@@ -848,7 +848,12 @@ Router::adjust_runcount(int32_t delta)
             new_value = STOP_RUNCOUNT;
         else
             new_value = old_value + delta;
+#if ! CLICK_ATOMIC_COMPARE_SWAP
+    } while (! _runcount.compare_and_swap(old_value, new_value));
+#else
     } while (_runcount.compare_swap(old_value, new_value) != old_value);
+#endif
+
     if ((int32_t) new_value <= 0)
         _master->request_stop();
 }

--- a/lib/routerthread.cc
+++ b/lib/routerthread.cc
@@ -158,8 +158,11 @@ RouterThread::driver_lock_tasks()
         select(0, 0, 0, 0, &waiter);
     }
 #endif
-
+#if ! CLICK_ATOMIC_COMPARE_SWAP
+    while (!_task_blocker.compare_and_swap(0, (uint32_t) -1)) {
+#else
     while (_task_blocker.compare_swap(0, (uint32_t) -1) != 0) {
+#endif
 #if CLICK_LINUXMODULE
         schedule();
 #endif

--- a/lib/string.cc
+++ b/lib/string.cc
@@ -417,7 +417,11 @@ String::append_uninitialized(int len)
         && ((dirty = _r.memo->dirty), _r.memo->capacity > dirty + len)) {
         char *real_dirty = _r.memo->real_data + dirty;
         if (real_dirty == _r.data + _r.length
-            && atomic_uint32_t::compare_swap(_r.memo->dirty, dirty, dirty + len) == dirty) {
+#if ! CLICK_ATOMIC_COMPARE_SWAP
+	&& atomic_uint32_t::compare_and_swap(_r.memo->dirty, dirty, dirty + len)) {
+#else
+	&& atomic_uint32_t::compare_swap(_r.memo->dirty, dirty, dirty + len) == dirty) {
+#endif
             _r.length += len;
             assert(_r.memo->dirty < _r.memo->capacity);
 #if HAVE_STRING_PROFILING


### PR DESCRIPTION
- Add support for C++11 atomic types, which could be enabled with `--enable-atomic-builtins`.
- TSC counter for all DPDK supported platforms
- Minor additions to `.gitignore`