### PR TITLE
Support for DPDK v20.11

### DIFF
--- a/elements/userlevel/fromdpdkdevice.cc
+++ b/elements/userlevel/fromdpdkdevice.cc
@@ -335,7 +335,7 @@ bool FromDPDKDevice::run_task(Task *t)
                 SET_PAINT_ANNO(p, iqueue);
             }
 
-#if RTE_VERSION >= RTE_VERSION_NUM(18,02,0,0)
+#if RTE_VERSION >= RTE_VERSION_NUM(18,02,0,0) && RTE_VERSION < RTE_VERSION_NUM(20,11,0,0)
             if (_set_timestamp && (pkts[i]->ol_flags & PKT_RX_TIMESTAMP)) {
                 p->timestamp_anno().assignlong(pkts[i]->timestamp);
             }


### PR DESCRIPTION
Covers:
 * DPDK v20.11-rc0
 * DPDK v20.11-rc1
 * DPDK v20.11-rc2
 * DPDK v20.11-rc3
 * DPDK v20.11-rc4

It looks like that the PKT_RX_TIMESTAMP is deprecated.

Signed-off-by: Georgios Katsikas <katsikas.gp@gmail.com>