### PR TITLE
builtin atomics: fix missing configure.in file

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1,6 +1,6 @@
-# generated automatically by aclocal 1.15.1 -*- Autoconf -*-
+# generated automatically by aclocal 1.16.1 -*- Autoconf -*-
 
-# Copyright (C) 1996-2017 Free Software Foundation, Inc.
+# Copyright (C) 1996-2018 Free Software Foundation, Inc.
 
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1,6 +1,6 @@
-# generated automatically by aclocal 1.16.1 -*- Autoconf -*-
+# generated automatically by aclocal 1.15.1 -*- Autoconf -*-
 
-# Copyright (C) 1996-2018 Free Software Foundation, Inc.
+# Copyright (C) 1996-2017 Free Software Foundation, Inc.
 
 # This file is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,

--- a/configure
+++ b/configure
@@ -880,11 +880,11 @@ enable_schedule_debugging
 enable_portable_binary
 enable_intel_cpu
 enable_avx2
+enable_atomic_builtins
 with_numa
 with_netmap
 with_proper
 with_expat
-enable_atomic_builtins
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1616,9 +1616,10 @@ Optional Features:
                           unportable binaries
   --enable-intel-cpu      enable Intel-specific machine instructions
   --enable-avx2           check whether AVX2 is enabled, default yes
-  --enable-atomic-builtins If specified, use the GCC builtins function to
-			  implement the atomic variables. It should be specified
-			  when not on a x86 platform. Requires GCC >= 4.7.0
+  --enable-atomic-builtins
+                          Use GCC builtins atomic functions instead of Click
+                          own implementation. It should be always used in
+                          non-x86 systems. It requires GCC >= 4.7.0
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -6504,10 +6505,8 @@ if test "x$enable_fullpush_nonatomic" = "xyes"; then
     $as_echo "#define HAVE_FULLPUSH_NONATOMIC 1" >>confdefs.h
 
 fi
-if test "${enable_atomic_builtins+set}" = "set"; then
-    $as_echo "#define HAVE_ATOMIC_BUILTINS 1" >>confdefs.h
 
-fi
+
 
 
 # Check whether --enable-batch was given.
@@ -11481,6 +11480,18 @@ $as_echo "${HAVE_AVX2}" >&6; }
 fi
 if test "${HAVE_AVX2}" = "yes"; then
   $as_echo "#define HAVE_AVX2 1" >>confdefs.h
+
+fi
+
+# Check whether --enable-atomic-builtins was given.
+if test "${enable_atomic_builtins+set}" = set; then :
+  enableval=$enable_atomic_builtins; :
+else
+  enable_atomic_builtins=no
+fi
+
+if test "x${enable_atomic_builtins}" = "xyes"; then
+        $as_echo "#define HAVE_ATOMIC_BUILTINS 1" >>confdefs.h
 
 fi
 

--- a/configure
+++ b/configure
@@ -6507,8 +6507,6 @@ if test "x$enable_fullpush_nonatomic" = "xyes"; then
 fi
 
 
-
-
 # Check whether --enable-batch was given.
 if test "${enable_batch+set}" = set; then :
   enableval=$enable_batch; :

--- a/configure.in
+++ b/configure.in
@@ -102,8 +102,6 @@ if test "x$enable_fullpush_nonatomic" = "xyes"; then
 fi
 
 
-
-
 AC_ARG_ENABLE([batch],
     [AS_HELP_STRING([  --disable-batch], [disable batching support])],
     [:], [enable_batch=$enable_userlevel])

--- a/configure.in
+++ b/configure.in
@@ -102,6 +102,8 @@ if test "x$enable_fullpush_nonatomic" = "xyes"; then
 fi
 
 
+
+
 AC_ARG_ENABLE([batch],
     [AS_HELP_STRING([  --disable-batch], [disable batching support])],
     [:], [enable_batch=$enable_userlevel])
@@ -1472,6 +1474,13 @@ if test "${check_avx2}" = "yes"; then
 fi
 if test "${HAVE_AVX2}" = "yes"; then
   AC_DEFINE(HAVE_AVX2)
+fi
+
+AC_ARG_ENABLE([atomic-builtins],
+    [AS_HELP_STRING([--enable-atomic-builtins], [Use GCC builtins atomic functions instead of Click own implementation. It should be always used in non-x86 systems. It requires GCC >= 4.7.0])],
+    [:], [enable_atomic_builtins=no])
+if test "x${enable_atomic_builtins}" = "xyes"; then
+        AC_DEFINE([HAVE_ATOMIC_BUILTINS])
 fi
 
 dnl


### PR DESCRIPTION
Fix missing `configure.in` file. The handling of the flag has been fixed too.

This is a fix for https://github.com/tbarbette/fastclick/pull/276#issuecomment-735239966