### PR TITLE
Packet annotation: allow not to clear them

### DIFF
--- a/elements/userlevel/fromdpdkdevice.hh
+++ b/elements/userlevel/fromdpdkdevice.hh
@@ -462,6 +462,7 @@ private:
     bool _tco;
     bool _uco;
     bool _ipco;
+    bool _clear;
 };
 
 CLICK_ENDDECLS

--- a/elements/userlevel/todpdkdevice.cc
+++ b/elements/userlevel/todpdkdevice.cc
@@ -76,7 +76,7 @@ int ToDPDKDevice::configure(Vector<String> &conf, ErrorHandler *errh)
     if (firstqueue == -1)
        firstqueue = 0;
     if (n_queues == -1) {
-	configure_tx(1,maxqueues,errh);
+        configure_tx(1,maxqueues,errh);
     } else {
         configure_tx(n_queues,n_queues,errh);
     }

--- a/include/click/packetbatch.hh
+++ b/include/click/packetbatch.hh
@@ -611,7 +611,7 @@ public :
 #if !CLICK_LINUXMODULE
     static PacketBatch *make_batch(unsigned char *data, uint16_t count, uint16_t *length,
                     buffer_destructor_type destructor,
-                                    void* argument = (void*) 0) CLICK_WARN_UNUSED_RESULT;
+                                    void* argument = (void*) 0, const bool clear=true) CLICK_WARN_UNUSED_RESULT;
 #endif
 
     /**

--- a/lib/packetbatch.cc
+++ b/lib/packetbatch.cc
@@ -82,7 +82,7 @@ void PacketBatch::fast_kill_nonatomic() {
  **/
 PacketBatch *
 PacketBatch::make_batch(unsigned char *data, uint16_t count, uint16_t *length,
-        buffer_destructor_type destructor, void* argument )
+        buffer_destructor_type destructor, void* argument, bool clean )
 {
 #if CLICK_PACKET_USE_DPDK
     click_chatter("UNIMPLEMENTED");
@@ -98,7 +98,7 @@ PacketBatch::make_batch(unsigned char *data, uint16_t count, uint16_t *length,
     WritablePacket *last = p;
     uint16_t i = 0;
     while(p) {
-        p->initialize();
+        p->initialize(clean);
         p->_head = p->_data = data;
         p->_tail = p->_end = data + length[i];
         data += length[i] & 63 ? (length[i] & ~63) + 64 : length[i];


### PR DESCRIPTION
The user may do the liveness analysis on its own, in anycase things like
aggregate, paint etc should be set before being read

This change was made as part of PacketMill