### PR TITLE
New options to disable features

### DIFF
--- a/config-userlevel.h.in
+++ b/config-userlevel.h.in
@@ -250,6 +250,9 @@
 /* Define if you use only DPDK buffer as data buffer. */
 #undef HAVE_DPDK_PACKET_POOL
 
+/* Define if DPDK software queue for TX is enabled. */
+#undef HAVE_IQUEUE
+
 /* Define if a Click user-level driver manages Intel DPDK packet pools. */
 #undef CLICK_PACKET_USE_DPDK
 

--- a/config.h.in
+++ b/config.h.in
@@ -26,6 +26,9 @@
 /* Define for forcing expensive packet operations. */
 #undef CLICK_FORCE_EXPENSIVE
 
+/* Define if indirect packets are not allowed. */
+#undef CLICK_NOINDIRECT
+
 /* Define to generate smaller object files. */
 #undef CLICK_OPTIMIZE_SIZE
 

--- a/configure
+++ b/configure
@@ -817,6 +817,7 @@ enable_kqueue
 enable_dpdk
 enable_dpdk_pool
 enable_dpdk_packet
+enable_dpdk_softqueue
 enable_zerocopy
 enable_clone
 enable_linuxmodule
@@ -1548,6 +1549,9 @@ Optional Features:
     --enable-dpdk         use DPDK
     --enable-dpdk-pool    use DPDK buffer instead of standard Click buffer
     --enable-dpdk-packet  Click packets are DPDK packet
+    --disable-dpdk-softqueue
+                          Do not use internal software queue in TX to buffer
+                          packets before flushing.
     --disable-zerocopy    disable Zero Copy
     --disable-clone       disable packet cloning
   --enable-linuxmodule    disable Linux kernel driver
@@ -7126,6 +7130,15 @@ if test "${enable_dpdk_packet+set}" = set; then :
   enableval=$enable_dpdk_packet; :
 else
   enable_dpdk_packet=no
+fi
+
+
+# Check whether --enable-dpdk-softqueue was given.
+if test "${enable_dpdk_softqueue+set}" = set; then :
+  enableval=$enable_dpdk_softqueue; :
+else
+  $as_echo "#define HAVE_IQUEUE 1" >>confdefs.h
+
 fi
 
 

--- a/configure
+++ b/configure
@@ -818,6 +818,7 @@ enable_dpdk
 enable_dpdk_pool
 enable_dpdk_packet
 enable_zerocopy
+enable_clone
 enable_linuxmodule
 enable_fixincludes
 enable_multithread
@@ -1548,6 +1549,7 @@ Optional Features:
     --enable-dpdk-pool    use DPDK buffer instead of standard Click buffer
     --enable-dpdk-packet  Click packets are DPDK packet
     --disable-zerocopy    disable Zero Copy
+    --disable-clone       disable packet cloning
   --enable-linuxmodule    disable Linux kernel driver
     --disable-fixincludes do not patch Linux kernel headers for C++
     --enable-multithread  support kernel multithreading
@@ -7281,6 +7283,17 @@ if test "x$enable_zerocopy" = xyes; then
     $as_echo "#define HAVE_ZEROCOPY 1" >>confdefs.h
 
 fi
+
+# Check whether --enable-clone was given.
+if test "${enable_clone+set}" = set; then :
+  enableval=$enable_clone; $as_echo "#define CLICK_NOINDIRECT 1" >>confdefs.h
+
+else
+  :
+fi
+
+
+
 
 
 # Check whether --enable-linuxmodule was given.

--- a/configure.in
+++ b/configure.in
@@ -415,6 +415,12 @@ if test "x$enable_zerocopy" = xyes; then
     AC_DEFINE(HAVE_ZEROCOPY)
 fi
 
+AC_ARG_ENABLE([clone],
+    [AS_HELP_STRING([  --disable-clone], [disable packet cloning])],
+    [AC_DEFINE(CLICK_NOINDIRECT)],[:])
+
+
+
 dnl linuxmodule driver and features
 
 AC_ARG_ENABLE([linuxmodule],

--- a/configure.in
+++ b/configure.in
@@ -283,6 +283,11 @@ AC_ARG_ENABLE([dpdk-packet],
                     [Click packets are DPDK packet])],
     [:], [enable_dpdk_packet=no])
 
+AC_ARG_ENABLE([dpdk-softqueue],
+    [AS_HELP_STRING([  --disable-dpdk-softqueue],
+                    [Do not use internal software queue in TX to buffer packets before flushing.])],
+    [:], [AC_DEFINE(HAVE_IQUEUE)])
+
 if test "x$enable_dpdk" != "xno"; then
 
     AC_MSG_CHECKING([for DPDK library])

--- a/elements/ethernet/ethermirror.cc
+++ b/elements/ethernet/ethermirror.cc
@@ -52,7 +52,13 @@ EtherMirror::simple_action(Packet *p)
 PacketBatch *
 EtherMirror::simple_action_batch(PacketBatch *batch)
 {
+#ifdef CLICK_NOINDIRECT
+    FOR_EACH_PACKET(batch, p)   {
+        EtherMirror::simple_action(p);
+    }
+#else
     EXECUTE_FOR_EACH_PACKET_DROPPABLE(EtherMirror::simple_action, batch, [](Packet*){});
+#endif
     return batch;
 }
 #endif

--- a/elements/userlevel/todpdkdevice.cc
+++ b/elements/userlevel/todpdkdevice.cc
@@ -25,7 +25,11 @@
 CLICK_DECLS
 
 ToDPDKDevice::ToDPDKDevice() :
-    _iqueues(), _dev(0),
+
+#if HAVE_IQUEUE
+    _iqueues(),
+#endif
+    _dev(0),
     _timeout(0), _congestion_warning_printed(false), _create(true),
     _tso(0), _tco(false), _uco(false), _ipco(false)
 {
@@ -47,7 +51,6 @@ int ToDPDKDevice::configure(Vector<String> &conf, ErrorHandler *errh)
             .read_mp("PORT", dev)
             .consume() < 0)
         return -1;
-
 
     if (parse(conf, errh) != 0)
         return -1;
@@ -72,6 +75,12 @@ int ToDPDKDevice::configure(Vector<String> &conf, ErrorHandler *errh)
             return errh->error("%s : Unknown or invalid PORT", dev.c_str());
     }
 
+
+#if HAVE_IQUEUE
+    if (_timeout > 0) {
+        return errh->error("Timeout parameter does not make sense without the IQUEUE feature.");
+    }
+#endif
     //TODO : If user put multiple ToDPDKDevice with the same port and without the QUEUE parameter, try to share the available queues among them
     if (firstqueue == -1)
        firstqueue = 0;
@@ -126,14 +135,14 @@ int ToDPDKDevice::initialize(ErrorHandler *errh)
     ret = initialize_tasks(false,errh);
     if (ret != 0)
         return ret;
-
+#if HAVE_IQUEUE
     for (unsigned i = 0; i < _iqueues.weight(); i++) {
         _iqueues.get_value(i).pkts = new struct rte_mbuf *[_internal_tx_queue_size];
         _iqueues.get_value(i).timeout.assign(this);
         _iqueues.get_value(i).timeout.initialize(this);
         _iqueues.get_value(i).timeout.move_thread(i);
     }
-
+#endif
     _this_node = DPDKDevice::get_port_numa_node(_dev->port_id);
 
     //To set is_fullpush, we need to compute passing threads
@@ -149,9 +158,11 @@ int ToDPDKDevice::initialize(ErrorHandler *errh)
 void ToDPDKDevice::cleanup(CleanupStage)
 {
     cleanup_tasks();
+#if HAVE_IQUEUE
     for (unsigned i = 0; i < _iqueues.weight(); i++) {
         delete[] _iqueues.get_value(i).pkts;
     }
+#endif
 }
 
 String ToDPDKDevice::statistics_handler(Element *e, void * thunk)
@@ -187,6 +198,14 @@ void ToDPDKDevice::add_handlers()
     add_read_handler("hw_errors",statistics_handler, h_oerrors);
 }
 
+
+inline void
+ToDPDKDevice::enqueue(rte_mbuf* &q, rte_mbuf* mbuf, const Packet* p) {
+    q = mbuf;
+}
+
+
+#if HAVE_IQUEUE
 inline void ToDPDKDevice::set_flush_timer(DPDKDevice::TXInternalQueue &iqueue) {
     if (_timeout >= 0 || iqueue.nr_pending) {
         if (iqueue.timeout.scheduled()) {
@@ -272,7 +291,7 @@ void ToDPDKDevice::push(int, Packet *p)
             }
         } else { // If there is space in the iqueue
             struct rte_mbuf* mbuf = DPDKDevice::get_mbuf(p, _create, _this_node);
-            if (mbuf != NULL) {
+            if (likely(mbuf != NULL)) {
                 enqueue(iqueue.pkts[(iqueue.index + iqueue.nr_pending) % _internal_tx_queue_size], mbuf, p);
                 iqueue.nr_pending++;
             } else {
@@ -297,13 +316,6 @@ void ToDPDKDevice::push(int, Packet *p)
 #endif
 }
 
-
-inline void
-ToDPDKDevice::enqueue(rte_mbuf* &q, rte_mbuf* mbuf, const Packet* p) {
-    q = mbuf;
-}
-
-
 /**
  * push_batch seems more complex than in tonetmapdevice, but it's only because
  *  we have to place pointers in an array, and we don't want to keep a linked
@@ -311,27 +323,26 @@ ToDPDKDevice::enqueue(rte_mbuf* &q, rte_mbuf* mbuf, const Packet* p) {
  *  array, and packets in the list, it would be a mess). So we use an array as
  *  a ring.
  */
-#if HAVE_BATCH
+# if HAVE_BATCH
 void ToDPDKDevice::push_batch(int, PacketBatch *head)
 {
     // Get the thread-local internal queue
     DPDKDevice::TXInternalQueue &iqueue = _iqueues.get();
-
     Packet* p = head;
     Packet* next;
 
     //No recycling through click if we have DPDK-backed packets
     bool congestioned;
-#if !CLICK_PACKET_USE_DPDK
+#  if !CLICK_PACKET_USE_DPDK
     BATCH_RECYCLE_START();
-#endif
+#  endif
     do {
         congestioned = false;
         //First, place the packets in the queue
         while (iqueue.nr_pending < (unsigned)_internal_tx_queue_size && p) { // Internal queue is full
             // While there is still place in the iqueue
             struct rte_mbuf* mbuf = DPDKDevice::get_mbuf(p, _create, _this_node);
-            if (mbuf != NULL) {
+            if (likely(mbuf != NULL)) {
                 enqueue(iqueue.pkts[(iqueue.index + iqueue.nr_pending) & (_internal_tx_queue_size - 1)], mbuf, p);
                 iqueue.nr_pending++;
             } else {
@@ -339,13 +350,13 @@ void ToDPDKDevice::push_batch(int, PacketBatch *head)
                 abort();
             }
             next = p->next();
-#if !CLICK_PACKET_USE_DPDK
+#  if !CLICK_PACKET_USE_DPDK
             BATCH_RECYCLE_PACKET_CONTEXT(p);
-#endif
+#  endif
             p = next;
         }
 
-        if (p != 0) {
+        if (unlikely(p != 0)) {
             congestioned = true;
             if (!_congestion_warning_printed) {
                 if (!_blocking)
@@ -365,7 +376,7 @@ void ToDPDKDevice::push_batch(int, PacketBatch *head)
         // If we're in blocking mode, we loop until we can put p in the iqueue
     } while (unlikely(_blocking && congestioned));
 
-#if !CLICK_PACKET_USE_DPDK
+#  if !CLICK_PACKET_USE_DPDK
     //If non-blocking, drop all packets that could not be sent
     while (p) {
         next = p->next();
@@ -373,14 +384,103 @@ void ToDPDKDevice::push_batch(int, PacketBatch *head)
         p = next;
         add_dropped(1);
     }
-#endif
+#  endif
 
-#if !CLICK_PACKET_USE_DPDK
+#  if !CLICK_PACKET_USE_DPDK
     BATCH_RECYCLE_END();
-#endif
+#  endif
+}
+# endif //HAVE_BATCH
+
+#else //HAVE_IQUEUE
+
+void ToDPDKDevice::push(int, Packet *p)
+{
+    click_chatter("ERROR : You must enable IQUEUE to push single-packets.");
+}
+
+# if HAVE_BATCH
+void ToDPDKDevice::push_batch(int, PacketBatch *head)
+{
+    Packet* p = head;
+    Packet* next;
+#  define TX_MAX_BURST 32
+#  if !CLICK_PACKET_USE_DPDK
+    BATCH_RECYCLE_START();
+#  endif
+    sendagain:
+        struct rte_mbuf* pkts[TX_MAX_BURST];
+        int count = head->count() > 32 ? 32: head->count();
+        //First, place the packets in the queue
+        for (int i = 0; i < count; i ++) {
+            struct rte_mbuf* mbuf = DPDKDevice::get_mbuf(p, _create, _this_node);
+            if (likely(mbuf != NULL)) {
+                enqueue(pkts[i], mbuf, p);
+            } else {
+                click_chatter("No more DPDK buffer");
+                abort();
+            }
+            next = p->next();
+#  if !CLICK_PACKET_USE_DPDK
+            BATCH_RECYCLE_PACKET_CONTEXT(p);
+#  endif
+            p = next;
+        }
+
+
+        unsigned sent = 0;
+
+        lock(); // ! This is a queue lock, not a thread lock.
+
+        sent = rte_eth_tx_burst(_dev->port_id, queue_for_thisthread_begin(), pkts, count);
+
+        unlock();
+
+        add_count(sent);
+
+        if (unlikely(sent != count)) { //We could not send all packets
+                if (!_congestion_warning_printed) {
+                    if (!_blocking)
+                        click_chatter("%s: packet dropped", name().c_str());
+                    else
+                        click_chatter("%s: congestion warning", name().c_str());
+                    _congestion_warning_printed = true;
+                }
+                if (_blocking) {
+                    int base = sent;
+
+                    do {
+                        lock(); // ! This is a queue lock, not a thread lock.
+
+                        sent = rte_eth_tx_burst(_dev->port_id, queue_for_thisthread_begin(), pkts + base, count);
+
+                        unlock();
+
+                        add_count(sent);
+                        count-=sent;
+                        base+=sent;
+                    } while (count > 0);
+
+                } else {
+                    add_dropped(count - sent);
+                    while (sent < count) {
+                        rte_pktmbuf_free(pkts[sent]);
+                        sent++;
+                    }
+                }
+        }
+        if (unlikely(p != 0)) //There are still packets to try sending
+            goto sendagain;
+
+#  if !CLICK_PACKET_USE_DPDK
+    BATCH_RECYCLE_END();
+#  endif
 
 }
-#endif
+# endif //HAVE_BATCH
+
+#endif //!HAVE_IQUEUE
+
 
 CLICK_ENDDECLS
 ELEMENT_REQUIRES(userlevel dpdk)

--- a/elements/userlevel/todpdkdevice.hh
+++ b/elements/userlevel/todpdkdevice.hh
@@ -1,6 +1,7 @@
 #ifndef CLICK_TODPDKDEVICE_USERLEVEL_HH
 #define CLICK_TODPDKDEVICE_USERLEVEL_HH
 
+#include <click/config.h>
 #include <click/batchelement.hh>
 #include <click/sync.hh>
 #include <click/dpdkdevice.hh>
@@ -140,7 +141,9 @@ public:
         h_opackets,h_obytes,h_oerrors
     };
 
+#if HAVE_IQUEUE
     void run_timer(Timer *);
+#endif
 #if HAVE_BATCH
     void push_batch(int port, PacketBatch *head);
 #endif
@@ -151,10 +154,11 @@ private:
 
     inline void enqueue(rte_mbuf* &q, rte_mbuf* mbuf, const Packet* p);
 
+#if HAVE_IQUEUE
     inline void set_flush_timer(DPDKDevice::TXInternalQueue &iqueue);
     void flush_internal_tx_queue(DPDKDevice::TXInternalQueue &);
-
     per_thread<DPDKDevice::TXInternalQueue> _iqueues;
+#endif
 
     DPDKDevice* _dev;
     int _timeout;

--- a/include/click/packet.hh
+++ b/include/click/packet.hh
@@ -104,12 +104,14 @@ class Packet { public:
     inline bool shared_nonatomic() const;
     Packet *clone(bool fast = false) CLICK_WARN_UNUSED_RESULT;
     inline WritablePacket *uniqueify() CLICK_WARN_UNUSED_RESULT;
-#if CLICK_LINUXMODULE
+#ifndef CLICK_NOINDIRECT
+# if CLICK_LINUXMODULE
     inline void get() {skb_get(skb());};
-#elif CLICK_PACKET_USE_DPDK
+# elif CLICK_PACKET_USE_DPDK
     inline void get() {rte_mbuf_refcnt_update(mb(), 1);};
-#else
+# else
     inline void get() {_use_count++;};
+# endif
 #endif
 
     inline const unsigned char *data() const;
@@ -730,7 +732,7 @@ class Packet { public:
 	*reinterpret_cast<click_aliasable_void_pointer_t *>(xanno()->c + i) = const_cast<void *>(x);
     }
 
-#if !CLICK_PACKET_USE_DPDK && !CLICK_LINUXMODULE
+#if !CLICK_PACKET_USE_DPDK && !CLICK_LINUXMODULE && !defined(CLICK_NOINDIRECT)
     inline Packet* data_packet() {
     	return _data_packet;
     }
@@ -840,8 +842,10 @@ class Packet { public:
 #if !(CLICK_LINUXMODULE || CLICK_PACKET_USE_DPDK)
     // User-space and BSD kernel module implementations.
 protected:
+#ifndef CLICK_NOINDIRECT
     atomic_uint32_t _use_count;
     Packet *_data_packet;
+#endif
 private:
     /* mimic Linux sk_buff */
     unsigned char *_head; /* start of allocated buffer */
@@ -1061,8 +1065,10 @@ WritablePacket::initialize(bool clear)
     click_chatter("UNIMPLEMENTED");
     assert(false); //Should be initialized by DPDK
 #else
+#if !CLICK_NOINDIRECT
     _use_count = 1;
     _data_packet = 0;
+#endif
 # if CLICK_USERLEVEL || CLICK_MINIOS
     _destructor = 0;
 # elif CLICK_BSDMODULE
@@ -1080,8 +1086,10 @@ WritablePacket::initialize_data()
     click_chatter("UNIMPLEMENTED");
     assert(false); //This may not illegal but I need to check what to be done
 #else
+# if !CLICK_NOINDIRECT
     _use_count = 1;
     _data_packet = 0;
+# endif
 #endif
     clear_annotations(false);
 }
@@ -1717,7 +1725,10 @@ Packet::kill()
 		//Dpdk takes care of indirect and related things
 		rte_pktmbuf_free(mb());
 	#elif HAVE_CLICK_PACKET_POOL && !defined(CLICK_FORCE_EXPENSIVE)
-		if (_use_count.dec_and_test()) {
+#ifndef CLICK_NOINDIRECT
+		if (_use_count.dec_and_test())
+#endif
+        {
 			WritablePacket::recycle(static_cast<WritablePacket *>(this));
 		}
 	#else
@@ -1747,7 +1758,11 @@ Packet::kill_nonatomic()
 #elif CLICK_PACKET_USE_DPDK
         rte_pktmbuf_free(mb());
 #elif HAVE_CLICK_PACKET_POOL
-        if (_use_count.nonatomic_dec_and_test()) {
+
+#ifndef CLICK_NOINDIRECT
+        if (_use_count.nonatomic_dec_and_test())
+#endif
+        {
             WritablePacket::recycle(static_cast<WritablePacket *>(this));
 
     }
@@ -1796,9 +1811,10 @@ Packet::make(struct mbuf *m)
     m_freem(m);
     return 0;
   }
+#ifndef CLICK_NOINDIRECT
   p->_use_count = 1;
   p->_data_packet = NULL;
-
+#endif
   if (m->m_pkthdr.len != m->m_len) {
     struct mbuf *m2;
     /* click needs contiguous data */
@@ -1847,12 +1863,16 @@ Packet::make(struct mbuf *m)
 inline bool
 Packet::shared() const
 {
-#if CLICK_LINUXMODULE
-    return skb_cloned(const_cast<struct sk_buff *>(skb()));
-#elif CLICK_PACKET_USE_DPDK
-    return rte_mbuf_refcnt_read(mb()) > 1 || RTE_MBUF_INDIRECT(mb());
+#ifdef CLICK_NOINDIRECT
+    return false;
 #else
+# if CLICK_LINUXMODULE
+    return skb_cloned(const_cast<struct sk_buff *>(skb()));
+# elif CLICK_PACKET_USE_DPDK
+    return rte_mbuf_refcnt_read(mb()) > 1 || RTE_MBUF_INDIRECT(mb());
+# else
     return (_data_packet || _use_count > 1);
+# endif
 #endif
 }
 
@@ -1863,12 +1883,16 @@ Packet::shared() const
 inline bool
 Packet::shared_nonatomic() const
 {
-#if CLICK_LINUXMODULE
-    return skb_cloned(const_cast<struct sk_buff *>(skb()));
-#elif CLICK_PACKET_USE_DPDK
-    return rte_mbuf_refcnt_read(mb()) > 1 || RTE_MBUF_INDIRECT(mb());
+#ifdef CLICK_NOINDIRECT
+    return false;
 #else
+# if CLICK_LINUXMODULE
+    return skb_cloned(const_cast<struct sk_buff *>(skb()));
+# elif CLICK_PACKET_USE_DPDK
+    return rte_mbuf_refcnt_read(mb()) > 1 || RTE_MBUF_INDIRECT(mb());
+# else
     return (_data_packet || _use_count.nonatomic_value() > 1);
+# endif
 #endif
 }
 
@@ -1912,13 +1936,17 @@ private:
 inline WritablePacket *
 Packet::uniqueify()
 {
-#ifdef CLICK_FORCE_EXPENSIVE
+#ifdef CLICK_NOINDIRECT
+    return static_cast<WritablePacket *>(this);
+#else
+#  ifdef CLICK_FORCE_EXPENSIVE
     PacketRef r(this);
-#endif
+#  endif
     if (!shared())
 	return static_cast<WritablePacket *>(this);
     else
-	return expensive_uniqueify(0, 0, true);
+	    return expensive_uniqueify(0, 0, true);
+#endif
 }
 
 inline WritablePacket *
@@ -2090,7 +2118,10 @@ Packet::shrink_data(const unsigned char *data, uint32_t length)
     (void) data;
     (void) length;
 # else
+
+#ifndef CLICK_NOINDIRECT
     assert(_data_packet);
+#endif
     if (data >= _head && data + length >= data && data + length <= _end) {
 	_head = _data = const_cast<unsigned char *>(data);
 	_tail = _end = const_cast<unsigned char *>(data + length);

--- a/include/click/packetbatch.hh
+++ b/include/click/packetbatch.hh
@@ -731,9 +731,15 @@ inline void PacketBatch::kill() {
 		BATCH_RECYCLE_ADD_DATA_PACKET(p);\
 	} else {\
 		BATCH_RECYCLE_ADD_PACKET(p);}}
-#else
+#elif !defined(CLICK_NOINDIRECT)
 #define BATCH_RECYCLE_UNKNOWN_PACKET(p) {\
 	if (p->data_packet() == 0 && p->buffer_destructor() == 0 && p->buffer() != 0) {\
+		BATCH_RECYCLE_ADD_DATA_PACKET(p);\
+	} else {\
+	    BATCH_RECYCLE_ADD_PACKET(p);}}
+#else
+#define BATCH_RECYCLE_UNKNOWN_PACKET(p) {\
+	if (p->buffer_destructor() == 0 && p->buffer() != 0) {\
 		BATCH_RECYCLE_ADD_DATA_PACKET(p);\
 	} else {\
 	    BATCH_RECYCLE_ADD_PACKET(p);}}


### PR DESCRIPTION
Disable packet cloning, preventing running packet accross multiple parallel pipelines, which is something not usually needed.
Disable the TX buffering queue for DPDK