### PR TITLE
PacketBatch: Remove inheritance to make the batching method abstract

### DIFF
--- a/elements/analysis/averagebatchcounter.cc
+++ b/elements/analysis/averagebatchcounter.cc
@@ -132,7 +132,7 @@ uint32_t
 AverageBatchCounter::compute_agg_frame_len(PacketBatch *batch)
 {
     uint32_t agg_len = 0;
-    for(Packet *p = batch; p != 0; p = p->next()) {
+    FOR_EACH_PACKET(batch, p) {
         uint32_t value = AGGREGATE_ANNO(p);
         if (value > 0) {
             agg_len += value;

--- a/elements/analysis/frommindump.cc
+++ b/elements/analysis/frommindump.cc
@@ -329,7 +329,7 @@ bool FromMinDump::run_task(Task *) {
     if (likely(p)) {
       if (unlikely(head == NULL)) {
         head = PacketBatch::start_head(p);
-        last = head;
+        last = p;
       } else {
         last->set_next(p);
         last = last->next();

--- a/elements/analysis/multireplay.cc
+++ b/elements/analysis/multireplay.cc
@@ -203,17 +203,17 @@ MultiReplayUnqueue::run_task(Task* task)
             if (head == 0) {
                 head = PacketBatch::start_head(q);
                 if (_quick_clone)
-                    SET_PAINT_ANNO(head,PAINT_ANNO(p));
-                last = head;
+                    SET_PAINT_ANNO(head->first(),PAINT_ANNO(p));
+                last = head->first();
                 c = 1;
             } else {
                 //If next packet is for another output, send the pending batch and start a new one
-                if (PAINT_ANNO(p) != PAINT_ANNO(head)) {
-                    output_push_batch(PAINT_ANNO(head),head->make_tail(last,c));
+                if (PAINT_ANNO(p) != PAINT_ANNO(head->first())) {
+                    output_push_batch(PAINT_ANNO(head->first()),head->make_tail(last,c));
                     head = PacketBatch::start_head(q);
                     if (_quick_clone)
-                        SET_PAINT_ANNO(head,PAINT_ANNO(p));
-                    last = head;
+                        SET_PAINT_ANNO(head->first(),PAINT_ANNO(p));
+                    last = head->first();
                     c = 1;
                 } else {
                     //Just add the packet to the end of the batch
@@ -231,7 +231,7 @@ MultiReplayUnqueue::run_task(Task* task)
 #if HAVE_BATCH
     //Flush pending batch
     if (head)
-        output_push_batch(PAINT_ANNO(head),head->make_tail(last,c));
+        output_push_batch(PAINT_ANNO(head->first()),head->make_tail(last,c));
 #endif
 
 

--- a/elements/analysis/replay.cc
+++ b/elements/analysis/replay.cc
@@ -374,7 +374,7 @@ loop:
 #if HAVE_BATCH
             if (head == 0) {
                 head = PacketBatch::start_head(q);
-                last = head;
+                last = q;
                 c = 1;
             } else {
                 //Just add the packet to the end of the batch

--- a/elements/analysis/replay.hh
+++ b/elements/analysis/replay.hh
@@ -140,7 +140,7 @@ inline bool ReplayBase::load_packets() {
                 if (p_input[i] == 0) {
                     do_pull:
 #if HAVE_BATCH
-                    p_input[i] = input_pull_batch(i,1);
+                    p_input[i] = input_pull_batch(i,1)->first();
 #else
                     p_input[i] = input(i).pull();
 #endif

--- a/elements/ethernet/ethervlanencap.cc
+++ b/elements/ethernet/ethervlanencap.cc
@@ -151,7 +151,10 @@ EtherVLANEncap::add_handlers()
     add_read_handler("config", read_handler, h_config);
     add_data_handlers("src", Handler::h_read | Handler::h_write, reinterpret_cast<EtherAddress *>(&_ethh.ether_shost));
     add_data_handlers("dst", Handler::h_read | Handler::h_write, reinterpret_cast<EtherAddress *>(&_ethh.ether_dhost));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
     add_net_order_data_handlers("ethertype", Handler::h_read | Handler::h_write, &_ethh.ether_vlan_encap_proto);
+#pragma GCC diagnostic pop
     add_read_handler("vlan_tci", read_handler, h_vlan_tci);
     add_write_handler("vlan_tci", reconfigure_keyword_handler, "3 VLAN_TCI");
     add_read_handler("vlan_id", read_keyword_handler, "VLAN_ID");

--- a/elements/flow/flowcounter.cc
+++ b/elements/flow/flowcounter.cc
@@ -27,7 +27,7 @@ int FlowCounter::configure(Vector<String> &conf, ErrorHandler *errh)
 
 void FlowCounter::push_flow(int, int* fcb, PacketBatch* flow)
 {
-    *fcb += flow->length();
+    *fcb += flow->count();
     output_push_batch(0, flow);
 }
 

--- a/elements/flow/tcpreorder.cc
+++ b/elements/flow/tcpreorder.cc
@@ -381,7 +381,7 @@ bool TCPReorder::putPacketInList(struct fcb_tcpreorder* tcpreorder, Packet* pack
 
 void TCPReorder::killList(struct fcb_tcpreorder* tcpreorder) {
         SFCB_STACK( //Packet in the list have no reference
-            FOR_EACH_PACKET_SAFE(tcpreorder->packetList,p) {
+            FOR_EACH_PACKET_SAFE(((PacketBatch*)(tcpreorder->packetList)),p) {
                 click_chatter("WARNING : Non-free TCPReorder flow bucket");
                 p->kill();
             }

--- a/elements/ip/ipaddrpairrewriter.cc
+++ b/elements/ip/ipaddrpairrewriter.cc
@@ -200,62 +200,7 @@ IPAddrPairRewriter::push(int port, Packet *p)
 void
 IPAddrPairRewriter::push_batch(int port, PacketBatch *batch)
 {
-    unsigned short outports = noutputs();
-    PacketBatch* out[outports];
-    bzero(out,sizeof(PacketBatch*)*outports);
-    PacketBatch *next = ((batch != NULL)? static_cast<PacketBatch*>(batch->next()) : NULL );
-    PacketBatch *p = batch;
-    PacketBatch *last = NULL;
-    int last_o = -1;
-    int passed = 0;
-    int count  = 0;
-    for (; p != NULL;p=next,next=(p==0?0:static_cast<PacketBatch*>(p->next()))) {
-        // The actual job of this element
-        int o = process(port, p);
-
-        if (o < 0 || o>=(outports))
-            o = (outports - 1);
-
-        if (o == last_o) {
-            passed ++;
-        }
-        else {
-            if ( !last ) {
-                out[o] = p;
-                p->set_count(1);
-                p->set_tail(p);
-            }
-            else {
-                out[last_o]->set_tail(last);
-                out[last_o]->set_count(out[last_o]->count() + passed);
-                if (!out[o]) {
-                    out[o] = p;
-                    out[o]->set_count(1);
-                    out[o]->set_tail(p);
-                }
-                else {
-                    out[o]->append_packet(p);
-                }
-                passed = 0;
-            }
-        }
-        last = p;
-        last_o = o;
-        count++;
-    }
-
-    if (passed) {
-        out[last_o]->set_tail(last);
-        out[last_o]->set_count(out[last_o]->count() + passed);
-    }
-
-    int i = 0;
-    for (; i < outports; i++) {
-        if (out[i]) {
-            out[i]->tail()->set_next(NULL);
-            checked_output_push_batch(i, out[i]);
-        }
-    }
+  CLASSIFY_EACH_PACKET(noutputs() + 1,([this,port](Packet* p){return process(port,p);}),batch,checked_output_push_batch);
 }
 #endif
 

--- a/elements/ip/ipaddrrewriter.cc
+++ b/elements/ip/ipaddrrewriter.cc
@@ -210,62 +210,7 @@ IPAddrRewriter::push(int port, Packet *p)
 void
 IPAddrRewriter::push_batch(int port, PacketBatch *batch)
 {
-    unsigned short outports = noutputs();
-    PacketBatch* out[outports];
-    bzero(out,sizeof(PacketBatch*)*outports);
-    PacketBatch *next = ((batch != NULL)? static_cast<PacketBatch*>(batch->next()) : NULL );
-    PacketBatch *p = batch;
-    PacketBatch *last = NULL;
-    int last_o = -1;
-    int passed = 0;
-    int count  = 0;
-    for (; p != NULL;p=next,next=(p==0?0:static_cast<PacketBatch*>(p->next()))) {
-        // The actual job of this element
-        int o = process(port, p);
-
-        if (o < 0 || o>=(outports))
-            o = (outports - 1);
-
-        if (o == last_o) {
-            passed ++;
-        }
-        else {
-            if (!last) {
-                out[o] = p;
-                p->set_count(1);
-                p->set_tail(p);
-            }
-            else {
-                out[last_o]->set_tail(last);
-                out[last_o]->set_count(out[last_o]->count() + passed);
-                if (!out[o]) {
-                    out[o] = p;
-                    out[o]->set_count(1);
-                    out[o]->set_tail(p);
-                }
-                else {
-                    out[o]->append_packet(p);
-                }
-                passed = 0;
-            }
-        }
-        last = p;
-        last_o = o;
-        count++;
-    }
-
-    if (passed) {
-        out[last_o]->set_tail(last);
-        out[last_o]->set_count(out[last_o]->count() + passed);
-    }
-
-    int i = 0;
-    for (; i < outports; i++) {
-        if (out[i]) {
-            out[i]->tail()->set_next(NULL);
-            checked_output_push_batch(i, out[i]);
-        }
-    }
+  CLASSIFY_EACH_PACKET(noutputs() + 1,([this,port](Packet* p){return process(port,p);}),batch,checked_output_push_batch);
 }
 #endif
 

--- a/elements/ip/iproutetable.cc
+++ b/elements/ip/iproutetable.cc
@@ -184,62 +184,8 @@ IPRouteTable::push(int port, Packet *p)
 void
 IPRouteTable::push_batch(int port, PacketBatch *batch)
 {
-	unsigned short outports = noutputs();
-	PacketBatch* out[outports];
-	bzero(out,sizeof(PacketBatch*)*outports);
-	PacketBatch* next = ((batch != NULL)? static_cast<PacketBatch*>(batch->next()) : NULL );
-	PacketBatch* p = batch;
-	PacketBatch* last = NULL;
-	int last_o = -1;
-	int passed = 0;
-	int count  = 0;
 
-	for ( ;p != NULL; p=next,next=(p==0?0:static_cast<PacketBatch*>(p->next())) ) {
-		// The actual job of this element
-		int o = process(port, p);
-
-		if (o < 0 || o>=(outports)) o = (outports - 1);
-
-		if (o == last_o) {
-			passed ++;
-		}
-		else {
-			if ( !last ) {
-				out[o] = p;
-				p->set_count(1);
-				p->set_tail(p);
-			}
-			else {
-				out[last_o]->set_tail(last);
-				out[last_o]->set_count(out[last_o]->count() + passed);
-				if (!out[o]) {
-					out[o] = p;
-					out[o]->set_count(1);
-					out[o]->set_tail(p);
-				}
-				else {
-					out[o]->append_packet(p);
-				}
-				passed = 0;
-			}
-		}
-		last = p;
-		last_o = o;
-		count++;
-	}
-
-	if (passed) {
-		out[last_o]->set_tail(last);
-		out[last_o]->set_count(out[last_o]->count() + passed);
-	}
-
-	int i = 0;
-	for (; i < outports; i++) {
-		if (out[i]) {
-			out[i]->tail()->set_next(NULL);
-			checked_output_push_batch(i, out[i]);
-		}
-	}
+  CLASSIFY_EACH_PACKET(noutputs() + 1,([this,port](Packet* p){return process(port,p);}),batch,checked_output_push_batch);
 }
 #endif
 

--- a/elements/standard/infinitesource.cc
+++ b/elements/standard/infinitesource.cc
@@ -132,7 +132,7 @@ InfiniteSource::run_task(Task *)
 	for (int i = 0; i < n; i++) {
 		if (head == NULL) {
 			head = PacketBatch::start_head(_packet->clone());
-			last = head;
+			last = head->first();
 		} else {
 			last->set_next(_packet->clone());
 			last = last->next();

--- a/elements/standard/mixedqueue.cc
+++ b/elements/standard/mixedqueue.cc
@@ -112,7 +112,7 @@ MixedQueue::push_batch(int port, PacketBatch *batch)
 		_empty_note.wake();
 
 		if (oldp)
-		checked_output_push(1, PacketBatch::make_from_packet(oldp));
+		checked_output_push_batch(1, PacketBatch::make_from_packet(oldp));
 	}
 }
 #endif

--- a/elements/standard/paint.cc
+++ b/elements/standard/paint.cc
@@ -42,14 +42,12 @@ Paint::configure(Vector<String> &conf, ErrorHandler *errh)
 
 #if HAVE_BATCH
 PacketBatch *
-Paint::simple_action_batch(PacketBatch *p)
+Paint::simple_action_batch(PacketBatch *batch)
 {
-	Packet* cur = p;
-	while (cur != NULL) {
+    FOR_EACH_PACKET(batch, cur) {	
 		cur->set_anno_u8(_anno, _color);
-		cur = cur->next();
 	}
-    return p;
+    return batch;
 }
 #endif
 Packet *

--- a/elements/standard/pipeliner.cc
+++ b/elements/standard/pipeliner.cc
@@ -50,7 +50,7 @@ void Pipeliner::cleanup(CleanupStage) {
         while ((p = storage.get_value(i).extract()) != 0) {
 #if HAVE_BATCH
             if (receives_batch == 1)
-                static_cast<PacketBatch*>(p)->kill();
+                reinterpret_cast<PacketBatch*>(p)->kill();
             else
 #endif
                 p->kill();
@@ -153,7 +153,7 @@ void Pipeliner::push_batch(int,PacketBatch* head) {
     int count = head->count();
     retry:
     //CLWB did not prove helpful here
-    if (storage->insert(head)) {
+    if (storage->insert(head->first())) {
         stats->count += count;
         if (sleepiness >= _sleep_threshold)
             _task.reschedule();
@@ -222,19 +222,19 @@ Pipeliner::run_task(Task* t)
         int n = 0;
         while (!s.is_empty() && n < _burst) {
 #if HAVE_BATCH
-            PacketBatch* b = static_cast<PacketBatch*>(s.extract());
+            PacketBatch* b = reinterpret_cast<PacketBatch*>(s.extract());
 
             if (unlikely(!receives_batch)) {
                 if (out == NULL) {
-                    b->set_tail(b);
+                    b->set_tail(b->first());
                     b->set_count(1);
                     out = b;
                 } else {
-                    out->append_packet(b);
+                    out->append_packet(b->first());
                 }
                 n+=1;
             } else {
-                n+=b->length();
+                n+=b->count();
                 if (out == NULL) {
                     out = b;
                 } else {

--- a/elements/standard/rrswitch.cc
+++ b/elements/standard/rrswitch.cc
@@ -81,7 +81,7 @@ RoundRobinSwitch::push_batch(int, PacketBatch *batch)
     if (_split_batch) {
       CLASSIFY_EACH_PACKET(_max,next,batch,output_push_batch);
     } else {
-      output(next(batch)).push_batch(batch);
+      output(next(batch->first())).push_batch(batch);
     }
 }
 #endif

--- a/elements/standard/strip.cc
+++ b/elements/standard/strip.cc
@@ -37,10 +37,8 @@ Strip::configure(Vector<String> &conf, ErrorHandler *errh)
 PacketBatch *
 Strip::simple_action_batch(PacketBatch *head)
 {
-	Packet* current = head;
-	while (current != NULL) {
+	FOR_EACH_PACKET(head, current) {
 		current->pull(_nbytes);
-		current = current->next();
 	}
 	return head;
 }

--- a/elements/tunnel/gtplookup.cc
+++ b/elements/tunnel/gtplookup.cc
@@ -173,7 +173,7 @@ GTPLookup::push_batch(int port, PacketBatch* batch) {
 	CLASSIFY_EACH_PACKET(3,fnt,batch,[this](int o, PacketBatch* batch){
 			if (o == 2) {
 			    batch->tail()->set_next(_queue.get());
-			    _queue.set(batch);
+			    _queue.set(batch->first());
 			} else {
 				checked_output_push_batch(o,batch);
 			}

--- a/elements/userlevel/todpdkdevice.cc
+++ b/elements/userlevel/todpdkdevice.cc
@@ -322,7 +322,7 @@ void ToDPDKDevice::push_batch(int, PacketBatch *head)
 {
     // Get the thread-local internal queue
     DPDKDevice::TXInternalQueue &iqueue = _iqueues.get();
-    Packet* p = head;
+    Packet* p = head->first();
     Packet* next;
 
     //No recycling through click if we have DPDK-backed packets

--- a/elements/userlevel/todpdkring.cc
+++ b/elements/userlevel/todpdkring.cc
@@ -281,7 +281,7 @@ ToDPDKRing::push_batch(int, PacketBatch *head)
     // Get the internal queue
     DPDKDevice::TXInternalQueue &iqueue = _iqueue;
 
-    Packet *p    = head;
+    Packet *p    = head->first();
     Packet *next = NULL;
 
     // No recycling through Click if we have DPDK packets

--- a/include/click/packetbatch.hh
+++ b/include/click/packetbatch.hh
@@ -9,7 +9,7 @@ CLICK_DECLS
  * Iterate over all packets of a batch. The batch cannot be modified during
  *   iteration. Use _SAFE version if you want to modify it on the fly.
  */
-#define FOR_EACH_PACKET(batch,p) for(Packet* p = batch;p != 0;p=p->next())
+#define FOR_EACH_PACKET(batch,p) for(Packet* p = batch->first();p != 0;p=p->next())
 
 /**
  * Iterate over all packets of a batch. The current packet can be modified
@@ -17,8 +17,8 @@ CLICK_DECLS
  *  the loop.
  */
 #define FOR_EACH_PACKET_SAFE(batch,p) \
-                Packet* fep_next = ((batch != 0)? batch->next() : 0 );\
-                Packet* p = batch;\
+                Packet* fep_next = ((batch != 0)? batch->first()->next() : 0 );\
+                Packet* p = batch->first();\
                 for (;p != 0;p=fep_next,fep_next=(p==0?0:p->next()))
 
 /**
@@ -27,8 +27,8 @@ CLICK_DECLS
  * Use _DROPPABLE version if the function could return null.
  */
 #define EXECUTE_FOR_EACH_PACKET(fnt,batch) \
-                Packet* efep_next = ((batch != 0)? batch->next() : 0 );\
-                Packet* p = batch;\
+                Packet* efep_next = ((batch != 0)? batch->first()->next() : 0 );\
+                Packet* p = batch->first();\
                 Packet* last = 0;\
                 for (;p != 0;p=efep_next,efep_next=(p==0?0:p->next())) {\
                     Packet* q = fnt(p);\
@@ -36,7 +36,7 @@ CLICK_DECLS
                         if (last) {\
                             last->set_next(q);\
                         } else {\
-                            batch = static_cast<PacketBatch*>(q);\
+                            batch = reinterpret_cast<PacketBatch*>(q);\
                         }\
                         q->set_next(efep_next);\
                     }\
@@ -51,8 +51,8 @@ CLICK_DECLS
  * reference. This function does not kill any packet by itself.
  */
 #define EXECUTE_FOR_EACH_PACKET_UNTIL_DO(fnt,batch,on_stop) \
-                Packet* efep_next = ((batch != 0)? batch->next() : 0 );\
-                Packet* p = batch;\
+                Packet* efep_next = ((batch != 0)? batch->first()->next() : 0 );\
+                Packet* p = batch->first();\
                 Packet* last = 0;\
                 int count = batch->count();\
                 for (;p != 0;p=efep_next,efep_next=(p==0?0:p->next())) {\
@@ -62,7 +62,7 @@ CLICK_DECLS
                         if (last) {\
                             last->set_next(q);\
                         } else {\
-                            batch = static_cast<PacketBatch*>(q);\
+                            batch = reinterpret_cast<PacketBatch*>(q);\
                             batch->set_count(count);\
                         }\
                         q->set_next(efep_next);\
@@ -91,8 +91,8 @@ CLICK_DECLS
  * that one, or null if the packet is to be dropped.
  */
 #define EXECUTE_FOR_EACH_PACKET_DROPPABLE(fnt,batch,on_drop) {\
-                Packet* efepd_next = ((batch != 0)? batch->next() : 0 );\
-                Packet* p = batch;\
+                Packet* efepd_next = ((batch != 0)? batch->first()->next() : 0 );\
+                Packet* p = batch->first();\
                 Packet* last = 0;\
                 int count = batch->count();\
                 for (;p != 0;p=efepd_next,efepd_next=(p==0?0:p->next())) {\
@@ -110,7 +110,7 @@ CLICK_DECLS
                         if (last) {\
                             last->set_next(q);\
                         } else {\
-                            batch = static_cast<PacketBatch*>(q);\
+                            batch = reinterpret_cast<PacketBatch*>(q);\
                         }\
                         q->set_next(efepd_next);\
                     }\
@@ -150,8 +150,8 @@ CLICK_DECLS
  * On_flush is always called on the batch after the last packet.
  */
 #define EXECUTE_FOR_EACH_PACKET_SPLITTABLE(fnt,batch,on_drop,on_flush) {\
-            Packet* next = ((batch != 0)? batch->next() : 0 );\
-            Packet* p = batch;\
+            Packet* next = ((batch != 0)? batch->first()->next() : 0 );\
+            Packet* p = batch->first();\
             Packet* last = 0;\
             int count = 0;\
             for (;p != 0;p=next,next=(p==0?0:p->next())) {\
@@ -171,7 +171,7 @@ CLICK_DECLS
                     if (last) {\
                         last->set_next(q);\
                     } else {\
-                        batch = static_cast<PacketBatch*>(q);\
+                        batch = reinterpret_cast<PacketBatch*>(q);\
                     }\
                     q->set_next(next);\
                 }\
@@ -207,26 +207,26 @@ CLICK_DECLS
     {\
         PacketBatch* out[(nbatches)];\
         bzero(out,sizeof(PacketBatch*)*(nbatches));\
-        PacketBatch* cep_next = ((cep_batch != 0)? static_cast<PacketBatch*>(cep_batch->next()) : 0 );\
-        PacketBatch* p = cep_batch;\
-        PacketBatch* last = 0;\
+        PacketBatch* cep_next = ((cep_batch != 0)? reinterpret_cast<PacketBatch*>(cep_batch->first()->next()) : 0 );\
+        Packet* p = cep_batch->first();\
+        Packet* last = 0;\
         int last_o = -1;\
         int passed = 0;\
-        for (;p != 0;p=cep_next,cep_next=(p==0?0:static_cast<PacketBatch*>(p->next()))) {\
+        for (;p != 0;p=cep_next->first(),cep_next=(p==0?0:reinterpret_cast<PacketBatch*>(p->next()))) {\
             int o = (fnt(p));\
             if (o < 0 || o>=(int)(nbatches)) o = (nbatches - 1);\
             if (o == last_o) {\
                 passed ++;\
             } else {\
                 if (last == 0) {\
-                    out[o] = p;\
-                    p->set_count(1);\
-                    p->set_tail(p);\
+                    out[o] = reinterpret_cast<PacketBatch*>(p);\
+                    reinterpret_cast<PacketBatch*>(p)->set_count(1);\
+                    reinterpret_cast<PacketBatch*>(p)->set_tail(p);\
                 } else {\
                     out[last_o]->set_tail(last);\
                     out[last_o]->set_count(out[last_o]->count() + passed);\
                     if (!out[o]) {\
-                        out[o] = p;\
+                        out[o] = reinterpret_cast<PacketBatch*>(p);\
                         out[o]->set_count(1);\
                         out[o]->set_tail(p);\
                     } else {\
@@ -261,12 +261,12 @@ CLICK_DECLS
     {\
         PacketBatch* out[(nbatches)];\
         bzero(out,sizeof(PacketBatch*)*(nbatches));\
-        PacketBatch* cep_next = ((cep_batch != 0)? static_cast<PacketBatch*>(cep_batch->next()) : 0 );\
-        Packet* p = cep_batch;\
+        PacketBatch* cep_next = ((cep_batch != 0)? reinterpret_cast<PacketBatch*>(cep_batch->first()->next()) : 0 );\
+        Packet* p = cep_batch->first();\
         Packet* last = 0;\
         int last_o = -1;\
         int passed = 0;\
-        for (;p != 0;p=cep_next,cep_next=(p==0?0:static_cast<PacketBatch*>(p->next()))) {\
+        for (;p != 0;p=cep_next->first(),cep_next=(p==0?0:reinterpret_cast<PacketBatch*>(p->next()))) {\
             int o = (fnt(p));\
             if (o>=(nbatches)) o = (nbatches - 1);\
             if (o == last_o) {\
@@ -274,7 +274,7 @@ CLICK_DECLS
             } else {\
                 if (last == 0) {\
                     if (o == -1) continue;\
-                    out[o] = static_cast<PacketBatch*>(p);\
+                    out[o] = reinterpret_cast<PacketBatch*>(p);\
                     out[o]->set_count(1);\
                     out[o]->set_tail(p);\
                 } else {\
@@ -284,7 +284,7 @@ CLICK_DECLS
                     }\
                     if (o != -1) {\
                         if (!out[o]) {\
-                            out[o] = static_cast<PacketBatch*>(p);\
+                            out[o] = reinterpret_cast<PacketBatch*>(p);\
                             out[o]->set_count(1);\
                             out[o]->set_tail(p);\
                         } else {\
@@ -328,7 +328,7 @@ CLICK_DECLS
  */
 #define MAKE_BATCH(fnt,head,max) {\
         head = PacketBatch::start_head(fnt);\
-        Packet* last = head;\
+        Packet* last = head->first();\
         if (head != 0) {\
             unsigned int count = 1;\
             while (count < (unsigned)(max>0?max:BATCH_MAX_PULL)) {\
@@ -357,7 +357,7 @@ CLICK_DECLS
  *
  * Batches must not mix cloned and unique packets. Use cut to split batches and have part of them cloned.
  */
-class PacketBatch : public WritablePacket {
+class PacketBatch {
 
 //Consider a batch size bigger as bogus (prevent infinite loop on bad pointer manipulation)
 #define MAX_BATCH_SIZE 8192
@@ -367,21 +367,21 @@ public :
      * Return the first packet of the batch
      */
     inline Packet* first() {
-        return this;
+        return (Packet*)this;
     }
 
     /*
      * Set the tail of the batch
      */
     inline void set_tail(Packet* p) {
-        set_prev(p);
+        first()->set_prev(p);
     }
 
     /*
      * Return the tail of the batch
      */
     inline Packet* tail() {
-        return prev();
+        return first()->prev();
     }
     
     /*
@@ -400,7 +400,7 @@ public :
      * Append a proper PacketBatch to this batch.
      */
     inline void append_batch(PacketBatch* head) {
-        tail()->set_next(head);
+        tail()->set_next(head->first());
         set_tail(head->tail());
         set_count(count() + head->count());
     }
@@ -418,7 +418,7 @@ public :
      * Return the number of packets in this batch
      */
     inline unsigned count() {
-        unsigned int r = BATCH_COUNT_ANNO(this);
+        unsigned int r = BATCH_COUNT_ANNO(first());
         assert(r); //If this is a batch, this anno has to be set
         return r;
     }
@@ -432,7 +432,7 @@ public :
      *  until you call make_tail().
      */
     inline static PacketBatch* start_head(Packet* p) {
-        return static_cast<PacketBatch*>(p);
+        return reinterpret_cast<PacketBatch*>(p);
     }
 
     /**
@@ -450,8 +450,8 @@ public :
         if (last == 0) {
             if (count != 1)
                 click_chatter("BUG in make_tail : last packet is the head, but count is %u",count);
-            set_tail(this);
-            set_next(0);
+            set_tail(first());
+            first()->set_next(0);
         } else {
             set_tail(last);
             last->set_next(0);
@@ -463,7 +463,7 @@ public :
      * Set the number of packets in this batch
      */
     inline void set_count(unsigned int c) {
-        SET_BATCH_COUNT_ANNO(this,c);
+        SET_BATCH_COUNT_ANNO(first(),c);
     }
 
     /**
@@ -487,7 +487,7 @@ public :
 
         int total_count = count();
 
-        second = static_cast<PacketBatch*>(middle->next());
+        second = reinterpret_cast<PacketBatch*>(middle->next());
         middle->set_next(0);
 
         Packet* second_tail = tail();
@@ -521,7 +521,7 @@ public :
 
         int total_count = count();
 
-        second = static_cast<PacketBatch*>(middle->next());
+        second = reinterpret_cast<PacketBatch*>(middle->next());
         middle->set_next(0);
 
         Packet* second_tail = tail();
@@ -540,7 +540,7 @@ public :
     PacketBatch* pop_front() {
         if (count() == 1)
             return 0;
-        PacketBatch* poped = PacketBatch::start_head(next());
+        PacketBatch* poped = PacketBatch::start_head(first()->next());
         poped->set_count(count() -1 );
         poped->set_tail(tail());
         return poped;
@@ -556,7 +556,7 @@ public :
      * @pre The tail->next() packet must be zero
      */
     inline static PacketBatch* make_from_tailed_list(Packet* head, unsigned int size) {
-        PacketBatch* b = static_cast<PacketBatch*>(head);
+        PacketBatch* b = reinterpret_cast<PacketBatch*>(head);
         b->set_count(size);
         return b;
     }
@@ -601,16 +601,16 @@ public :
      */
     inline static PacketBatch* make_from_packet(Packet* p) {
         if (!p) return 0;
-        PacketBatch* b =  static_cast<PacketBatch*>(p);
+        PacketBatch* b = reinterpret_cast<PacketBatch*>(p);
         b->set_count(1);
-        b->set_tail(b);
-        b->set_next(0);
+        b->set_tail(p);
+        p->set_next(0);
         return b;
     }
 
 #if !CLICK_LINUXMODULE
     static PacketBatch *make_batch(unsigned char *data, uint16_t count, uint16_t *length,
-                    buffer_destructor_type destructor,
+                    Packet::buffer_destructor_type destructor,
                                     void* argument = (void*) 0, const bool clear=true) CLICK_WARN_UNUSED_RESULT;
 #endif
 
@@ -618,7 +618,7 @@ public :
      * Return the first packet of this batch
      */
     inline Packet* begin() {
-        return this;
+        return first();
     }
 
     /**
@@ -639,7 +639,7 @@ public :
     inline PacketBatch* clone_batch() {
         PacketBatch* head = 0;
         Packet* last = 0;
-        FOR_EACH_PACKET(this,p) {
+        FOR_EACH_PACKET(this, p) {
             Packet* q = p->clone();
             if (last == 0) {
                 head = start_head(q);
@@ -792,6 +792,19 @@ inline void PacketBatch::kill() {
             batch->make_tail(batch ## last, batch ## count)
 
 typedef Packet::PacketType PacketType;
+
+/**
+ * Recycle a whole batch of unshared packets of the same type
+ *
+ * @precond No packet are shared
+ */
+inline void PacketBatch::recycle_batch(bool is_data) {
+    if (is_data) {
+        WritablePacket::recycle_data_batch((WritablePacket*)this->first(),tail(),count());
+    } else {
+        WritablePacket::recycle_packet_batch((WritablePacket*)this->first(),tail(),count());
+    }
+}
 
 CLICK_ENDDECLS
 #endif

--- a/lib/packetbatch.cc
+++ b/lib/packetbatch.cc
@@ -28,18 +28,6 @@ CLICK_DECLS
 #if HAVE_BATCH
 
 # if HAVE_CLICK_PACKET_POOL
-/**
- * Recycle a whole batch of unshared packets of the same type
- *
- * @precond No packet are shared
- */
-CLICK_ALWAYS_INLINE void PacketBatch::recycle_batch(bool is_data) {
-    if (is_data) {
-        WritablePacket::recycle_data_batch(this,tail(),count());
-    } else {
-        WritablePacket::recycle_packet_batch(this,tail(),count());
-    }
-}
 
 /**
  * Recycle a whole batch, faster in most cases as it add batches to the pool in
@@ -82,7 +70,7 @@ void PacketBatch::fast_kill_nonatomic() {
  **/
 PacketBatch *
 PacketBatch::make_batch(unsigned char *data, uint16_t count, uint16_t *length,
-        buffer_destructor_type destructor, void* argument, bool clean )
+        Packet::buffer_destructor_type destructor, void* argument, bool clean)
 {
 #if CLICK_PACKET_USE_DPDK
     click_chatter("UNIMPLEMENTED");

--- a/lib/router.cc
+++ b/lib/router.cc
@@ -1714,8 +1714,9 @@ Router::store_local_handler(int eindex, Handler &to_store)
                 break;
             }
         }
-        if (l >= r)
+        if (l >= r) {
             l = _handler_first_by_name.insert(l, -1);
+        } 
         name_index = l - _handler_first_by_name.begin();
     }
 


### PR DESCRIPTION
Towards allowing batches to be either vector, LL or whatever we have to
stop casting PacketBatch to the first packet, as vectors would be
independent objects