### PR TITLE
FromDPDKDevice: add unset option to PAUSE

### DIFF
--- a/lib/dpdkdevice.cc
+++ b/lib/dpdkdevice.cc
@@ -1262,6 +1262,8 @@ FlowControlModeArg::parse(
         result = FC_TX;
     } else if (str == "none" || str == "off") {
         result = FC_NONE;
+    } else if (str == "unset") {
+        result = FC_UNSET;
     } else
         return false;
 


### PR DESCRIPTION
unset option for PAUSE was specified in the documentation but not
accepted by the parser