### PR TITLE
Fix compilation on non x86

### DIFF
--- a/configure
+++ b/configure
@@ -5880,6 +5880,7 @@ ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ex
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
+if test `uname -m` == "x86_64"; then
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -6873,6 +6874,9 @@ fi
 
 
   CFLAGS="$CFLAGS $X86_FEATURE_CFLAGS"
+
+
+fi
 
 
 

--- a/configure
+++ b/configure
@@ -5880,8 +5880,9 @@ ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ex
 ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 
-if test `uname -m` == "x86_64"; then
-ac_ext=c
+case "$target" in
+        *x86*)
+                ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
@@ -6876,7 +6877,12 @@ fi
   CFLAGS="$CFLAGS $X86_FEATURE_CFLAGS"
 
 
-fi
+        ;;
+        *)
+                # AC_MSG_WARN(["Skipping x86 tests since target is $target"])
+        ;;
+esac
+
 
 
 

--- a/configure.in
+++ b/configure.in
@@ -52,7 +52,11 @@ AC_C_INLINE
 CLICK_PROG_CXX
 AC_PROG_CXXCPP
 
+if test `uname -m` == "x86_64"; then
 AX_CHECK_X86_FEATURES
+fi
+
+
 
 AC_TRY_RUN([#include <new>
 

--- a/configure.in
+++ b/configure.in
@@ -52,9 +52,15 @@ AC_C_INLINE
 CLICK_PROG_CXX
 AC_PROG_CXXCPP
 
-if test `uname -m` == "x86_64"; then
-AX_CHECK_X86_FEATURES
-fi
+case "$target" in
+        *x86*)
+                AX_CHECK_X86_FEATURES
+        ;;
+        *)
+                # AC_MSG_WARN(["Skipping x86 tests since target is $target"])
+        ;;
+esac
+
 
 
 

--- a/include/click/glue.hh
+++ b/include/click/glue.hh
@@ -744,7 +744,7 @@ click_get_cycles()
     uint32_t xlo, xhi;
     __asm__ __volatile__ ("rdtsc" : "=a" (xlo), "=d" (xhi));
     return xlo;
-#elif CLICK_USERLEVEL && HAVE_DPDK && _RTE_CYCLES_H_
+#elif CLICK_USERLEVEL && HAVE_DPDK && defined(_RTE_CYCLES_H_)
     // On other architectures we use DPDK implementation, if available
     return rte_get_tsc_cycles();
 #elif CLICK_USERLEVEL


### PR DESCRIPTION
- When checking for AVX2 support on non x86 platform the control is skipped, otherwise it fails the configuration. Should this control be implemented differently?
- Fix a wrong compilation flag guard regarding click_get_cycles