### PR TITLE
New element: SetTCPChecksumIP6 - Calculates TCP/IPv6 checksum and sets the TCP header field.

### DIFF
--- a/elements/tcpudp/settcpchecksumip6.cc
+++ b/elements/tcpudp/settcpchecksumip6.cc
@@ -1,5 +1,5 @@
 /*
- * SetTCPChecksumIP6.{cc,hh} -- sets the TCP header checksum
+ * settcpchecksumip6.{cc,hh} -- sets the TCP header checksum for IPv6 packets
  * Robert Morris
  *
  * Copyright (c) 1999-2000 Massachusetts Institute of Technology

--- a/elements/tcpudp/settcpchecksumip6.cc
+++ b/elements/tcpudp/settcpchecksumip6.cc
@@ -22,6 +22,7 @@
 #include <click/error.hh>
 #include <clicknet/ip6.h>
 #include <clicknet/tcp.h>
+
 CLICK_DECLS
 
 SetTCPChecksumIP6::SetTCPChecksumIP6()
@@ -67,5 +68,7 @@ SetTCPChecksumIP6::simple_action(Packet *p_in)
 }
 
 CLICK_ENDDECLS
+
+ELEMENT_REQUIRES(ip6)
 EXPORT_ELEMENT(SetTCPChecksumIP6)
 ELEMENT_MT_SAFE(SetTCPChecksumIP6)

--- a/elements/tcpudp/settcpchecksumip6.cc
+++ b/elements/tcpudp/settcpchecksumip6.cc
@@ -1,0 +1,71 @@
+/*
+ * SetTCPChecksumIP6.{cc,hh} -- sets the TCP header checksum
+ * Robert Morris
+ *
+ * Copyright (c) 1999-2000 Massachusetts Institute of Technology
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
+#include <click/config.h>
+#include "settcpchecksumip6.hh"
+#include <click/glue.hh>
+#include <click/args.hh>
+#include <click/error.hh>
+#include <clicknet/ip6.h>
+#include <clicknet/tcp.h>
+CLICK_DECLS
+
+SetTCPChecksumIP6::SetTCPChecksumIP6()
+{
+}
+
+SetTCPChecksumIP6::~SetTCPChecksumIP6()
+{
+}
+
+int
+SetTCPChecksumIP6::configure(Vector<String> &conf, ErrorHandler *errh)
+{
+  return Args(conf, this, errh)
+        .complete();
+}
+
+Packet *
+SetTCPChecksumIP6::simple_action(Packet *p_in)
+{
+  WritablePacket *p = p_in->uniqueify();
+  click_ip6 *ip6 = p->ip6_header();
+  click_tcp *tcp = p->tcp_header();
+  unsigned plen = ntohs(ip6->ip6_plen);
+
+  if (!p->has_transport_header() || plen < sizeof(click_tcp)
+      || plen > (unsigned)p->transport_length())
+    goto bad;
+
+  //Only if TCP
+  if (ip6->ip6_nxt == 6) {
+      tcp->th_sum = htons(in6_fast_cksum(&ip6->ip6_src, &ip6->ip6_dst, ip6->ip6_plen, ip6->ip6_nxt, tcp->th_sum, (unsigned char *)tcp, ip6->ip6_plen));
+  } else {
+      //click_chatter("SetTCPChecksumIP6: Not a TCP/IPv6 packet");
+  }
+
+  return p;
+
+ bad:
+  click_chatter("SetTCPChecksumIP6: bad lengths");
+  p->kill();
+  return(0);
+}
+
+CLICK_ENDDECLS
+EXPORT_ELEMENT(SetTCPChecksumIP6)
+ELEMENT_MT_SAFE(SetTCPChecksumIP6)

--- a/elements/tcpudp/settcpchecksumip6.cc
+++ b/elements/tcpudp/settcpchecksumip6.cc
@@ -1,6 +1,6 @@
 /*
  * settcpchecksumip6.{cc,hh} -- sets the TCP header checksum for IPv6 packets
- * Robert Morris
+ * Kristof Kovacs, based on settcpchecksum.{cc,hh} and fastudpsrcip6.{cc,hh}
  *
  * Copyright (c) 1999-2000 Massachusetts Institute of Technology
  *

--- a/elements/tcpudp/settcpchecksumip6.hh
+++ b/elements/tcpudp/settcpchecksumip6.hh
@@ -1,0 +1,38 @@
+#ifndef CLICK_SETTCPCHECKSUMIP6_HH
+#define CLICK_SETTCPCHECKSUMIP6_HH
+#include <click/batchelement.hh>
+#include <click/glue.hh>
+CLICK_DECLS
+
+/*
+ * =c
+ * SetTCPChecksumIP6()
+ * =s tcp
+ * sets TCP/IP6 packets' checksums
+ * =d
+ * Input packets should be TCP in IP6.
+ *
+ * Calculates the TCP header's checksum and sets the checksum header field.
+ * Uses the IP6 header fields to generate the pseudo-header.
+ *
+ * Example:
+ *
+ * FromDump("dump.pcap") -> CheckIP6Header(, 14) -> SetTCPChecksumIP6 -> ToDump("dump-with-ipv6-tcp-cksum.pcap", UNBUFFERED true);
+ *
+ * =a CheckIP6Header, SetTCPChecksum
+ */
+
+class SetTCPChecksumIP6 : public SimpleElement<SetTCPChecksumIP6> { public:
+
+  SetTCPChecksumIP6() CLICK_COLD;
+  ~SetTCPChecksumIP6() CLICK_COLD;
+
+  const char *class_name() const override		{ return "SetTCPChecksumIP6"; }
+  const char *port_count() const override		{ return PORTS_1_1; }
+  int configure(Vector<String> &conf, ErrorHandler *errh) CLICK_COLD;
+
+  Packet *simple_action(Packet *);
+};
+
+CLICK_ENDDECLS
+#endif


### PR DESCRIPTION
The existing `SetTCPChecksum` element only supports TCP over IPv4. This is a new element that does the same for TCP over IPv6.

The new element's naming convention follows `FastUDPSource` and `FastUDPSourceIP6`, and is also the reason I've put this in `tcpudp/` instead of `ip6/`.

The code is based mostly on the original `SetTCPChecksum` and the way `FastUDPSourceIP6` calculates checksum for its packets.
