### PR TITLE
New flow-level element (SFMaker) added!

### DIFF
--- a/elements/flow/sfmaker.cc
+++ b/elements/flow/sfmaker.cc
@@ -1,6 +1,18 @@
 /*
- * SFMaker.{cc,hh} -- remove insults in web pages
- * Tom Barbette
+ * SFMaker.{cc,hh} -- Delay packets for a given time.
+ * 
+ * Copyright (c) 2021 Tom Barbette
+ * Copyright (c) 2021 Hamid Ghasemi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
  */
 
 #include <click/config.h>
@@ -103,8 +115,8 @@ int SFMaker::configure(Vector<String> &conf, ErrorHandler *errh)
             .read_or_set("BYPASS_AFTER_FAIL", _bypass_after_fail, 0)
             .read_or_set("MAX_BURST", _max_burst, 1024)
             .read_or_set("MAX_TX_BURST", _max_tx_burst, 32)
-	    .read_or_set("MIN_TX_BURST", _min_tx_burst, 1)
-	    .read_or_set("MAX_TX_DELAY", _max_tx_delay, 0)
+            .read_or_set("MIN_TX_BURST", _min_tx_burst, 1)
+            .read_or_set("MAX_TX_DELAY", _max_tx_delay, 0)
             .read_or_set("ALWAYSUP", _always, false)
             .read_or_set("MAX_CAP", _max_capacity, -1)
             .complete() < 0)

--- a/elements/flow/sfmaker.hh
+++ b/elements/flow/sfmaker.hh
@@ -163,7 +163,7 @@ struct SFFlow {
 
 SFMaker()
 
-=s middlebox
+=s flow
 
 Delay packets up to DELAY in the hope that bursts can be merged. Then sends packets by (eventually) merged bursts, reordered by flow priority.
 


### PR DESCRIPTION
Buffer packets up to DELAY in the hope of receiving multiple packets of the same flow.
Eventually, sends packets by merged bursts, reordered by flow priority.
The goal is increasing packets spatial locality to achieve higher performance in next steps/NFs.