### PR TITLE
Created  toexternalprocess.hh

### DIFF
--- a/elements/standard/toexternalprocess.hh
+++ b/elements/standard/toexternalprocess.hh
@@ -1,0 +1,80 @@
+// -*- c-basic-offset: 4 -*-
+#ifndef CLICK_TO_EXTERNAL_PROCESS
+#define CLICK_TO_EXTERNAL_PROCESS
+#include <click/element.hh>
+#include <click/atomic.hh>
+#include <click/args.hh>
+
+#include <sys/types.h>
+#include <sys/select.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <stdio.h>
+#include <string.h>
+#include <thread>
+#include <mutex>
+
+CLICK_DECLS
+
+#define INPUT_INTERFACE 0
+#define OUTPUT_INTERFACE  0
+
+
+
+class ToExternalProcess : public Element { public:
+    ToExternalProcess() CLICK_COLD;
+
+    
+
+    // overriding of the basic methods used by the FastClick infrastructure to catch the object definition
+    const char *class_name() const override	{ return "ToExternalProcess"; }
+    const char *port_count() const override	{ return "1/1"; }
+    const char *processing() const override	{ return PUSH; }
+
+    // method to initialize the object (called by the framework)
+    int configure(Vector<String> &, ErrorHandler *) CLICK_COLD;
+
+    
+    // destructor, this method is used to free some variable allocated
+    ~ToExternalProcess();
+
+    void push(int, Packet *);
+    private:
+    //identification number of a shared memory allocated by another process,
+    //this object not create a shared memory
+    int _shared_memory_id; 
+    // pointer referencing shared memory
+    char* shared_memory;
+    // maximum size of raw frame, the default value is equal to Ethernet maximum package size
+    int _package_size =1522; 
+    // the max number of element who could be putted in the buffer (when it  is full it will be overwrited)
+    int _buffer_size; 
+    // number of pages the buffer is divided into
+    int _number_of_pages;     
+    // semaphore identifier, used to signal to the other process that a page is ready to be computed
+    int _semaphore_id;
+    // this attribute tells if the data have to be sent in full or only the header 
+    bool _entire_packet_copy;
+    // this method sets the semaphore
+    void sendToProcess(const  unsigned char* p_data,unsigned short p_size);
+    // header size
+    unsigned short _header_size;
+    // just a vector of \0 used to fill the memory when the frame is smaller than max package size
+    char* empty_data;
+    // calculated value, number of row in page
+    uint _num_now_in_page=0;
+    // mutex used protect the variable _wirite_index increments
+    std::mutex _mux;
+    // the absolute row number who will be used to save the received frame
+    uint _num_actual_row=0;
+    //this method sets the semaphore
+    bool unlockSemaphor();
+};
+
+CLICK_ENDDECLS
+#endif


### PR DESCRIPTION
The Element ToExternalProcess is a not batch element that push data in a shared memory initialized by another process who lives out of FastClick. The referiment to the shared memory must be passed as a parameter. This Element consider the memory as diveided in virtual pages, each times it fill a virtual page it sets a shared semaphore.
This class could be used to implements cybersecurity tools as WAF, NAC, IPS, IDS, or tools who neesd to interact with external data and functions.
When the memory is full, this element go back to the first memory byte and rewrites the old contens. The external process should works the content before overwriting occurs.
The parameters are:
-SHARED_MEMORY_ID : positional mandatory parameter, it is the id of shared memory initialized by the external process
-SEMAPHORE_ID: positional mandatory parameter, it is the id a shared semaphore who will be set by the the element when the virtual page will be filled
-BUFFER_SIZE: positional parameter, it is an integer who specify how many rows the buffer contains (a row is a memory space sufficient to write a package, defined in the PACKAGE_SIZE parameter)
-NUMBER_OF_PAGES: positional parameter, it is an integer who specifies how many pages the buffer is divided into
-ENTEER_PACKET : positional boolean parameter, if it is "false" the Element will copy the first 32 bytes in the shared memory, else all data ll be copied.
-PACKAGE_SIZE :  positional parameter, it is the size of a packet, if the Element will receive Ethernet frames this should take the value 1522

Configuration Example:
tep :: ToExternalProcess(SHARED_MEMORY_ID 123, SEMAPHORE_ID 255, BUFFER_SIZE 1024, NUMBER_OF_PAGES 128, ENTEER_PACKET 1, PACKAGE_SIZE 1522);