### PR TITLE
remove verbosity from default DPDK args

### DIFF
--- a/userlevel/click.cc
+++ b/userlevel/click.cc
@@ -437,8 +437,6 @@ main(int argc, char **argv)
 
         args.dpdk_arg.push_back((char*)(new String("512M"))->c_str());
 
-        args.dpdk_arg.push_back((char*)(new String("-v"))->c_str());
-
         args.dpdk_arg.push_back((char*)(new String("--log-level=debug"))->c_str());
 
         args.dpdk_arg.push_back((char*)(new String("--"))->c_str());


### PR DESCRIPTION
Signed-off-by: Georgios Katsikas <gkatsikas@ubitech.eu>