### PR TITLE
[Fix build without DPDK] Add DPDK dependency to DeviceBalancer

### DIFF
--- a/elements/userlevel/devicebalancer.cc
+++ b/elements/userlevel/devicebalancer.cc
@@ -544,5 +544,5 @@ DeviceBalancer::add_handlers()
 
 
 CLICK_ENDDECLS
-ELEMENT_REQUIRES(load userlevel rsspp flow)
+ELEMENT_REQUIRES(load userlevel rsspp flow dpdk)
 EXPORT_ELEMENT(DeviceBalancer)


### PR DESCRIPTION
Add DPDK dependency to DeviceBalancer because it requires `rte_flow.h` which is only available with DPDK. This modification repairs the build of fastclick without DPDK.