### PR TITLE
Add basic BIER elements

### DIFF
--- a/DISTFILES
+++ b/DISTFILES
@@ -388,7 +388,7 @@ archive.hh
 args.hh
 array_memory.hh
 atomic.hh
-biertable.cc
+biertable.hh
 bighashmap.cc
 bighashmap.hh
 bighashmap_arena.hh

--- a/DISTFILES
+++ b/DISTFILES
@@ -388,6 +388,7 @@ archive.hh
 args.hh
 array_memory.hh
 atomic.hh
+biertable.cc
 bighashmap.cc
 bighashmap.hh
 bighashmap_arena.hh
@@ -474,6 +475,7 @@ storage.hh
 threadsched.hh
 
 ./include/clicknet:
+bier.h
 dhcp.h
 ether.h
 fddi.h
@@ -493,6 +495,7 @@ wifi.h
 archive.cc
 args.cc
 atomic.cc
+biertable.cc
 bighashmap_arena.cc
 bitvector.cc
 clp.c

--- a/configure.in
+++ b/configure.in
@@ -679,6 +679,7 @@ fi])
 ELEMENTS_ARG_ENABLE(analysis, [include elements for network analysis], yes)
 ELEMENTS_ARG_ENABLE(app, [include application-level elements], yes)
 ELEMENTS_ARG_ENABLE(aqm, [include active queue management elements], yes)
+ELEMENTS_ARG_ENABLE(bier, [include BIER elements], NO)
 ELEMENTS_ARG_ENABLE(ethernet, [include Ethernet elements], yes)
 ELEMENTS_ARG_ENABLE(etherswitch, [include Ethernet switch elements], NO)
 ELEMENTS_ARG_ENABLE(flow, [include Enable flow system and elements], NO, enable_flow=yes, [ -a "x$enable_batch" = xyes ] )
@@ -1082,6 +1083,11 @@ if test "x$enable_ip6" = xyes; then
     EXTRA_DRIVER_OBJS="ip6address.o ip6flowid.o ip6table.o $EXTRA_DRIVER_OBJS"
     EXTRA_TOOL_OBJS="ip6address.o $EXTRA_TOOL_OBJS"
 fi
+
+if test "x$enable_bier" = xyes; then
+    EXTRA_DRIVER_OBJS="biertable.o $EXTRA_DRIVER_OBJS"
+fi
+
 AC_SUBST(EXTRA_DRIVER_OBJS)
 AC_SUBST(EXTRA_TOOL_OBJS)
 

--- a/elements/bier/bierroutetable.cc
+++ b/elements/bier/bierroutetable.cc
@@ -35,6 +35,10 @@ int BierRouteTable::add_route(bfrid, IP6Address, bitstring, IP6Address, int, Str
   return errh->error("cannot add routes to this routing table");
 }
 
+int BierRouteTable::del_route(bfrid, ErrorHandler *errh) {
+  return errh->error("cannot del routes to this routing table");
+}
+
 String BierRouteTable::dump_routes() {
   return String();
 }
@@ -82,6 +86,20 @@ int BierRouteTable::add_route_handler(const String &conf, Element *e, void *, Er
 String BierRouteTable::table_handler(Element *e, void *) {
   BierRouteTable *r = static_cast<BierRouteTable *>(e);
   return r->dump_routes();
+}
+
+int BierRouteTable::del_route_handler(const String &conf, Element *e, void *, ErrorHandler *errh) {
+  BierRouteTable *r = static_cast<BierRouteTable *>(e);
+  Vector<String> words;
+  cp_spacevec(conf, words);
+
+  bfrid bfrid;
+
+  if (Args(words, r, errh).read_mp("BFR-ID", bfrid).complete() < 0)
+    return -1;
+
+  return r->del_route(bfrid, errh);
+
 }
 
 CLICK_ENDDECLS

--- a/elements/bier/bierroutetable.cc
+++ b/elements/bier/bierroutetable.cc
@@ -1,5 +1,5 @@
 /*
- * bierroutetable.{cc,hh} -- element encapsulates packet in IP6 SRv6 header
+ * bierroutetable.{cc,hh} -- implement handlers for BIFT element
  * Nicolas Rybowski
  *
  * Copyright (c) 2024 UCLouvain

--- a/elements/bier/bierroutetable.cc
+++ b/elements/bier/bierroutetable.cc
@@ -13,7 +13,7 @@ void* BierRouteTable::cast(const char *name) {
     return Element::cast(name);
 }
 
-int BierRouteTable::add_route(bfrid, bitstring, IP6Address, ErrorHandler *errh) {
+int BierRouteTable::add_route(bfrid, bitstring, IP6Address, int, String, ErrorHandler *errh) {
   return errh->error("cannot add routes to this routing table");
 }
 
@@ -29,17 +29,22 @@ int BierRouteTable::add_route_handler(const String &conf, Element *e, void *, Er
   bfrid dst;
   bitstring fbm;
   IP6Address nxt;
+  int output;
+  String ifname;
 
   int ok;
 
+  // TODO: read_all for BFRID and define dst as an array for route addition batching
   ok = Args(words, r, errh)
        .read_mp("BFRID", dst)
        .read_mp("BITSTRING", fbm)
        .read_mp("NXT", nxt)
+       .read_mp("IFIDX", output)
+       .read_mp("IFNAME", ifname)
        .complete();
 
   if (ok >= 0)
-    ok = r->add_route(dst, fbm, nxt, errh);
+    ok = r->add_route(dst, fbm, nxt, output, ifname, errh);
 
   return ok;
 }

--- a/elements/bier/bierroutetable.cc
+++ b/elements/bier/bierroutetable.cc
@@ -21,6 +21,7 @@
 #include <click/error.hh>
 #include <click/glue.hh>
 #include <click/ip6address.hh>
+#include <click/ipaddress.hh>
 CLICK_DECLS
 
 void* BierRouteTable::cast(const char *name) {
@@ -30,7 +31,7 @@ void* BierRouteTable::cast(const char *name) {
     return Element::cast(name);
 }
 
-int BierRouteTable::add_route(bfrid, bitstring, IP6Address, int, String, ErrorHandler *errh) {
+int BierRouteTable::add_route(bfrid, IP6Address, bitstring, IP6Address, int, String, ErrorHandler *errh) {
   return errh->error("cannot add routes to this routing table");
 }
 
@@ -44,6 +45,7 @@ int BierRouteTable::add_route_handler(const String &conf, Element *e, void *, Er
   cp_spacevec(conf, words);
 
   bfrid dst;
+  IP6Address bfr_prefix;
   bitstring fbm;
   IP6Address nxt;
   int output;
@@ -54,6 +56,7 @@ int BierRouteTable::add_route_handler(const String &conf, Element *e, void *, Er
   // TODO: read_all for BFRID and define dst as an array for route addition batching
   ok = Args(words, r, errh)
        .read_mp("BFRID", dst)
+       .read_mp("BFRPREFIX", bfr_prefix)
        .read_mp("BITSTRING", fbm)
        .read_mp("NXT", nxt)
        .read_mp("IFIDX", output)
@@ -61,7 +64,7 @@ int BierRouteTable::add_route_handler(const String &conf, Element *e, void *, Er
        .complete();
 
   if (ok >= 0)
-    ok = r->add_route(dst, fbm, nxt, output, ifname, errh);
+    ok = r->add_route(dst, bfr_prefix, fbm, nxt, output, ifname, errh);
 
   return ok;
 }

--- a/elements/bier/bierroutetable.cc
+++ b/elements/bier/bierroutetable.cc
@@ -1,3 +1,20 @@
+/*
+ * bierroutetable.{cc,hh} -- element encapsulates packet in IP6 SRv6 header
+ * Nicolas Rybowski
+ *
+ * Copyright (c) 2024 UCLouvain
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
 #include <click/config.h>
 #include "bierroutetable.hh"
 #include <click/args.hh>

--- a/elements/bier/bierroutetable.cc
+++ b/elements/bier/bierroutetable.cc
@@ -1,0 +1,53 @@
+#include <click/config.h>
+#include "bierroutetable.hh"
+#include <click/args.hh>
+#include <click/error.hh>
+#include <click/glue.hh>
+#include <click/ip6address.hh>
+CLICK_DECLS
+
+void* BierRouteTable::cast(const char *name) {
+  if (strcmp(name, "BierRouteTable") == 0)
+    return (void*) this;
+  else
+    return Element::cast(name);
+}
+
+int BierRouteTable::add_route(bfrid, bitstring, IP6Address, ErrorHandler *errh) {
+  return errh->error("cannot add routes to this routing table");
+}
+
+String BierRouteTable::dump_routes() {
+  return String();
+}
+
+int BierRouteTable::add_route_handler(const String &conf, Element *e, void *, ErrorHandler *errh) {
+  BierRouteTable *r = static_cast<BierRouteTable *>(e);
+  Vector<String> words;
+  cp_spacevec(conf, words);
+
+  bfrid dst;
+  bitstring fbm;
+  IP6Address nxt;
+
+  int ok;
+
+  ok = Args(words, r, errh)
+       .read_mp("BFRID", dst)
+       .read_mp("BITSTRING", fbm)
+       .read_mp("NXT", nxt)
+       .complete();
+
+  if (ok >= 0)
+    ok = r->add_route(dst, fbm, nxt, errh);
+
+  return ok;
+}
+
+String BierRouteTable::table_handler(Element *e, void *) {
+  BierRouteTable *r = static_cast<BierRouteTable *>(e);
+  return r->dump_routes();
+}
+
+CLICK_ENDDECLS
+ELEMENT_PROVIDES(BierRouteTable)

--- a/elements/bier/bierroutetable.hh
+++ b/elements/bier/bierroutetable.hh
@@ -1,0 +1,21 @@
+#ifndef CLICK_BIERROUTETABLE_HH
+#define CLICK_BIERROUTETABLE_HH
+#include <click/glue.hh>
+#include <click/batchelement.hh>
+#include <click/ip6address.hh>
+#include <clicknet/bier.h>
+CLICK_DECLS
+
+class BierRouteTable : public BatchElement {
+  public:
+    void* cast(const char*) override;
+
+    virtual int add_route(bfrid, bitstring, IP6Address, ErrorHandler*);
+    virtual String dump_routes();
+
+    static int add_route_handler(const String&, Element*, void*, ErrorHandler*);
+    static String table_handler(Element*, void*);
+};
+
+CLICK_ENDDECLS
+#endif

--- a/elements/bier/bierroutetable.hh
+++ b/elements/bier/bierroutetable.hh
@@ -11,11 +11,14 @@ class BierRouteTable : public BatchElement {
     void* cast(const char*) override;
     const char *port_count() const override { return PORTS_0_0; }
 
-    virtual int add_route(bfrid, bitstring, IP6Address, ErrorHandler*);
+    virtual int add_route(bfrid, bitstring, IP6Address, int, String, ErrorHandler*);
     virtual String dump_routes();
 
     static int add_route_handler(const String&, Element*, void*, ErrorHandler*);
     static String table_handler(Element*, void*);
+
+  private:
+    uint16_t _bfr_id;
 };
 
 CLICK_ENDDECLS

--- a/elements/bier/bierroutetable.hh
+++ b/elements/bier/bierroutetable.hh
@@ -11,7 +11,7 @@ class BierRouteTable : public BatchElement {
     void* cast(const char*) override;
     const char *port_count() const override { return PORTS_0_0; }
 
-    virtual int add_route(bfrid, bitstring, IP6Address, int, String, ErrorHandler*);
+    virtual int add_route(bfrid, IP6Address, bitstring, IP6Address, int, String, ErrorHandler*);
     virtual String dump_routes();
 
     static int add_route_handler(const String&, Element*, void*, ErrorHandler*);

--- a/elements/bier/bierroutetable.hh
+++ b/elements/bier/bierroutetable.hh
@@ -9,6 +9,7 @@ CLICK_DECLS
 class BierRouteTable : public BatchElement {
   public:
     void* cast(const char*) override;
+    const char *port_count() const override { return PORTS_0_0; }
 
     virtual int add_route(bfrid, bitstring, IP6Address, ErrorHandler*);
     virtual String dump_routes();

--- a/elements/bier/bierroutetable.hh
+++ b/elements/bier/bierroutetable.hh
@@ -12,9 +12,11 @@ class BierRouteTable : public BatchElement {
     const char *port_count() const override { return PORTS_0_0; }
 
     virtual int add_route(bfrid, IP6Address, bitstring, IP6Address, int, String, ErrorHandler*);
+    virtual int del_route(bfrid, ErrorHandler*);
     virtual String dump_routes();
 
     static int add_route_handler(const String&, Element*, void*, ErrorHandler*);
+    static int del_route_handler(const String&, Element*, void*, ErrorHandler*);
     static String table_handler(Element*, void*);
 
   private:

--- a/elements/bier/checkbierheader.cc
+++ b/elements/bier/checkbierheader.cc
@@ -1,3 +1,20 @@
+/*
+ * checkbierheader.{cc,hh} -- element encapsulates packet in IP6 SRv6 header
+ * Nicolas Rybowski
+ *
+ * Copyright (c) 2024 UCLouvain
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
 #include <click/config.h>
 #include "checkbierheader.hh"
 #include <click/element.hh>

--- a/elements/bier/checkbierheader.cc
+++ b/elements/bier/checkbierheader.cc
@@ -1,0 +1,84 @@
+#include <click/config.h>
+#include "checkbierheader.hh"
+#include <click/element.hh>
+#include <clicknet/ip6.h>
+#include <click/packet.hh>
+#include <clicknet/bier.h>
+#include <click/args.hh>
+#include <click/error.hh>
+#include <click/standard/alignmentinfo.hh>
+
+CLICK_DECLS
+
+CheckBIERHeader::CheckBIERHeader() : _offset(0) {
+  _drops = 0;
+}
+
+CheckBIERHeader::~CheckBIERHeader() {}
+
+int CheckBIERHeader::configure(Vector<String> &conf,ErrorHandler *errh) {
+  if (Args(conf, this, errh)
+      .read_p("OFFSET", _offset)
+      .complete() < 0
+  )
+    return -1;
+  return 0;
+}
+
+void CheckBIERHeader::drop(Packet *p) {
+  if (_drops == 0) {
+    click_chatter("BIER header check failed");
+  }
+  _drops++;
+
+  if (noutputs() == 2) {
+    output(1).push(p);
+  } else {
+    p->kill();
+  }
+  
+}
+
+Packet *CheckBIERHeader::simple_action(Packet *p) {
+  const click_bier *bier;
+  unsigned plen;
+  // const click_ip6 *iph = (click_ip6*) p->ip_header();
+  // if (iph->ip6_nxt != IP6PROTO_BIERIN6) {
+    // click_chatter("Not a BIERin6 packet");
+    // goto drop;
+  // }
+
+  bier = reinterpret_cast<const click_bier*>(p->data());
+  plen = p->length();
+
+  if((int)plen < (int)sizeof(click_bier)) {
+    click_chatter("BIERin6 header too small");
+    goto drop;
+  }
+  
+  return(p);
+
+  drop:
+    drop(p);
+    return 0;
+}
+
+String CheckBIERHeader::read_handler(Element *e, void *thunk) {
+  CheckBIERHeader *c = reinterpret_cast<CheckBIERHeader *>(e);
+  switch (reinterpret_cast<uintptr_t>(thunk)) {
+    case h_drops: {
+        return String(c->_drops);
+    }
+    defaut: {
+      return String();
+    }
+  }
+}
+
+void CheckBIERHeader::add_handlers() {
+  add_read_handler("drops", read_handler, h_drops);
+}
+
+CLICK_ENDDECLS
+EXPORT_ELEMENT(CheckBIERHeader)
+ELEMENT_MT_SAFE(CheckBIERHeader)

--- a/elements/bier/checkbierheader.cc
+++ b/elements/bier/checkbierheader.cc
@@ -42,11 +42,6 @@ void CheckBIERHeader::drop(Packet *p) {
 Packet *CheckBIERHeader::simple_action(Packet *p) {
   const click_bier *bier;
   unsigned plen;
-  // const click_ip6 *iph = (click_ip6*) p->ip_header();
-  // if (iph->ip6_nxt != IP6PROTO_BIERIN6) {
-    // click_chatter("Not a BIERin6 packet");
-    // goto drop;
-  // }
 
   bier = reinterpret_cast<const click_bier*>(p->data());
   plen = p->length();
@@ -55,6 +50,10 @@ Packet *CheckBIERHeader::simple_action(Packet *p) {
     click_chatter("BIERin6 header too small");
     goto drop;
   }
+
+  // TODO: check that BSL is different from 0
+
+  // TODO: check that BS is not NULL
   
   return(p);
 

--- a/elements/bier/checkbierheader.cc
+++ b/elements/bier/checkbierheader.cc
@@ -1,5 +1,5 @@
 /*
- * checkbierheader.{cc,hh} -- element encapsulates packet in IP6 SRv6 header
+ * checkbierheader.{cc,hh} -- checks BIER header for correctness
  * Nicolas Rybowski
  *
  * Copyright (c) 2024 UCLouvain

--- a/elements/bier/checkbierheader.hh
+++ b/elements/bier/checkbierheader.hh
@@ -1,0 +1,58 @@
+#ifndef CLICK_CHECKBIERHEADER_HH
+#define CLICK_CHECKBIERHEADER_HH
+#include <click/batchelement.hh>
+#include <click/confparse.hh>
+#include <clicknet/bier.h>
+CLICK_DECLS
+
+/*
+ * =c
+ * CheckBIERHeader([OFFSET])
+ * =s ip6
+ *
+ * =d
+ * 
+ * Expects BIER packets as input starting at OFFSET bytes. Default OFFSET is zero.
+ * Checks that thet packet's length is reasonable.
+ * Pushes invalid or non BIERin6 packets out on output 1, unless output 1 was unused; if so,
+ * drop the packets.
+ *
+ * Keyword arguments are:
+ *
+ * =over 8
+ *
+ * =item OFFSET
+ *
+ * Unsigned integer. Byte position at which the BIER header begins. Default is 0.
+ *
+ * =back
+ *
+ */
+
+class CheckBIERHeader : public SimpleElement<CheckBIERHeader> {
+  public:
+     CheckBIERHeader();
+     ~CheckBIERHeader();
+
+     const char *class_name() const override { return "CheckBIERHeader"; }
+     const char *port_count() const override { return PORTS_1_1X2; }
+     const char *processing() const override { return PROCESSING_A_AH; }
+
+     int configure(Vector<String> &, ErrorHandler *) CLICK_COLD;
+     void add_handlers() CLICK_COLD;
+
+     Packet *simple_action(Packet *p);
+
+  private:
+    int _offset;
+    atomic_uint64_t _drops;
+
+    enum {h_drops};
+    
+    void drop(Packet *p);
+    static String read_handler(Element *e, void *thunk) CLICK_COLD;
+  
+};
+
+CLICK_ENDDECLS
+#endif

--- a/elements/bier/checkbierheader.hh
+++ b/elements/bier/checkbierheader.hh
@@ -8,13 +8,13 @@ CLICK_DECLS
 /*
  * =c
  * CheckBIERHeader([OFFSET])
- * =s ip6
+ * =s bier
  *
  * =d
  * 
  * Expects BIER packets as input starting at OFFSET bytes. Default OFFSET is zero.
  * Checks that thet packet's length is reasonable.
- * Pushes invalid or non BIERin6 packets out on output 1, unless output 1 was unused; if so,
+ * Pushes invalid or non BIER packets out on output 1, unless output 1 was unused; if so,
  * drop the packets.
  *
  * Keyword arguments are:

--- a/elements/bier/lookupbiertable.cc
+++ b/elements/bier/lookupbiertable.cc
@@ -1,3 +1,20 @@
+/*
+ * lookupbiertable.{cc,hh} -- element encapsulates packet in IP6 SRv6 header
+ * Nicolas Rybowski
+ *
+ * Copyright (c) 2024 UCLouvain
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
 #include <click/config.h>
 #include <click/args.hh>
 #include <click/glue.hh>

--- a/elements/bier/lookupbiertable.cc
+++ b/elements/bier/lookupbiertable.cc
@@ -177,9 +177,14 @@ int LookupBierTable::add_route(bfrid dst, IP6Address bfr_prefix, bitstring fbm, 
   return 0;
 }
 
+int LookupBierTable::del_route(bfrid bfrid, ErrorHandler *errh) {
+  _t.del(bfrid);
+  return 0;
+}
+
 void LookupBierTable::add_handlers() {
   add_write_handler("add", add_route_handler, 0);
-  // TODO: implement route deletion
+  add_write_handler("del", del_route_handler, 0);
   add_read_handler("table", table_handler, 0);
 }
 

--- a/elements/bier/lookupbiertable.cc
+++ b/elements/bier/lookupbiertable.cc
@@ -147,7 +147,8 @@ int LookupBierTable::classify(Packet *p_in) {
       click_ip6 *ip6 = reinterpret_cast<click_ip6*>(p2->data());
       ip6->ip6_dst = bfr_prefix;
       click_bier *bier = reinterpret_cast<click_bier*>(p2->data()+sizeof(click_ip6));
-      memcpy(bier->bitstring, (bs & fbm).data_words(), bsl/(sizeof(Bitvector::word_type)*8));
+      memcpy(bier_cpy->bitstring, (bs & fbm).data_words(), bsl/8);
+      bier->bier_ttl -= 1;
       bier->encode();
       
       // ifname is ensured to be in _ifaces because of the check upon route addition.

--- a/elements/bier/lookupbiertable.cc
+++ b/elements/bier/lookupbiertable.cc
@@ -1,22 +1,164 @@
 #include <click/config.h>
+#include <click/args.hh>
+#include <click/glue.hh>
+#include <click/packet.hh>
+#include <click/straccum.hh>
+#include <clicknet/bier.h>
+#include <clicknet/ip6.h>
+#include <cstdint>
+#include <click/error.hh>
 #include "lookupbiertable.hh"
-#include "bierroutetable.hh"
 CLICK_DECLS
 
-LookupBierTable::LookupBierTable() {}
+LookupBierTable::LookupBierTable() : _bfr_id(0) {
+  _drops = 0;
+}
 LookupBierTable::~LookupBierTable() {}
 
-int LookupBierTable::classify(Packet *p) { return 0; }
+int LookupBierTable::configure(Vector<String> &conf,ErrorHandler *errh) {
+  Vector<String> ifaces;
 
-int LookupBierTable::add_route(bfrid dst, bitstring fbm, IP6Address nxt, ErrorHandler *errh) {
-  // if (output < 0 && output >= noutputs())
-  // return errh->error("port number out of range");
-  _t.add(dst, fbm, nxt);
+  if (Args(conf, this, errh)
+      .read("BIFT_ID", _bift_id)
+      .read("BFR_ID", _bfr_id)
+      .read_all("IFACE", ifaces)
+      .complete() < 0
+  )
+    return -1;
+
+  for (int i=0; i<ifaces.size(); i++) {
+    Vector<String> iface = ifaces[i].split(':');
+    _ifaces.insert(iface[0], atoi(iface[1].c_str()));
+  }
+
+  if (noutputs() < 2) {
+    click_chatter("LookupBierTable requires at least two outputs:\n- 0 for dropped packets\n- 1 for packets destined to localhost");
+    return -1;
+  }
+  
+  return 0;
+}
+
+void LookupBierTable::drop(Packet *p) {
+  if (noutputs() >= 2)
+    output(0).push(p);
+  else
+    p->kill();
+}
+
+/** 
+* 0 -> drop
+* 1 -> loopback
+* 2.. -> interfaces
+*/
+int LookupBierTable::classify(Packet *p_in) {
+
+  unsigned short k = 0;
+  uint16_t bift_id;
+  IP6Address nxt;
+  bitstring fbm;
+  bfrid bfr_id;
+  int index;
+  Packet *dup;
+  size_t bsl;
+  String ifname;
+
+  WritablePacket *p = (WritablePacket *)p_in->uniqueify();
+  click_ip6 *ip6 = reinterpret_cast<click_ip6*>(p->data());
+  click_bier *bier = reinterpret_cast<click_bier *>(p->data()+sizeof(click_ip6));
+  bier->decode();
+  bsl = click_bier_expand_bsl(bier);
+  bitstring bs(bier->bitstring, bsl);
+ 
+  click_chatter(
+    "bift_id %05x\ntc %02x\ns %x\nttl %02x\nnibble %02x\nver %x\nbsl %x\nentropy %02x\noam %x\nrsv %x\ndscp %x\nproto %x\nbfrid %02x\nbs %s",
+    bier->bier_bift_id,
+    bier->bier_tc,
+    bier->bier_s,
+    bier->bier_ttl,
+    bier->bier_nibble,
+    bier->bier_version,
+    bier->bier_bsl,
+    bier->bier_entropy,
+    bier->bier_oam,
+    bier->bier_rsv,
+    bier->bier_dscp,
+    bier->bier_proto,
+    bier->bier_bfr_id,
+    bs.unparse().c_str()
+  );
+
+  // Sanity check: the BIFT ID specified in the BIER packet corresponds to the current BIFT. 
+  if (bier->bier_bift_id != _bift_id) return -1;
+
+  // RFC8279 Section 6.5 Step 2
+  while (bs != 0) {
+    click_chatter("bs %s", bs.unparse().c_str());
+
+    // RFC8279 Section 6.5 Step 3: Find first node in bitstring
+    while (bs[k] == 0) k++;
+    bfr_id = k+1;
+    click_chatter("found bdr_id %u", bfr_id);
+
+    // RFC8279 Section 6.5 Step 4: Deliver packet to overlay
+    if (bfr_id == _bfr_id){
+      // Remove local bit
+      bs[k] = 0;
+
+      // Strip IPv6 header and BIER header, then push to loopback
+      Packet *p2 = p->duplicate();
+      p2->pull(40+click_bier_hdr_len(bier));
+      output(1).push(p2); 
+      continue;
+    }
+
+    // RFC8279 Section 6.5 Step 5
+    // There is no need to select the correct BIFT as this element represents a single BIFT, and
+    // the BIER packet's BIFT ID already has been verified earlier.
+
+    // RFC8279 Section 6.5 Step 6
+    if (_t.lookup(bfr_id, fbm, nxt, index, ifname)) {
+      fbm.resize(bsl);
+  
+      // RFC8279 Section 6.5 Step 7
+      WritablePacket *p2 = p->duplicate();
+      click_ip6 *ip6 = reinterpret_cast<click_ip6*>(p2->data());
+      ip6->ip6_dst = nxt;
+      click_bier *bier_dup = reinterpret_cast<click_bier*>(p2->data()+sizeof(click_ip6));
+      memcpy(bier_dup->bitstring, (bs & fbm).data_words(), bsl/(sizeof(Bitvector::word_type)*8));
+      bier_dup->encode();
+      // TODO: Add ethernet header to the packet
+      
+      // ifname is ensured to be in _ifaces because of the check upon route addition.
+      output(_ifaces[ifname]).push(p2->duplicate());
+
+      // RFC8279 Section 6.5 Step 8
+      bs &= ~fbm;
+    } else {
+      click_chatter("Nexthop for BFR-ID %u not found in BIFT. Ignoring.", bfr_id);
+      // Skip BFR
+      bs[k] = 0;
+    }
+  }
+
+  return -1;
+
+  drop:
+    drop(p_in);
+    return -1;
+}
+
+int LookupBierTable::add_route(bfrid dst, bitstring fbm, IP6Address nxt, int output, String ifname, ErrorHandler *errh) {
+  // if (output < 0 || output >= noutputs())
+    // return errh->error("port number <%u> out of range", output);
+  // TODO: Check if ifname is in table
+  _t.add(dst, fbm, nxt, output, ifname);
   return 0;
 }
 
 void LookupBierTable::add_handlers() {
   add_write_handler("add", add_route_handler, 0);
+  // TODO: implement route deletion
   add_read_handler("table", table_handler, 0);
 }
 

--- a/elements/bier/lookupbiertable.cc
+++ b/elements/bier/lookupbiertable.cc
@@ -1,5 +1,5 @@
 /*
- * lookupbiertable.{cc,hh} -- element encapsulates packet in IP6 SRv6 header
+ * lookupbiertable.{cc,hh} -- duplicates and forwards BIER packets
  * Nicolas Rybowski
  *
  * Copyright (c) 2024 UCLouvain
@@ -170,9 +170,12 @@ int LookupBierTable::classify(Packet *p_in) {
 }
 
 int LookupBierTable::add_route(bfrid dst, IP6Address bfr_prefix, bitstring fbm, IP6Address nxt, int output, String ifname, ErrorHandler *errh) {
-  // if (output < 0 || output >= noutputs())
-    // return errh->error("port number <%u> out of range", output);
-  // TODO: Check if ifname is in table
+  if (output < 0 || output >= noutputs())
+    return errh->error("port number <%u> out of range", output);
+
+  if (!_ifaces.find(ifname))
+    return errh->error("unknown interface <%s>", ifname.c_str());
+
   _t.add(dst, bfr_prefix, fbm, nxt, output, ifname);
   return 0;
 }

--- a/elements/bier/lookupbiertable.cc
+++ b/elements/bier/lookupbiertable.cc
@@ -88,24 +88,6 @@ int LookupBierTable::classify(Packet *p_in) {
   bsl = click_bier_expand_bsl(bier);
   bitstring bs(bier->bitstring, bsl);
  
-  click_chatter(
-    "bift_id %05x\ntc %02x\ns %x\nttl %02x\nnibble %02x\nver %x\nbsl %x\nentropy %02x\noam %x\nrsv %x\ndscp %x\nproto %x\nbfrid %02x\nbs %s",
-    bier->bier_bift_id,
-    bier->bier_tc,
-    bier->bier_s,
-    bier->bier_ttl,
-    bier->bier_nibble,
-    bier->bier_version,
-    bier->bier_bsl,
-    bier->bier_entropy,
-    bier->bier_oam,
-    bier->bier_rsv,
-    bier->bier_dscp,
-    bier->bier_proto,
-    bier->bier_bfr_id,
-    bs.unparse().c_str()
-  );
-
   // Sanity check: the BIFT ID specified in the BIER packet corresponds to the current BIFT. 
   if (bier->bier_bift_id != _bift_id) {
     click_chatter("Unknown BIFT-ID %x. Ignoring.", bier->bier_bift_id);
@@ -114,12 +96,10 @@ int LookupBierTable::classify(Packet *p_in) {
 
   // RFC8279 Section 6.5 Step 2
   while (bs != 0) {
-    click_chatter("bs %s", bs.unparse().c_str());
 
     // RFC8279 Section 6.5 Step 3: Find first node in bitstring
     while (bs[k] == 0) k++;
     bfr_id = k+1;
-    click_chatter("found bdr_id %u", bfr_id);
 
     // RFC8279 Section 6.5 Step 4: Deliver packet to overlay
     if (bfr_id == _bfr_id){
@@ -147,7 +127,7 @@ int LookupBierTable::classify(Packet *p_in) {
       click_ip6 *ip6 = reinterpret_cast<click_ip6*>(p2->data());
       ip6->ip6_dst = bfr_prefix;
       click_bier *bier = reinterpret_cast<click_bier*>(p2->data()+sizeof(click_ip6));
-      memcpy(bier_cpy->bitstring, (bs & fbm).data_words(), bsl/8);
+      memcpy(bier->bitstring, (bs & fbm).data_words(), bsl/8);
       bier->bier_ttl -= 1;
       bier->encode();
       

--- a/elements/bier/lookupbiertable.cc
+++ b/elements/bier/lookupbiertable.cc
@@ -151,8 +151,9 @@ int LookupBierTable::classify(Packet *p_in) {
 }
 
 int LookupBierTable::add_route(bfrid dst, IP6Address bfr_prefix, bitstring fbm, IP6Address nxt, int output, String ifname, ErrorHandler *errh) {
-  if (output < 0 || output >= noutputs())
-    return errh->error("port number <%u> out of range", output);
+  // FIXME: Output corresponds to kernel interface id and not to a FastClick output
+  // if (output < 0 || output >= noutputs())
+  //   return errh->error("port number <%u> out of range", output);
 
   if (!_ifaces.find(ifname))
     return errh->error("unknown interface <%s>", ifname.c_str());

--- a/elements/bier/lookupbiertable.cc
+++ b/elements/bier/lookupbiertable.cc
@@ -1,0 +1,25 @@
+#include <click/config.h>
+#include "lookupbiertable.hh"
+#include "bierroutetable.hh"
+CLICK_DECLS
+
+LookupBierTable::LookupBierTable() {}
+LookupBierTable::~LookupBierTable() {}
+
+int LookupBierTable::classify(Packet *p) { return 0; }
+
+int LookupBierTable::add_route(bfrid dst, bitstring fbm, IP6Address nxt, ErrorHandler *errh) {
+  // if (output < 0 && output >= noutputs())
+  // return errh->error("port number out of range");
+  _t.add(dst, fbm, nxt);
+  return 0;
+}
+
+void LookupBierTable::add_handlers() {
+  add_write_handler("add", add_route_handler, 0);
+  add_read_handler("table", table_handler, 0);
+}
+
+CLICK_ENDDECLS
+ELEMENT_REQUIRES(BierRouteTable)
+EXPORT_ELEMENT(LookupBierTable)

--- a/elements/bier/lookupbiertable.hh
+++ b/elements/bier/lookupbiertable.hh
@@ -1,0 +1,30 @@
+#ifndef CLICK_BIFT_HH
+#define CLICK_BIFT_HH
+#include <click/batchelement.hh>
+#include <click/ip6address.hh>
+#include <click/biertable.hh>
+#include "bierroutetable.hh"
+CLICK_DECLS
+
+class LookupBierTable : public ClassifyElement<LookupBierTable, BierRouteTable> {
+	public:
+		LookupBierTable();
+		~LookupBierTable();
+
+		const char *class_name() const override { return "LookupBierTable"; }
+		const char *port_count() const override { return "1/-"; }
+		const char *processing() const override { return PUSH; }
+
+		int classify(Packet *p);
+
+		void add_handlers() override CLICK_COLD;
+
+		int add_route(bfrid dst, bitstring fbm, IP6Address nxt, ErrorHandler*);
+		String dump_routes() { return _t.dump(); }
+
+	private:
+		BierTable _t;
+};
+
+CLICK_ENDDECLS
+#endif

--- a/elements/bier/lookupbiertable.hh
+++ b/elements/bier/lookupbiertable.hh
@@ -21,7 +21,7 @@ class LookupBierTable : public ClassifyElement<LookupBierTable, BierRouteTable> 
     int configure(Vector<String> &, ErrorHandler *) CLICK_COLD;
 		void add_handlers() override CLICK_COLD;
 
-		int add_route(bfrid dst, bitstring fbm, IP6Address nxt, int, String, ErrorHandler*);
+		int add_route(bfrid dst, IP6Address bfr_prefix, bitstring fbm, IP6Address nxt, int, String, ErrorHandler*);
 		String dump_routes() { return _t.dump(); }
 
 	private:

--- a/elements/bier/lookupbiertable.hh
+++ b/elements/bier/lookupbiertable.hh
@@ -7,6 +7,49 @@
 #include "bierroutetable.hh"
 CLICK_DECLS
 
+/*
+ * =c
+ * LookupBierTable(BIFT_ID BFR_ID IFACE ...)
+ * =s bier
+ *
+ * =d
+ * Input: IP6 packets (no ether header).
+ * Expects a destination IP6 address annotation with each packet.
+ *
+ * Implements the forwarding procedure of BIER packets as defined in RFC8279 Section 6.
+ * Outputs 0 and 1 are reserved: discarded packets are pushed on output 0 while packets destined
+ * to the current BFR are pushed on output 1.
+ *
+ * Keyword arguments are:
+ *
+ * =over 8
+ *
+ * =item BIFT_ID
+ *
+ * The identifier of the current BIFT. This identifier defines the bitstring length (BSL),
+ * set identifier (SI) and sub-domain identifier (SD).
+ *
+ * =item BFR_ID
+ *
+ * The identifier of the current BFR.
+ *
+ * =item IFACE
+ *
+ * A mapping of a physical interface with the output number of the element.
+ *
+ * =back
+ *
+ * =e
+ *
+ *   bift :: LookupBierTable(BIFT_ID 0x01234 BFR_ID 1 IFACE eth0:2 IFACE eth1:3);
+ *   rt[0] -> Discard;
+ *   rt[1] -> ... -> ToDevice(lo);
+ *   rt[2] -> ... -> ToDevice(eth0);
+ *   rt[3] -> ... -> ToDevice(eth1);
+ *   ...
+ *
+ */
+
 class LookupBierTable : public ClassifyElement<LookupBierTable, BierRouteTable> {
 	public:
 		LookupBierTable();

--- a/elements/bier/lookupbiertable.hh
+++ b/elements/bier/lookupbiertable.hh
@@ -3,6 +3,7 @@
 #include <click/batchelement.hh>
 #include <click/ip6address.hh>
 #include <click/biertable.hh>
+#include <click/hashmap.hh>
 #include "bierroutetable.hh"
 CLICK_DECLS
 
@@ -17,13 +18,22 @@ class LookupBierTable : public ClassifyElement<LookupBierTable, BierRouteTable> 
 
 		int classify(Packet *p);
 
+    int configure(Vector<String> &, ErrorHandler *) CLICK_COLD;
 		void add_handlers() override CLICK_COLD;
 
-		int add_route(bfrid dst, bitstring fbm, IP6Address nxt, ErrorHandler*);
+		int add_route(bfrid dst, bitstring fbm, IP6Address nxt, int, String, ErrorHandler*);
 		String dump_routes() { return _t.dump(); }
 
 	private:
 		BierTable _t;
+
+    uint16_t _bfr_id;
+    uint32_t _bift_id;
+    atomic_uint64_t _drops;
+    HashMap<String, int> _ifaces;
+
+    void drop(Packet *p);
+    void decap(click_bier *bier);
 };
 
 CLICK_ENDDECLS

--- a/elements/bier/lookupbiertable.hh
+++ b/elements/bier/lookupbiertable.hh
@@ -22,6 +22,7 @@ class LookupBierTable : public ClassifyElement<LookupBierTable, BierRouteTable> 
 		void add_handlers() override CLICK_COLD;
 
 		int add_route(bfrid dst, IP6Address bfr_prefix, bitstring fbm, IP6Address nxt, int, String, ErrorHandler*);
+		int del_route(bfrid, ErrorHandler*);
 		String dump_routes() { return _t.dump(); }
 
 	private:

--- a/elements/ip6/checkbierin6header.cc
+++ b/elements/ip6/checkbierin6header.cc
@@ -1,5 +1,5 @@
 /*
- * checkbierin6header.{cc,hh} -- element encapsulates packet in IP6 SRv6 header
+ * checkbierin6header.{cc,hh} -- checks BIERin6 header for correctness
  * Nicolas Rybowski
  *
  * Copyright (c) 2024 UCLouvain
@@ -57,7 +57,6 @@ Packet *CheckBIERin6Header::simple_action(Packet *p) {
   
   const click_ip6 *iph = (click_ip6*) p->ip_header();
   if (iph->ip6_nxt != IP6PROTO_BIERIN6) {
-    click_chatter("Not a BIERin6 packet");
     goto drop;
   }
 

--- a/elements/ip6/checkbierin6header.cc
+++ b/elements/ip6/checkbierin6header.cc
@@ -1,3 +1,20 @@
+/*
+ * checkbierin6header.{cc,hh} -- element encapsulates packet in IP6 SRv6 header
+ * Nicolas Rybowski
+ *
+ * Copyright (c) 2024 UCLouvain
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
 #include <click/config.h>
 #include "checkbierin6header.hh"
 #include <clicknet/ip6.h>

--- a/elements/ip6/checkbierin6header.cc
+++ b/elements/ip6/checkbierin6header.cc
@@ -1,0 +1,57 @@
+#include <click/config.h>
+#include "checkbierin6header.hh"
+#include <clicknet/ip6.h>
+#include <click/glue.hh>
+#include <click/args.hh>
+#include <clicknet/bier.h>
+#include <click/error.hh>
+
+CLICK_DECLS
+
+CheckBIERin6Header::CheckBIERin6Header(): _offset(0) {
+  _drops = 0;
+}
+
+CheckBIERin6Header::~CheckBIERin6Header() {}
+
+int CheckBIERin6Header::configure(Vector<String> &conf, ErrorHandler *errh) {
+  if (Args(conf, this, errh)
+    .read_p("OFFSET", _offset)
+    .complete() < 0
+  )
+    return -1;
+  return 0;
+}
+
+void CheckBIERin6Header::drop(Packet *p) {
+  if (_drops == 0) {
+    click_chatter("IPv6 packet does not contains a BIER packet");
+  }
+  _drops++;
+
+  if (noutputs() == 2) {
+    output(1).push(p);
+  } else {
+    p->kill();
+  }
+}
+
+Packet *CheckBIERin6Header::simple_action(Packet *p) {
+  
+  const click_ip6 *iph = (click_ip6*) p->ip_header();
+  if (iph->ip6_nxt != IP6PROTO_BIERIN6) {
+    click_chatter("Not a BIERin6 packet");
+    goto drop;
+  }
+
+  return(p);
+  
+  drop:
+    drop(p);
+    return 0;
+}
+
+
+CLICK_ENDDECLS
+EXPORT_ELEMENT(CheckBIERin6Header)
+ELEMENT_MT_SAFE(CheckBIERin6Header)

--- a/elements/ip6/checkbierin6header.hh
+++ b/elements/ip6/checkbierin6header.hh
@@ -1,0 +1,26 @@
+#ifndef CLICK_CHECKBIERIN6HEADER_HH
+#define CLICK_CHECKBIERIN6HEADER_HH
+#include <click/batchelement.hh>
+#include <click/atomic.hh>
+CLICK_DECLS
+
+class CheckBIERin6Header : public SimpleElement<CheckBIERin6Header> {
+  public:
+   CheckBIERin6Header();
+   ~CheckBIERin6Header();
+
+   const char *class_name() const override { return "CheckBIERin6Header"; }
+   const char *port_count() const override { return PORTS_1_1X2; }
+
+   int configure(Vector<String> &, ErrorHandler *) CLICK_COLD;
+
+   Packet *simple_action(Packet *p);
+
+  private:
+    int _offset;
+    atomic_uint64_t _drops;
+    void drop(Packet *p); 
+};
+
+CLICK_ENDDECLS
+#endif

--- a/elements/ip6/checkbierin6header.hh
+++ b/elements/ip6/checkbierin6header.hh
@@ -4,6 +4,29 @@
 #include <click/atomic.hh>
 CLICK_DECLS
 
+/*
+ * =c
+ * CheckBIERin6Header([OFFSET])
+ * =s ip6
+ *
+ * =d
+ *
+ * Expects BIER packets encapsulated in IPv6 packets as input starting at OFFSET bytes. Default OFFSET is zero.
+ * Checks that the IPv6 packet contains a BIER packet.
+ * Pushes invalid or non BIERin6 packets out on output 1, unless output 1 was unused; if so,
+ * drop the packets.
+ *
+ * Keyword arguments are:
+ *
+ * =over 8
+ *
+ * =item OFFSET
+ *
+ * Unsigned integer. Byte position at which the BIER header begins. Default is 0.
+ *
+ * =back
+ *
+ */
 class CheckBIERin6Header : public SimpleElement<CheckBIERin6Header> {
   public:
    CheckBIERin6Header();

--- a/etc/libclick/DISTFILES
+++ b/etc/libclick/DISTFILES
@@ -28,6 +28,7 @@ include/click/archive.hh
 include/click/args.hh
 include/click/array_memory.hh
 include/click/atomic.hh
+include/click/biertable.hh
 include/click/bitvector.hh
 include/click/bighashmap.cc
 include/click/bighashmap.hh
@@ -108,6 +109,7 @@ include/click/standard/storage.hh
 include/click/standard/threadsched.hh
 
 include/clicknet
+include/clicknet/bier.h
 include/clicknet/ether.h
 include/clicknet/fddi.h
 include/clicknet/icmp.h
@@ -126,6 +128,7 @@ etc/libclick/lc-libsrc-Makefile.in:libsrc/Makefile.in
 lib/archive.cc:libsrc/archive.cc
 lib/args.cc:libsrc/args.cc
 lib/atomic.cc:libsrc/atomic.cc
+lib/biertable.cc:libsrc/biertable.cc
 lib/bighashmap_arena.cc:libsrc/bighashmap_arena.cc
 lib/bitvector.cc:libsrc/bitvector.cc
 lib/clp.c:libsrc/clp.c

--- a/etc/libclick/lc-configure.ac
+++ b/etc/libclick/lc-configure.ac
@@ -316,6 +316,11 @@ if test "x$enable_ip6" = xyes; then
     EXTRA_DRIVER_OBJS="ip6address.o ip6flowid.o ip6table.o $EXTRA_DRIVER_OBJS"
     EXTRA_TOOL_OBJS="ip6address.o $EXTRA_TOOL_OBJS"
 fi
+
+if test "x$enable_bier" =xyes; then
+    EXTRA_DRIVER_OBJS="biertable.o $EXTRA_DRIVER_OBJS"
+fi
+
 AC_SUBST(EXTRA_DRIVER_OBJS)
 AC_SUBST(EXTRA_TOOL_OBJS)
 

--- a/include/click/biertable.hh
+++ b/include/click/biertable.hh
@@ -1,0 +1,35 @@
+#ifndef CLICK_BIERTABLE_HH
+#define CLICK_BIERTABLE_HH
+#include <click/config.h>
+#include <click/confparse.hh>
+#include <click/glue.hh>
+#include <clicknet/bier.h>
+#include <click/ip6address.hh>
+CLICK_DECLS
+
+class BierTable {
+  public:
+    BierTable();
+    ~BierTable();
+
+    bool lookup(const bfrid &dst) const;
+
+    void del(const bfrid &dst);
+    void add(const bfrid &dst, const bitstring fbm, const IP6Address &nxt);
+    void clear() { _v.clear(); }
+    String dump();
+
+  private:
+    struct Entry {
+      bfrid _dst;
+      bitstring _fbm;
+      IP6Address _nxt;
+      int _valid;
+      // String 
+    };
+
+    Vector<Entry> _v;
+};
+
+CLICK_ENDDECLS
+#endif

--- a/include/click/biertable.hh
+++ b/include/click/biertable.hh
@@ -12,10 +12,10 @@ class BierTable {
     BierTable();
     ~BierTable();
 
-    bool lookup(const bfrid &dst) const;
+    bool lookup(const bfrid &dst, bitstring &fbm, IP6Address &nxt, int &index, String &ifname) const;
 
     void del(const bfrid &dst);
-    void add(const bfrid &dst, const bitstring fbm, const IP6Address &nxt);
+    void add(const bfrid &dst, const bitstring fbm, const IP6Address &nxt, int output, String ifname);
     void clear() { _v.clear(); }
     String dump();
 
@@ -24,8 +24,9 @@ class BierTable {
       bfrid _dst;
       bitstring _fbm;
       IP6Address _nxt;
+      int _if_idx;
+      String _if_name;
       int _valid;
-      // String 
     };
 
     Vector<Entry> _v;

--- a/include/click/biertable.hh
+++ b/include/click/biertable.hh
@@ -12,16 +12,17 @@ class BierTable {
     BierTable();
     ~BierTable();
 
-    bool lookup(const bfrid &dst, bitstring &fbm, IP6Address &nxt, int &index, String &ifname) const;
+    bool lookup(const bfrid &dst, IP6Address &bfr_prefix, bitstring &fbm, IP6Address &nxt, int &index, String &ifname) const;
 
     void del(const bfrid &dst);
-    void add(const bfrid &dst, const bitstring fbm, const IP6Address &nxt, int output, String ifname);
+    void add(const bfrid &dst, const IP6Address bfr_prefix, const bitstring fbm, const IP6Address &nxt, int output, String ifname);
     void clear() { _v.clear(); }
     String dump();
 
   private:
     struct Entry {
       bfrid _dst;
+      IP6Address _bfr_prefix;
       bitstring _fbm;
       IP6Address _nxt;
       int _if_idx;

--- a/include/click/bitvector.hh
+++ b/include/click/bitvector.hh
@@ -32,6 +32,7 @@ class Bitvector {
     explicit inline Bitvector(bool bit);
     inline Bitvector(int n, bool bit);
     inline Bitvector(const Bitvector &x);
+    inline Bitvector(word_type *array, int n);
     inline ~Bitvector();
 
     inline int size() const;
@@ -155,6 +156,21 @@ inline Bitvector::Bitvector(int n)
     } else {
 	_max = -1;
 	resize(n);
+    }
+}
+
+inline Bitvector::Bitvector(word_type *array, int n) : _data(_f){
+    assert(n >= 0);
+    if (n <= inlinebits) {
+        _max = n - 1;
+        memset(_f, 0, sizeof(_f));
+    } else {
+        _max = -1;
+        resize(n);
+    }
+    for (unsigned int i = 0; i < n / (sizeof(word_type)*8); i++) {
+        _data[i] = array[i];
+        click_chatter("bv %i %x %x", i, _data[i], array[i]);
     }
 }
 

--- a/include/clicknet/bier.h
+++ b/include/clicknet/bier.h
@@ -1,0 +1,33 @@
+#ifndef CLICKNET_BIER_H
+#define CLICKNET_BIER_H
+
+#ifndef IP6PROTO_BIERIN6
+#define IP6PROTO_BIERIN6 253
+#endif
+
+#include <click/bitvector.hh>
+#include <stdint.h>
+
+typedef uint16_t bfrid;
+typedef Bitvector bitstring; // bslen == 256
+
+
+// RFC8296 Section 2
+struct click_bier {
+  unsigned bift_id : 20;
+  unsigned tc : 3;
+  unsigned s : 1;
+  uint8_t ttl;
+  unsigned nibble : 4;
+  unsigned version : 4;
+  unsigned bsl : 4;
+  unsigned entropy : 20;
+  unsigned oam : 2;
+  unsigned _rsv : 2;
+  unsigned dscp : 6;
+  unsigned proto : 6;
+  unsigned bfr_id : 16;
+  uint64_t bitstring;
+};
+
+#endif

--- a/include/clicknet/bier.h
+++ b/include/clicknet/bier.h
@@ -1,33 +1,130 @@
 #ifndef CLICKNET_BIER_H
 #define CLICKNET_BIER_H
 
+#include <cstdint>
 #ifndef IP6PROTO_BIERIN6
 #define IP6PROTO_BIERIN6 253
 #endif
 
+#include <arpa/inet.h>
 #include <click/bitvector.hh>
+#include <click/packet.hh>
+#include <math.h>
 #include <stdint.h>
 
 typedef uint16_t bfrid;
-typedef Bitvector bitstring; // bslen == 256
+typedef Bitvector bitstring;
 
+typedef enum: uint8_t { _invalid, _64 = 1, _128, _256, _512, _1024, _2048, _4096 } bsl_t;
+
+#define bier_ttl     bier_un.bier_un2.ttl
+#define bier_tc      bier_un.bier_un2.tc
+#define bier_s       bier_un.bier_un2.s
+#define bier_bift_id bier_un.bier_un2.bift_id
+#define bier_nibble  bier_un.bier_un2.nibble
+#define bier_version bier_un.bier_un2.version
+#define bier_bsl     bier_un.bier_un2.bsl
+#define bier_entropy bier_un.bier_un2.entropy
+#define bier_oam     bier_un.bier_un2.oam
+#define bier_rsv     bier_un.bier_un2.rsv
+#define bier_dscp    bier_un.bier_un2.dscp
+#define bier_proto   bier_un.bier_un2.proto
+#define bier_bfr_id  bier_un.bier_un2.bfr_id
+
+static inline std::size_t _click_bier_expand_bsl(uint8_t bsl) {
+  std::size_t ret = 0;
+  switch (bsl) {
+    case _64: ret = 64; break;
+    case _128: ret = 128; break;
+    case _256: ret = 256; break;
+    case _512: ret = 512; break;
+    case _1024: ret = 1024; break;
+    case _2048: ret = 2048; break;
+    case _4096: ret = 4096; break;
+    default: break; 
+  }
+  return ret;
+}
 
 // RFC8296 Section 2
 struct click_bier {
-  unsigned bift_id : 20;
-  unsigned tc : 3;
-  unsigned s : 1;
-  uint8_t ttl;
-  unsigned nibble : 4;
-  unsigned version : 4;
-  unsigned bsl : 4;
-  unsigned entropy : 20;
-  unsigned oam : 2;
-  unsigned _rsv : 2;
-  unsigned dscp : 6;
-  unsigned proto : 6;
-  unsigned bfr_id : 16;
-  uint64_t bitstring;
-};
+  union {
+    struct {
+      uint32_t bier_un1_l1;
+      uint32_t bier_un1_l2;
+      uint32_t bier_un1_l3;
+    } bier_un1;
+    struct {
+#if CLICK_BYTE_ORDER == CLICK_BIG_ENDIAN
+      unsigned bift_id: 20;
+      unsigned tc: 3;
+      unsigned s: 1;
+      unsigned ttl: 8;
+      unsigned nibble: 4;
+      unsigned version: 4;
+      unsigned bsl: 4;
+      unsigned entropy: 20;
+      unsigned oam: 2;
+      unsigned rsv: 2;
+      unsigned dscp: 6;
+      unsigned proto: 6;
+      unsigned bfr_id: 16;
+#elif CLICK_BYTE_ORDER == CLICK_LITTLE_ENDIAN
+      unsigned ttl: 8;
+      unsigned s: 1;
+      unsigned tc: 3;
+      unsigned bift_id: 20;
+      unsigned entropy: 20;
+      unsigned bsl: 4;
+      unsigned version: 4;
+      unsigned nibble: 4;
+      unsigned bfr_id: 16;
+      unsigned proto: 6;
+      unsigned dscp: 6;
+      unsigned rsv: 2;
+      unsigned oam: 2;
+#endif
+    } bier_un2;
+  } bier_un;
+
+  uint32_t bitstring[];
+
+  void decode() {
+#if CLICK_BYTE_ORDER == CLICK_LITTLE_ENDIAN
+    bier_un.bier_un1.bier_un1_l1  = htonl(bier_un.bier_un1.bier_un1_l1); 
+    bier_un.bier_un1.bier_un1_l2  = htonl(bier_un.bier_un1.bier_un1_l2); 
+    bier_un.bier_un1.bier_un1_l3  = htonl(bier_un.bier_un1.bier_un1_l3);
+    // FIXME: Do not use BSL per RFC8296. BSL should be provided as an argument.
+    size_t bsl = _click_bier_expand_bsl(bier_bsl) / 32;
+    click_chatter("bsl %u %u", bier_bsl, bsl);
+    uint32_t _bitstring[bsl] = {0};
+    for (size_t i=0; i<bsl; i++) _bitstring[bsl-1-i] = htonl(bitstring[i]);
+    memcpy(bitstring, _bitstring, bsl*sizeof(uint32_t));
+#endif
+  }
+
+  void encode() {
+#if CLICK_BYTE_ORDER == CLICK_LITTLE_ENDIAN
+    bier_un.bier_un1.bier_un1_l1  = ntohl(bier_un.bier_un1.bier_un1_l1); 
+    bier_un.bier_un1.bier_un1_l2  = ntohl(bier_un.bier_un1.bier_un1_l2); 
+    bier_un.bier_un1.bier_un1_l3  = ntohl(bier_un.bier_un1.bier_un1_l3); 
+#endif
+  }
+
+} __attribute__ ((aligned (4), packed));
+
+static inline std::size_t click_bier_expand_bsl(click_bier *hdr) {
+  return _click_bier_expand_bsl(hdr->bier_bsl);
+}
+
+static inline std::size_t click_bier_hdr_len(click_bier *hdr) {
+  // FIXME: From RFC8296 about BSL field
+  /*  "Note: When parsing the BIER header, a BFR MUST infer the length of
+   *   the BitString from the BIFT-id and MUST NOT infer it from the
+   *    value of this field.  This field is present only to enable offline
+   *   tools (such as LAN analyzers) to parse the BIER header."
+   */
+  return (3+pow((double)2, (double)hdr->bier_bsl))*sizeof(uint32_t);
+}
 
 #endif

--- a/include/clicknet/bier.h
+++ b/include/clicknet/bier.h
@@ -96,8 +96,7 @@ struct click_bier {
     bier_un.bier_un1.bier_un1_l3  = htonl(bier_un.bier_un1.bier_un1_l3);
     // FIXME: Do not use BSL per RFC8296. BSL should be provided as an argument.
     size_t bsl = _click_bier_expand_bsl(bier_bsl) / 32;
-    click_chatter("bsl %u %u", bier_bsl, bsl);
-    uint32_t _bitstring[bsl] = {0};
+    uint32_t _bitstring[bsl];
     for (size_t i=0; i<bsl; i++) _bitstring[bsl-1-i] = htonl(bitstring[i]);
     memcpy(bitstring, _bitstring, bsl*sizeof(uint32_t));
 #endif
@@ -105,9 +104,14 @@ struct click_bier {
 
   void encode() {
 #if CLICK_BYTE_ORDER == CLICK_LITTLE_ENDIAN
+    // FIXME: Do not use BSL per RFC8296. BSL should be provided as an argument.
+    size_t bsl = _click_bier_expand_bsl(bier_bsl) / 32;
     bier_un.bier_un1.bier_un1_l1  = ntohl(bier_un.bier_un1.bier_un1_l1); 
     bier_un.bier_un1.bier_un1_l2  = ntohl(bier_un.bier_un1.bier_un1_l2); 
     bier_un.bier_un1.bier_un1_l3  = ntohl(bier_un.bier_un1.bier_un1_l3); 
+    uint32_t _bitstring[bsl];
+    for (size_t i=0; i<bsl; i++) _bitstring[bsl-1-i] = ntohl(bitstring[i]);
+    memcpy(bitstring, _bitstring, bsl*sizeof(uint32_t));
 #endif
   }
 

--- a/lib/biertable.cc
+++ b/lib/biertable.cc
@@ -1,3 +1,20 @@
+/*
+ * biertable.{cc,hh} -- element encapsulates packet in IP6 SRv6 header
+ * Nicolas Rybowski
+ *
+ * Copyright (c) 2024 UCLouvain
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, subject to the conditions
+ * listed in the Click LICENSE file. These conditions include: you must
+ * preserve this copyright notice, and you cannot mention the copyright
+ * holders in advertising related to the Software without their permission.
+ * The Software is provided WITHOUT ANY WARRANTY, EXPRESS OR IMPLIED. This
+ * notice is a summary of the Click LICENSE file; the license in that file is
+ * legally binding.
+ */
+
 #include <click/config.h>
 #include <click/biertable.hh>
 #include <click/glue.hh>

--- a/lib/biertable.cc
+++ b/lib/biertable.cc
@@ -1,0 +1,53 @@
+#include <click/config.h>
+#include <click/biertable.hh>
+#include <click/straccum.hh>
+#include <iostream>
+CLICK_DECLS
+
+BierTable::BierTable(){}
+BierTable::~BierTable(){}
+
+bool BierTable::lookup(const bfrid &dst) const {
+  return false;
+}
+
+void BierTable::del(const bfrid &dst) {
+  for (int i = 0; i < _v.size(); i++) {
+    if (_v[i]._valid && _v[i]._dst == dst)
+      _v[i]._valid = 0;
+  }
+}
+
+void BierTable::add(const bfrid &dst, const bitstring fbm, const IP6Address &nxt) {
+  struct Entry e;
+  e._dst = dst;
+  e._fbm = fbm;
+  e._nxt = nxt;
+  e._valid = 1;
+
+  // Avoid duplicate routes
+  del(dst);
+  
+  for (int i = 0; i < _v.size(); i++)
+    if (!_v[i]._valid) {
+      _v[i] = e;
+      return;
+    }
+  _v.push_back(e);
+}
+
+String BierTable::dump() {
+  StringAccum sa;
+  if (_v.size())
+    sa << "# Active routes\n# BFR-id    F-BM    Nexthop\n";
+  for (int i=0; i< _v.size(); i++) {
+    if (_v[i]._valid) {
+      sa << "    " << _v[i]._dst;
+      sa << "      " << _v[i]._fbm.unparse();
+      sa << "      " << _v[i]._nxt << '\n';
+    }
+  }
+  return sa.take_string();
+}
+
+CLICK_ENDDECLS

--- a/lib/biertable.cc
+++ b/lib/biertable.cc
@@ -1,5 +1,6 @@
 #include <click/config.h>
 #include <click/biertable.hh>
+#include <click/glue.hh>
 #include <click/straccum.hh>
 #include <iostream>
 CLICK_DECLS
@@ -7,8 +8,25 @@ CLICK_DECLS
 BierTable::BierTable(){}
 BierTable::~BierTable(){}
 
-bool BierTable::lookup(const bfrid &dst) const {
-  return false;
+bool BierTable::lookup(const bfrid &dst, bitstring &fbm, IP6Address &nxt, int &index, String &ifname) const {
+  int best = -1;
+
+  for (int i = 0; i < _v.size(); i++) {
+    if (_v[i]._valid && dst == _v[i]._dst) {
+        best = i;
+        break;
+    }
+  }
+
+  if (best < 0)
+    return false;
+  else {
+    nxt = _v[best]._nxt;
+    fbm = _v[best]._fbm;
+    index = _v[best]._if_idx;
+    ifname = _v[best]._if_name;
+    return true;
+  }
 }
 
 void BierTable::del(const bfrid &dst) {
@@ -18,12 +36,14 @@ void BierTable::del(const bfrid &dst) {
   }
 }
 
-void BierTable::add(const bfrid &dst, const bitstring fbm, const IP6Address &nxt) {
+void BierTable::add(const bfrid &dst, const bitstring fbm, const IP6Address &nxt, int output, String ifname) {
   struct Entry e;
   e._dst = dst;
   e._fbm = fbm;
   e._nxt = nxt;
   e._valid = 1;
+  e._if_idx = output;
+  e._if_name = ifname;
 
   // Avoid duplicate routes
   del(dst);
@@ -39,12 +59,14 @@ void BierTable::add(const bfrid &dst, const bitstring fbm, const IP6Address &nxt
 String BierTable::dump() {
   StringAccum sa;
   if (_v.size())
-    sa << "# Active routes\n# BFR-id    F-BM    Nexthop\n";
+    sa << "# Active routes\n# BFR-id    F-BM    Nexthop    Ifindex\n";
   for (int i=0; i< _v.size(); i++) {
     if (_v[i]._valid) {
       sa << "    " << _v[i]._dst;
       sa << "      " << _v[i]._fbm.unparse();
-      sa << "      " << _v[i]._nxt << '\n';
+      sa << "      " << _v[i]._nxt;
+      sa << "      " << _v[i]._if_idx;
+      sa << "      " << _v[i]._if_name << '\n';
     }
   }
   return sa.take_string();

--- a/lib/biertable.cc
+++ b/lib/biertable.cc
@@ -25,7 +25,7 @@ CLICK_DECLS
 BierTable::BierTable(){}
 BierTable::~BierTable(){}
 
-bool BierTable::lookup(const bfrid &dst, bitstring &fbm, IP6Address &nxt, int &index, String &ifname) const {
+bool BierTable::lookup(const bfrid &dst, IP6Address &bfr_prefix, bitstring &fbm, IP6Address &nxt, int &index, String &ifname) const {
   int best = -1;
 
   for (int i = 0; i < _v.size(); i++) {
@@ -39,6 +39,7 @@ bool BierTable::lookup(const bfrid &dst, bitstring &fbm, IP6Address &nxt, int &i
     return false;
   else {
     nxt = _v[best]._nxt;
+    bfr_prefix = _v[best]._bfr_prefix;
     fbm = _v[best]._fbm;
     index = _v[best]._if_idx;
     ifname = _v[best]._if_name;
@@ -53,9 +54,10 @@ void BierTable::del(const bfrid &dst) {
   }
 }
 
-void BierTable::add(const bfrid &dst, const bitstring fbm, const IP6Address &nxt, int output, String ifname) {
+void BierTable::add(const bfrid &dst, const IP6Address bfr_prefix, const bitstring fbm, const IP6Address &nxt, int output, String ifname) {
   struct Entry e;
   e._dst = dst;
+  e._bfr_prefix = bfr_prefix;
   e._fbm = fbm;
   e._nxt = nxt;
   e._valid = 1;
@@ -76,10 +78,11 @@ void BierTable::add(const bfrid &dst, const bitstring fbm, const IP6Address &nxt
 String BierTable::dump() {
   StringAccum sa;
   if (_v.size())
-    sa << "# Active routes\n# BFR-id    F-BM    Nexthop    Ifindex\n";
+    sa << "# Active routes\n# BFR-id   BFR-prefix     F-BM    Nexthop    Ifindex\n";
   for (int i=0; i< _v.size(); i++) {
     if (_v[i]._valid) {
       sa << "    " << _v[i]._dst;
+      sa << "    " << _v[i]._bfr_prefix;
       sa << "      " << _v[i]._fbm.unparse();
       sa << "      " << _v[i]._nxt;
       sa << "      " << _v[i]._if_idx;


### PR DESCRIPTION
This PR adds basic elements for BIER packets processing.

First, it adds the Bier Forwarding Table (BIFT) which is implemented as the IPv6 forwarding table. That is, Fastclick is extended with a 'biertable' that defines the basic operations on the BIFT. The 'bierroutetable' element defines handlers allowing external interactions and the 'lookupbiertable' is the element representing the BIFT.

Second, two simple filtering elements are added, (i) 'checkbierheader' that verifies the header of a BIER packet and (ii) 'checkbierin6header' that filters IPv6 packet to detect BIERin6 encapsulated BIER packets.

# TODO

- [x] Batch routes addition
- [x] Allow routes suppression via handler
- [x] Add elements documentation
- [x] (Support Bitstring length greater than 256 bits)
- [x] Implement BIER forwarding 