### PR TITLE
Fix parsing of CheckIPHeader offset argument

### DIFF
--- a/elements/ip/checkipheader.cc
+++ b/elements/ip/checkipheader.cc
@@ -113,7 +113,6 @@ CheckIPHeader::configure(Vector<String> &conf, ErrorHandler *errh)
 
     if (Args(conf, this, errh)
         .read("BADSRC", OldBadSrcArg(), _bad_src)
-        .read_or_set("OFFSET", _offset, 0)
         .complete() < 0)
         return -1;
 


### PR DESCRIPTION
The argument is currently parsed twice. The first time it's consumed, the second time it's always set to 0.