### PR TITLE
Fixes for 64-bit rates

### DIFF
--- a/elements/standard/bandwidthmeter.cc
+++ b/elements/standard/bandwidthmeter.cc
@@ -52,7 +52,7 @@ BandwidthMeter::configure(Vector<String> &conf, ErrorHandler *errh)
     else if (ba.status == NumArg::status_unitless)
       errh->warning("no units for bandwidth argument %d, assuming Bps", i+1);
 
-  unsigned max_value = 0xFFFFFFFF >> _rate.scale();
+  uint64_t max_value = UINT64_MAX >> _rate.scale();
   for (int i = 0; i < conf.size(); i++) {
     if (vals[i] > max_value)
       return errh->error("rate %d too large (max %u)", i+1, max_value);
@@ -78,7 +78,7 @@ BandwidthMeter::push(int, Packet *p)
 {
   _rate.update(p->length());
 
-  unsigned r = _rate.scaled_average();
+  uint64_t r = _rate.scaled_average();
   if (_nmeters < 2) {
     int n = (r >= _meter1);
     output(n).push(p);

--- a/elements/standard/bandwidthmeter.hh
+++ b/elements/standard/bandwidthmeter.hh
@@ -37,7 +37,7 @@ CLICK_DECLS
 
 class BandwidthMeter : public Element { protected:
 
-  RateEWMAX<RateEWMAXParameters<4, 10, uint64_t, int64_t>> _rate;
+  RateEWMA _rate;
 
   uint64_t _meter1;
   uint64_t *_meters;

--- a/elements/standard/bandwidthmeter.hh
+++ b/elements/standard/bandwidthmeter.hh
@@ -37,7 +37,7 @@ CLICK_DECLS
 
 class BandwidthMeter : public Element { protected:
 
-  RateEWMA _rate;
+  RateEWMAX<RateEWMAXParameters<4, 10, uint64_t, int64_t>> _rate;
 
   uint64_t _meter1;
   uint64_t *_meters;
@@ -55,7 +55,7 @@ class BandwidthMeter : public Element { protected:
   const char *port_count() const override		{ return "1/2-"; }
   const char *processing() const override		{ return PUSH; }
 
-  unsigned scaled_rate() const		{ return _rate.scaled_average(); }
+  uint64_t scaled_rate() const		{ return _rate.scaled_average(); }
   unsigned rate_scale() const		{ return _rate.scale(); }
   unsigned rate_freq() const		{ return _rate.epoch_frequency(); }
 

--- a/elements/standard/ratedsource.cc
+++ b/elements/standard/ratedsource.cc
@@ -78,7 +78,7 @@ RatedSource::configure(Vector<String> &conf, ErrorHandler *errh)
         rate = bandwidth / (_datasize < 0 ? _data.length() : _datasize);
     }
 
-    int burst = rate < 200 ? 2 : rate / 100;
+    uint64_t burst = rate < 200 ? 2 : rate / 100;
     if (bandwidth > 0 && burst < 2 * datasize) {
         burst = 2 * datasize;
     }

--- a/elements/standard/ratedunqueue.cc
+++ b/elements/standard/ratedunqueue.cc
@@ -70,12 +70,12 @@ RatedUnqueue::configure_helper(TokenBucket *tb, bool is_bandwidth, Element *elt,
 	bigint::limb_type res[2];
 	bigint::multiply(res[1], res[0], r, dur_msec);
 	bigint::divide(res, res, 2, 1000);
-	tokens = res[1] ? UINT_MAX : res[0];
+	tokens = res[1] ? UINT64_MAX : res[0];
     }
 
     if (is_bandwidth) {
-	unsigned new_tokens = tokens + tb_bandwidth_thresh;
-	tokens = (tokens < new_tokens ? new_tokens : UINT_MAX);
+	uint64_t new_tokens = tokens + tb_bandwidth_thresh;
+	tokens = (tokens < new_tokens ? new_tokens : UINT64_MAX);
     }
 
     tb->assign(r, tokens ? tokens : 1);

--- a/include/click/ewma.hh
+++ b/include/click/ewma.hh
@@ -490,9 +490,9 @@ class RateEWMAXParameters : public FixedEWMAXParameters<STABILITY, SCALE, T, U> 
 };
 
 /** @brief A RateEWMAX with stability shift 4 (alpha 1/16), scaling factor 10
- *  (10 bits of fraction), one rate, and underlying type <code>unsigned</code>
+ *  (10 bits of fraction), one rate, and underlying type <code>uint64_t</code>
  *  that measures epochs in jiffies. */
-typedef RateEWMAX<RateEWMAXParameters<4, 10> > RateEWMA;
+typedef RateEWMAX<RateEWMAXParameters<4, 10, uint64_t, int64_t> > RateEWMA;
 
 
 template <typename P>


### PR DESCRIPTION
This adds some uint32->uint64 conversions which I missed in #395.
They affect RatedUnqueue, RatedSource and BandwidthMeter.