### PR TITLE
Fix compilation with --enable-stats=2

### DIFF
--- a/include/click/element.hh
+++ b/include/click/element.hh
@@ -812,8 +812,8 @@ Element::Port::push(Packet* p) const
 # else
     _e->push(_port, p);
 # endif
-    }
 #endif
+    }
 #if HAVE_FLOW_DYNAMIC
     if (_unstack) {
         fcb_stack = tmp_stack;


### PR DESCRIPTION
Due to a misplaced }, compilation fails when FastClick is configured with statistics set to 2. 
This fixes #409.