### PR TITLE
Refactor ControlSocket & HttpServer elements

### DIFF
--- a/elements/userlevel/controlsocket.cc
+++ b/elements/userlevel/controlsocket.cc
@@ -183,7 +183,7 @@ ControlSocket::initialize_socket(ErrorHandler *errh)
     if (_socket_fd < 0)
       return initialize_socket_error(errh, "socket");
     int sockopt = 1;
-    if (setsockopt(_socket_fd, SOL_SOCKET, SO_REUSEADDR, (void *)&sockopt, sizeof(sockopt)) < 0)
+    if (setsockopt(_socket_fd, SOL_SOCKET, SO_REUSEPORT, (void *)&sockopt, sizeof(sockopt)) < 0)
       errh->warning("setsockopt: %s", strerror(errno));
 
     // bind to port

--- a/elements/userlevel/httpserver.cc
+++ b/elements/userlevel/httpserver.cc
@@ -84,6 +84,7 @@ int HTTPServer::initialize(ErrorHandler *errh) {
             NULL,
             &ahc_echo,
             (void*)this,
+            MHD_OPTION_LISTENING_ADDRESS_REUSE, 1,
             MHD_OPTION_END);
     if (_daemon == NULL)
         return 1;

--- a/elements/userlevel/httpserver.cc
+++ b/elements/userlevel/httpserver.cc
@@ -84,7 +84,7 @@ int HTTPServer::initialize(ErrorHandler *errh) {
             NULL,
             &ahc_echo,
             (void*)this,
-            MHD_OPTION_END);
+            MHD_OPTION_LISTENING_ADDRESS_REUSE, 1,
     if (_daemon == NULL)
         return 1;
 

--- a/elements/userlevel/httpserver.cc
+++ b/elements/userlevel/httpserver.cc
@@ -84,7 +84,6 @@ int HTTPServer::initialize(ErrorHandler *errh) {
             NULL,
             &ahc_echo,
             (void*)this,
-            MHD_OPTION_LISTENING_ADDRESS_REUSE, 1,
             MHD_OPTION_END);
     if (_daemon == NULL)
         return 1;
@@ -309,6 +308,15 @@ MHD_Result HTTPServer::ahc_echo(
         click_chatter("Could not create response");
         return MHD_NO;
     }
+    
+    MHD_add_response_header(response, "Access-Control-Allow-Origin", "*");
+    MHD_add_response_header(response, "Access-Control-Allow-Methods", "GET, POST, PUT, DELETE");
+    MHD_add_response_header(response, "Access-Control-Allow-Headers", "Content-Type");
+    
+    if (path == "element_map" && e == server->router()->root_element()) {
+        MHD_add_response_header(response, "Content-Type", "text/plain");
+    }
+    
     ret = MHD_queue_response(connection,
             status,
             response);


### PR DESCRIPTION
- Added 'MHD_OPTION_LISTENING_ADDRESS_REUSE' to allow the reuse of the listening address for the HTTPserver.
- replace 'SO_REUSEADD' with 'SO_REUSEPORT' in ControlSocket to allow reuse of the same port.
