### PR TITLE
fix httpserver.cc

### DIFF
--- a/elements/userlevel/httpserver.cc
+++ b/elements/userlevel/httpserver.cc
@@ -84,7 +84,8 @@ int HTTPServer::initialize(ErrorHandler *errh) {
             NULL,
             &ahc_echo,
             (void*)this,
-            MHD_OPTION_LISTENING_ADDRESS_REUSE, 1);
+            MHD_OPTION_LISTENING_ADDRESS_REUSE, 1,
+            MHD_OPTION_END);
     if (_daemon == NULL)
         return 1;
 


### PR DESCRIPTION
I forgot to re-add  'MHD_OPTION_END'.
It is mandatory to use MHD_OPTION_END as last argument, even when there are no additional arguments. 