### PR TITLE
Commented out click_chatter("take!") in CheckIP6Header::simple_action

### DIFF
--- a/elements/ip6/checkip6header.cc
+++ b/elements/ip6/checkip6header.cc
@@ -157,7 +157,7 @@ CheckIP6Header::simple_action(Packet *p)
 
     // shorten packet according to IP6 payload length field
     if(unlikely(ntohs(ip->ip6_plen) < (plen-ip6_totallen))) {
-        click_chatter("take!");
+        //click_chatter("take!");
         p->take(plen - ip6_totallen - ntohs(ip->ip6_plen));
     }
 


### PR DESCRIPTION
Commented out click_chatter("take!") in CheckIP6Header::simple_action, because it's a too central place, has no huge value, and spams the log full. :)

Keep up the good work, Tom! Thank you for all your time you put into this project.